### PR TITLE
wayland: sync drawn border size on window creation

### DIFF
--- a/src/api/wayland/window.rs
+++ b/src/api/wayland/window.rs
@@ -87,6 +87,8 @@ impl Window {
             } else if attributes.decorations {
                 decorated.set_decorate(true);
             }
+            // Finally, set the decorations size
+            decorated.resize(width as i32, height as i32);
         }
 
         // init general handler


### PR DESCRIPTION
Without that, the border actually drawn do not match the size the window believe it has.