### PR TITLE
Add 'use-x-over-wayland' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,8 @@ wayland-client = { version = "0.8.6", features = ["dlopen"] }
 wayland-kbd = "0.8.0"
 wayland-window = "0.5.0"
 x11-dl = "2.8"
+
+[features]
+# Under linux/bsd use X preferentially over Wayland, if running a Wayland session this means the window will render 
+# using XWayland. This feature will not affect other operating systems.
+use-x-over-wayland = []

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -3,7 +3,7 @@ extern crate winit;
 fn main() {
     let events_loop = winit::EventsLoop::new();
 
-    let window = winit::WindowBuilder::new()
+    let _window = winit::WindowBuilder::new()
         .with_title("A fantastic window!")
         .build(&events_loop)
         .unwrap();

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -27,17 +27,26 @@ pub enum UnixBackend {
     X(Arc<XConnection>),
     Wayland(Arc<wayland::WaylandContext>),
     Error(XNotSupported),
-} 
+}
 
 lazy_static!(
     pub static ref UNIX_BACKEND: UnixBackend = {
-        if let Some(ctxt) = wayland::WaylandContext::init() {
-            UnixBackend::Wayland(Arc::new(ctxt))
-        } else {
+        #[inline]
+        fn x_backend() -> UnixBackend {
             match XConnection::new(Some(x_error_callback)) {
                 Ok(x) => UnixBackend::X(Arc::new(x)),
                 Err(e) => UnixBackend::Error(e),
             }
+        }
+
+        if cfg!(feature = "use-x-over-wayland") {
+            x_backend()
+        }
+        else if let Some(ctxt) = wayland::WaylandContext::init() {
+            UnixBackend::Wayland(Arc::new(ctxt))
+        }
+        else {
+            x_backend()
         }
     };
 );


### PR DESCRIPTION
As the wayland code is currently not working well enough under a gnome wayland session (Ie currently the window example renders nothing), I've added a feature to allow XWayland usage, ie simply use X when in a wayland session. Now in a gnome wayland session I can run the window example with `cargo run --example window --features use-x-over-wayland`

It is debatable whether this should be default until the wayland code is in a better state. In any case this feature will allow me to use this lib in wayland.