### PR TITLE
Several fixes for the macOS backend

### DIFF
--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -19,7 +19,7 @@ pub struct EventsLoop {
     //
     // This is *only* `Some` for the duration of a call to either of these methods and will be
     // `None` otherwise.
-    pub user_callback: UserCallback,
+    user_callback: UserCallback,
 }
 
 struct Modifiers {
@@ -61,15 +61,19 @@ impl UserCallback {
 
     // Emits the given event via the user-given callback.
     //
-    // This is *only* called within the `poll_events` and `run_forever` methods so we know that it
-    // is safe to `unwrap` the callback without causing a panic as there must be at least one
-    // callback stored.
-    //
     // This is unsafe as it requires dereferencing the pointer to the user-given callback. We
     // guarantee this is safe by ensuring the `UserCallback` never lives longer than the user-given
     // callback.
-    pub unsafe fn call_with_event(&self, event: Event) {
-        let callback: *mut FnMut(Event) = self.mutex.lock().unwrap().take().unwrap();
+    //
+    // Note that the callback may not always be `Some`. This is because some `NSWindowDelegate`
+    // callbacks can be triggered by means other than `NSApp().sendEvent`. For example, if a window
+    // is destroyed or created during a call to the user's callback, the `WindowDelegate` methods
+    // may be called with `windowShouldClose` or `windowDidResignKey`.
+    unsafe fn call_with_event(&self, event: Event) {
+        let callback = match self.mutex.lock().unwrap().take() {
+            Some(callback) => callback,
+            None => return,
+        };
         (*callback)(event);
         *self.mutex.lock().unwrap() = Some(callback);
     }
@@ -117,9 +121,7 @@ impl EventsLoop {
         loop {
             unsafe {
                 // First, yield all pending events.
-                while let Some(event) = self.pending_events.lock().unwrap().pop_front() {
-                    self.user_callback.call_with_event(event);
-                }
+                self.call_user_callback_with_pending_events();
 
                 let pool = foundation::NSAutoreleasePool::new(cocoa::base::nil);
 
@@ -161,9 +163,7 @@ impl EventsLoop {
         loop {
             unsafe {
                 // First, yield all pending events.
-                while let Some(event) = self.pending_events.lock().unwrap().pop_front() {
-                    self.user_callback.call_with_event(event);
-                }
+                self.call_user_callback_with_pending_events();
 
                 let pool = foundation::NSAutoreleasePool::new(cocoa::base::nil);
 
@@ -214,6 +214,34 @@ impl EventsLoop {
                     0);
             appkit::NSApp().postEvent_atStart_(event, cocoa::base::NO);
             foundation::NSAutoreleasePool::drain(pool);
+        }
+    }
+
+    fn call_user_callback_with_pending_events(&self) {
+        loop {
+            let event = match self.pending_events.lock().unwrap().pop_front() {
+                Some(event) => event,
+                None => return,
+            };
+            unsafe {
+                self.user_callback.call_with_event(event);
+            }
+        }
+    }
+
+    // Calls the user callback if one exists.
+    //
+    // Otherwise, stores the event in the `pending_events` queue.
+    //
+    // This is necessary for the case when `WindowDelegate` callbacks are triggered during a call
+    // to the user's callback.
+    pub fn call_user_callback_with_event_or_store_in_pending(&self, event: Event) {
+        if self.user_callback.mutex.lock().unwrap().is_some() {
+            unsafe {
+                self.user_callback.call_with_event(event);
+            }
+        } else {
+            self.pending_events.lock().unwrap().push_back(event);
         }
     }
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -217,6 +217,18 @@ impl EventsLoop {
         }
     }
 
+    // Removes the window with the given `Id` from the `windows` list.
+    //
+    // This is called when a window is either `Closed` or `Drop`ped.
+    pub fn find_and_remove_window(&self, id: super::window::Id) {
+        if let Ok(mut windows) = self.windows.lock() {
+            windows.retain(|w| match w.upgrade() {
+                Some(w) => w.id() != id,
+                None => true,
+            });
+        }
+    }
+
     fn call_user_callback_with_pending_events(&self) {
         loop {
             let event = match self.pending_events.lock().unwrap().pop_front() {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -26,7 +26,8 @@ impl Window2 {
     {
         let weak_events_loop = ::std::sync::Arc::downgrade(&events_loop);
         let window = ::std::sync::Arc::new(try!(Window::new(weak_events_loop, attributes, pl_attribs)));
-        events_loop.windows.lock().unwrap().push(window.clone());
+        let weak_window = ::std::sync::Arc::downgrade(&window);
+        events_loop.windows.lock().unwrap().push(weak_window);
         Ok(Window2 { window: window })
     }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -181,6 +181,14 @@ impl Drop for Window {
         if let Some(ev) = self.delegate.state.events_loop.upgrade() {
             ev.find_and_remove_window(id);
         }
+
+        // Close the window if it has not yet been closed.
+        let nswindow = *self.window;
+        if nswindow != nil {
+            unsafe {
+                msg_send![nswindow, close];
+            }
+        }
     }
 }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -174,7 +174,10 @@ impl Drop for Window {
         let id = self.id();
         if let Some(ev) = self.delegate.state.events_loop.upgrade() {
             let mut windows = ev.windows.lock().unwrap();
-            windows.retain(|w| w.id() != id)
+            windows.retain(|w| match w.upgrade() {
+                Some(w) => w.id() != id,
+                None => true,
+            })
         }
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -57,7 +57,7 @@ impl WindowDelegate {
             };
 
             if let Some(events_loop) = state.events_loop.upgrade() {
-                events_loop.user_callback.call_with_event(event);
+                events_loop.call_user_callback_with_event_or_store_in_pending(event);
             }
         }
 


### PR DESCRIPTION
While updating `glutin` and `glium` and testing their examples, several bugs in the macOS backend started to show themselves. See the individual commits and their messages for details on each of the fixes.

Closes #73.