### PR TITLE
linux: Add missing Window2::id() impl

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -147,7 +147,10 @@ impl Window2 {
 
     #[inline]
     pub fn id(&self) -> WindowId {
-        unimplemented!()
+        match self {
+            &Window2::X(ref w) => WindowId::X(w.id()),
+            &Window2::Wayland(ref w) => WindowId::Wayland(w.id())
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This was forgotten in #150 