### PR TITLE
wayland: Initially paint the window white so that they always exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ dwmapi-sys = "0.1"
 wayland-client = { version = "0.8.6", features = ["dlopen"] }
 wayland-kbd = "0.8.0"
 wayland-window = "0.5.0"
+tempfile = "2.1"
 x11-dl = "2.8"

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -10,6 +10,7 @@ use self::event_loop::EventsLoopSink;
 
 extern crate wayland_kbd;
 extern crate wayland_window;
+extern crate tempfile;
 
 mod context;
 mod event_loop;


### PR DESCRIPTION
This adds a dependency on the tempfile crate, but this was already a transitive dependency via wayland-window.

This PR uses the basic mechanism of wayland for passing memory buffers to paint the window content white once at creation, to ensure the window actually exists and can receive events, to avoid the issues like https://github.com/tomaka/glutin/issues/884

This mechanism is guaranteed to always be available by the wayland spec, and does not pose any problem to initialize an EGL or Vulkan context afterwards.

closes #109