### PR TITLE
Fix poll_events on x11 not draining completely

### DIFF
--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -126,6 +126,7 @@ impl EventsLoop {
     pub fn poll_events<F>(&self, mut callback: F)
         where F: FnMut(Event)
     {
+        self.interrupted.store(false, ::std::sync::atomic::Ordering::Relaxed);
         let xlib = &self.display.xlib;
 
         let mut xev = unsafe { mem::uninitialized() };


### PR DESCRIPTION
If the interrupted flag were set going into poll_events, it would only
ever handle the first event in the queue. Now, the flag is reset at the
start so events are processed until the caller requests otherwise.