### PR TITLE
X11 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -234,7 +234,7 @@ impl EventsLoop {
 
                 let mut ev_mods = ModifiersState::default();
 
-                let mut keysym = unsafe {
+                let keysym = unsafe {
                     (self.display.xlib.XKeycodeToKeysym)(self.display.display, xkev.keycode as ffi::KeyCode, 0)
                 };
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -103,6 +103,37 @@ impl EventsLoop {
 
     pub fn interrupt(&self) {
         self.interrupted.store(true, ::std::sync::atomic::Ordering::Relaxed);
+
+        // Push an event on the X event queue so that methods like run_forever will advance.
+
+        // Get a window for the event.
+        //
+        // It should not matter which window is used since the purpose is merely
+        // to advance the event loop.
+        let window = {
+            let windows = self.windows.lock().unwrap();
+            match windows.keys().nth(0) {
+                Some(window_id) => window_id.0,
+                None => return
+            }
+        };
+
+        let mut xev = ffi::XClientMessageEvent {
+            type_: ffi::ClientMessage,
+            window: window,
+            format: 32,
+            message_type: 0,
+            serial: 0,
+            send_event: 0,
+            display: self.display.display,
+            data: unsafe { mem::zeroed() },
+        };
+
+        unsafe {
+            (self.display.xlib.XSendEvent)(self.display.display, window, 0, 0, mem::transmute(&mut xev));
+            (self.display.xlib.XFlush)(self.display.display);
+            self.display.check_errors().expect("Failed to call XSendEvent after wakeup");
+        }
     }
 
     pub fn poll_events<F>(&self, mut callback: F)


### PR DESCRIPTION
* X11 `poll_events` actually drains queue as the documentation suggests
* Makes `EventLoop::interrupt` actually wakeup the event loop. Previously it would just raise a flag without allowing `run_forever` to spin. This is the same behavior as the old `WindowProxy::wakeup_event_loop` method.

Unfortunately, `EventsLoop::interrupt` is also the recommend way to exit a `run_forever` loop from within the event handler callback. Pushing an extra event on the queue in that case is simply wasteful. Changing this would require a refactor taking one of two possible forms:

1. Add a method *in addition* to interrupt intended for waking up the
   event loop
2. Add a return type to the event callback like
```rust
    enum Continue { True, False }
```
   which would be used in lieu of the atomic interrupt flag. With the return value here, interrupt would only be needed from _other_ threads.

At any rate, that's out of scope for this PR. Should I open a ticket discussing this API issue?