### PR TITLE
Add travis builds for more versions of OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ matrix:
         - os: osx
           osx_image: xcode7.3 # OS X 10.11
         - os: osx
-          osx_image: xcode7.1 # OS X 10.10
-        - os: osx
-          osx_image: beta-xcode6.2 # OS X 10.9
+          osx_image: xcode6.4 # OS X 10.10
 
 after_success: 
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ matrix:
           osx_image: xcode7.1 # OS X 10.10
         - os: osx
           osx_image: beta-xcode6.2 # OS X 10.9
-os:
-  - linux
-  - osx
 
 after_success: 
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,19 @@ script:
   - cargo build --verbose
   - cargo test --verbose
 
+matrix:
+    include:
+        # Linux builds
+        - os: linux
+        # OS X builds
+        - os: osx
+          osx_image: xcode8.1 # OS X 10.12
+        - os: osx
+          osx_image: xcode7.3 # OS X 10.11
+        - os: osx
+          osx_image: xcode7.1 # OS X 10.10
+        - os: osx
+          osx_image: beta-xcode6.2 # OS X 10.9
 os:
   - linux
   - osx


### PR DESCRIPTION
I thought this might help a little for catching version specific bugs like the ones that showed up in #89.

However now that I think about it, this still would not catch the bug that appeared in #89 as it occurred due to a run-time segmentation fault. @tomaka perhaps I could add a test file with some short tests that simply build a window (with some unique parameters like `with_title`, `with_max_dimensions`, etc for each test), poll events once and then end? Would travis even be able to run gui tests like this I wonder?

Also, are we interested in supporting OS X systems this far back? The oldest test is for the 2013 version of OS X, which I don't think is unreasonably old.

I'm not 100% sure this travis config will work, I'm just copying the example given in [this SO post](http://stackoverflow.com/questions/39473107/is-it-possible-for-travis-ci-to-be-configured-to-build-in-multiple-os-x-versions) and in [the vague multi-os travis guide](https://docs.travis-ci.com/user/multi-os/).