### PR TITLE
Add a `WindowBuilder::with_window_resize_callback` method.

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -12,9 +12,11 @@ fn resize_callback(width: u32, height: u32) {
 }
 
 fn main() {
-    let mut window = winit::WindowBuilder::new().build().unwrap();
-    window.set_title("A fantastic window!");
-    window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));
+    let window = winit::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_window_resize_callback(resize_callback)
+        .build()
+        .unwrap();
 
     for event in window.wait_events() {
         println!("{:?}", event);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,6 @@ pub struct WindowBuilder {
 
     /// Platform-specific configuration.
     platform_specific: platform::PlatformSpecificWindowBuilderAttributes,
-
-    /// A function called upon resizing, necessary to receive resize events on Mac and possibly
-    /// other systems.
-    window_resize_callback: Option<fn(u32, u32)>,
 }
 
 /// Error that can happen while creating a window or a headless renderer.
@@ -263,6 +259,10 @@ pub struct WindowAttributes {
     /// [iOS only] Enable multitouch, see [UIView#multipleTouchEnabled]
     /// (https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/instp/UIView/multipleTouchEnabled)
     pub multitouch: bool,
+
+    /// A function called upon resizing, necessary to receive resize events on Mac and possibly
+    /// other systems.
+    pub resize_callback: Option<fn(u32, u32)>,
 }
 
 impl Default for WindowAttributes {
@@ -278,6 +278,7 @@ impl Default for WindowAttributes {
             transparent: false,
             decorations: true,
             multitouch: false,
+            resize_callback: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,10 @@ pub struct WindowBuilder {
 
     /// Platform-specific configuration.
     platform_specific: platform::PlatformSpecificWindowBuilderAttributes,
+
+    /// A function called upon resizing, necessary to receive resize events on Mac and possibly
+    /// other systems.
+    window_resize_callback: Option<fn(u32, u32)>,
 }
 
 /// Error that can happen while creating a window or a headless renderer.

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,7 +18,6 @@ impl WindowBuilder {
         WindowBuilder {
             window: Default::default(),
             platform_specific: Default::default(),
-            window_resize_callback: None,
         }
     }
 
@@ -99,7 +98,7 @@ impl WindowBuilder {
     /// during window resizing.
     #[inline]
     pub fn with_window_resize_callback(mut self, cb: fn(u32, u32)) -> WindowBuilder {
-        self.window_resize_callback = Some(cb);
+        self.window.resize_callback = Some(cb);
         self
     }
 
@@ -122,7 +121,7 @@ impl WindowBuilder {
         let mut w = try!(platform::Window::new(&self.window, &self.platform_specific));
 
         // a window resize callback was given
-        if let Some(callback) = self.window_resize_callback {
+        if let Some(callback) = self.window.resize_callback {
             w.set_window_resize_callback(Some(callback));
         }
 


### PR DESCRIPTION
This allows for passing the window_resize_callback fn during the window
building stage. More importantly, this allows setting the callback
without the need for mutable access to the Window, making it possible
to set the callback in the downstream glium crate.

This may solve tomaka/glium#1232 for most folk.