### PR TITLE
Set #[repr] of VirtualKeyCode to u32

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -138,6 +138,7 @@ pub enum MouseScrollDelta {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[repr(u32)]
 pub enum VirtualKeyCode {
     /// The '1' key over the letters.
     Key1,


### PR DESCRIPTION
This allows to have an array of `bools` for the key states.

Fixes #87