### PR TITLE
Bump version to expose WM_CLASS fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]


### PR DESCRIPTION
#168 is currently not visible to downstream libraries. A version bump fixes that.

Fixes #170.