### PR TITLE
Remove android_main! call

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
 
 use winit::{Event, ElementState, MouseCursor};
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window = winit::WindowBuilder::new().build().unwrap();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
 
 use std::io::{self, Write};
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     // enumerating monitors

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
 
 use winit::{Event, ElementState};
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window = winit::WindowBuilder::new().build().unwrap();

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -1,11 +1,4 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window = winit::WindowBuilder::new()

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
 
 use std::thread;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window1 = winit::WindowBuilder::new().build().unwrap();

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,11 +1,4 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn resize_callback(width: u32, height: u32) {
     println!("Window resized to {}x{}", width, height);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,11 +1,4 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate winit;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn resize_callback(width: u32, height: u32) {
     println!("Window resized to {}x{}", width, height);


### PR DESCRIPTION
No longer needed with android-rs-glue 0.2

The examples probably weren't compiling on Android without this change.
