### PR TITLE
Readd pub import erroneously removed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -13,6 +13,8 @@ use platform::x11::ffi::XVisualInfo;
 use wayland_client::protocol::wl_display::WlDisplay;
 use wayland_client::protocol::wl_surface::WlSurface;
 
+pub use platform::x11;
+
 // TODO: do not expose XConnection
 pub fn get_x11_xconnection() -> Option<Arc<XConnection>> {
     match *UNIX_BACKEND {


### PR DESCRIPTION
This pub import was accidentally removed in #150, and is used by glutin.

However it exposes the integrality of winit's guts regarding x11, which is probably not wanted... ? Maybe a more selective import should be appropriate, and in this case, what should we expose?

(glutin needs at least `XError`, `XNotSupported`, and `XConnection`)