### PR TITLE
macos: Map our user generated event to Event::Awakened

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -822,6 +822,12 @@ unsafe fn NSEventToEvent(window: &Window, nsevent: id) -> Option<Event> {
         appkit::NSEventTypePressure => {
             Some(Event::TouchpadPressure(nsevent.pressure(), nsevent.stage()))
         },
+        appkit::NSApplicationDefined => {
+            match nsevent.subtype() {
+                appkit::NSEventSubtype::NSApplicationActivatedEventType => { Some(Event::Awakened) }
+                _ => { None }
+            }
+        },
         _  => { None },
     }
 }


### PR DESCRIPTION
This fixes propagation of Event::Awakend when using poll_event() on
macOS