### PR TITLE
linux: remove outdated comment

### DIFF
--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -25,7 +25,6 @@ enum Backend {
 
 lazy_static!(
     static ref BACKEND: Backend = {
-        // Wayland backend is not production-ready yet so we disable it
         if let Some(ctxt) = wayland::WaylandContext::init() {
             Backend::Wayland(Arc::new(ctxt))
         } else {


### PR DESCRIPTION
The wayland backend has been active for some time, but for some reason the comment was not removed (most likely I forgot it).