### PR TITLE
Use a hand pointing a finger in X11 as MouseCursor::Hand

### DIFF
--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -792,7 +792,7 @@ impl Window {
                 MouseCursor::Copy => load("copy"),
                 MouseCursor::Crosshair => load("crosshair"),
                 MouseCursor::Default => load("left_ptr"),
-                MouseCursor::Hand => load("hand1"),
+                MouseCursor::Hand => loadn(&["hand2", "hand1"]),
                 MouseCursor::Help => load("question_arrow"),
                 MouseCursor::Move => load("move"),
                 MouseCursor::Grab => loadn(&["openhand", "grab"]),


### PR DESCRIPTION
Fix #120.

I didn't find if "hand2" is universally available, so I used the old value "hand1" as a fallback.