### PR TITLE
Update 'winit' dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-winit = "0.5"
+winit = "0.6"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
It now matches the current release line, 0.6.x