### PR TITLE
Naive implementation of resize events for OS X.

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -75,13 +75,15 @@ impl WindowDelegate {
 
                 // need to notify context before (?) event
                 // let _: () = msg_send![*state.context, update];
+                let rect = NSView::frame(*state.view);
+                let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
+                let width = (scale_factor * rect.size.width as f32) as u32;
+                let height = (scale_factor * rect.size.height as f32) as u32;
 
                 if let Some(handler) = state.resize_handler {
-                    let rect = NSView::frame(*state.view);
-                    let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-                    (handler)((scale_factor * rect.size.width as f32) as u32,
-                              (scale_factor * rect.size.height as f32) as u32);
+                    (handler)(width, height);
                 }
+                (*state).pending_events.lock().unwrap().push_back(Event::Resized(width, height));
             }
         }
 


### PR DESCRIPTION
These events are batched, and delievered en masse at the end of the resize. This isn't a great developer experience (and it should probably be called out in the docs), but it makes it possible for winit client applications to detect and respond to resizes without special-casing Mac OS targets.

See #39. This is only a partial fix, and does not provide on-the-fly resize events.