### PR TITLE
Support removing window decorations in x11 and macOS

### DIFF
--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -311,23 +311,22 @@ impl Window {
                 }
             };
 
-            let masks = if screen.is_some() || attrs.transparent {
-                // Fullscreen or transparent window
+            let masks = if screen.is_some() {
+                // Fullscreen window
                 appkit::NSBorderlessWindowMask as NSUInteger |
                 appkit::NSResizableWindowMask as NSUInteger |
                 appkit::NSTitledWindowMask as NSUInteger
             } else if attrs.decorations {
-                // Classic opaque window with titlebar
+                // Window with a titlebar
                 appkit::NSClosableWindowMask as NSUInteger |
                 appkit::NSMiniaturizableWindowMask as NSUInteger |
                 appkit::NSResizableWindowMask as NSUInteger |
                 appkit::NSTitledWindowMask as NSUInteger
             } else {
-                // Opaque window without a titlebar
+                // Window without a titlebar
                 appkit::NSClosableWindowMask as NSUInteger |
                 appkit::NSMiniaturizableWindowMask as NSUInteger |
                 appkit::NSResizableWindowMask as NSUInteger |
-                appkit::NSTitledWindowMask as NSUInteger |
                 appkit::NSFullSizeContentViewWindowMask as NSUInteger
             };
 


### PR DESCRIPTION
macOS already had some code in place trying to remove the title bar, but it was not correct. Also, transparent windows on macOS always had a title bar, which may not always be desired.

Tested on Arch Linux with kwin (on KDE5 with Plasma) and i3 window managers. And on macOS El Capitan, 10.11.

@mitchmindtree: You might wanna take a look, since you mentioned the macOS problem in [my glutin PR](https://github.com/tomaka/glutin/pull/865).