### PR TITLE
Mouse device events

### DIFF
--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -30,7 +30,7 @@ fn main() {
 
                     WindowEvent::Closed => return ControlFlow::Break,
 
-                    a @ WindowEvent::MouseMoved { .. } => {
+                    a @ WindowEvent::CursorMoved { .. } => {
                         println!("{:?}", a);
                     },
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -41,20 +41,20 @@ pub enum WindowEvent {
     KeyboardInput { device_id: DeviceId, input: KeyboardInput },
 
     /// The cursor has moved on the window.
-    MouseMoved {
+    CursorMoved {
         device_id: DeviceId,
 
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
-        /// limited by the display area and it may have been transformed by the OS to implement effects such as mouse
+        /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
         position: (f64, f64),
     },
 
     /// The cursor has entered the window.
-    MouseEntered { device_id: DeviceId },
+    CursorEntered { device_id: DeviceId },
 
     /// The cursor has left the window.
-    MouseLeft { device_id: DeviceId },
+    CursorLeft { device_id: DeviceId },
 
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel { device_id: DeviceId, delta: MouseScrollDelta, phase: TouchPhase },
@@ -99,7 +99,7 @@ pub enum DeviceEvent {
 
     /// Change in physical position of a pointing device.
     ///
-    /// This represents raw, unfiltered physical motion. Not to be confused with `WindowEvent::MouseMoved`.
+    /// This represents raw, unfiltered physical motion. Not to be confused with `WindowEvent::CursorMoved`.
     MouseMoved {
         /// (x, y) change in position in unspecified units.
         ///

--- a/src/events.rs
+++ b/src/events.rs
@@ -93,7 +93,25 @@ pub enum WindowEvent {
 pub enum DeviceEvent {
     Added,
     Removed,
-    Motion { axis: AxisId, value: f64 },
+
+    /// Change in physical position of a pointing device.
+    ///
+    /// This represents raw, unfiltered physical motion. Not to be confused with `WindowEvent::MouseMoved`.
+    MouseMoved {
+        /// (x, y) change in position in unspecified units.
+        ///
+        /// Different devices may use different units.
+        delta: (f64, f64),
+    },
+
+    /// Physical scroll event
+    MouseWheel {
+        delta: MouseScrollDelta,
+    },
+
+    /// Motion on some analog axis not otherwise handled.
+    AxisMoved { axis: AxisId, value: f64 },
+
     Button { button: ButtonId, state: ElementState },
     Key(KeyboardInput),
     Text { codepoint: char },

--- a/src/events.rs
+++ b/src/events.rs
@@ -41,11 +41,14 @@ pub enum WindowEvent {
     KeyboardInput { device_id: DeviceId, input: KeyboardInput },
 
     /// The cursor has moved on the window.
-    ///
-    /// `position` is (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this
-    /// data is limited by the display area and it may have been transformed by the OS to implement effects such as
-    /// mouse acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-    MouseMoved { device_id: DeviceId, position: (f64, f64) },
+    MouseMoved {
+        device_id: DeviceId,
+
+        /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
+        /// limited by the display area and it may have been transformed by the OS to implement effects such as mouse
+        /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
+        position: (f64, f64),
+    },
 
     /// The cursor has entered the window.
     MouseEntered { device_id: DeviceId },
@@ -66,8 +69,10 @@ pub enum WindowEvent {
     /// is being pressed) and stage (integer representing the click level).
     TouchpadPressure { device_id: DeviceId, pressure: f32, stage: i64 },
 
-    /// Motion on some analog axis not otherwise handled. May overlap with mouse motion.
-    AxisMotion { device_id: DeviceId, axis: AxisId, value: f64 },
+    /// Motion on some analog axis not otherwise handled.
+    ///
+    /// May overlap with mouse motion.
+    AxisMoved { device_id: DeviceId, axis: AxisId, value: f64 },
 
     /// The window needs to be redrawn.
     Refresh,

--- a/src/events.rs
+++ b/src/events.rs
@@ -69,9 +69,7 @@ pub enum WindowEvent {
     /// is being pressed) and stage (integer representing the click level).
     TouchpadPressure { device_id: DeviceId, pressure: f32, stage: i64 },
 
-    /// Motion on some analog axis not otherwise handled.
-    ///
-    /// May overlap with mouse motion.
+    /// Motion on some analog axis. May report data redundant to other, more specific events.
     AxisMoved { device_id: DeviceId, axis: AxisId, value: f64 },
 
     /// The window needs to be redrawn.
@@ -114,7 +112,7 @@ pub enum DeviceEvent {
         delta: MouseScrollDelta,
     },
 
-    /// Motion on some analog axis not otherwise handled.
+    /// Motion on some analog axis. May report data redundant to other, more specific events.
     AxisMoved { axis: AxisId, value: f64 },
 
     Button { button: ButtonId, state: ElementState },

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -375,10 +375,10 @@ impl wl_pointer::Handler for InputHandler {
                 self.mouse_focus = Some(window.clone());
                 let (w, h) = self.mouse_location;
                 let mut guard = self.callback.lock().unwrap();
-                guard.send_event(Event::MouseEntered { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)) },
+                guard.send_event(Event::CursorEntered { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)) },
                                  make_wid(window));
-                guard.send_event(Event::MouseMoved { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                                     position: (w, h) },
+                guard.send_event(Event::CursorMoved { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                                      position: (w, h) },
                                  make_wid(window));
                 break;
             }
@@ -394,7 +394,7 @@ impl wl_pointer::Handler for InputHandler {
         self.mouse_focus = None;
         for window in &self.windows {
             if window.equals(surface) {
-                self.callback.lock().unwrap().send_event(Event::MouseLeft { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)) },
+                self.callback.lock().unwrap().send_event(Event::CursorLeft { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)) },
                                                          make_wid(window));
             }
         }
@@ -410,8 +410,8 @@ impl wl_pointer::Handler for InputHandler {
         self.mouse_location = (surface_x, surface_y);
         if let Some(ref window) = self.mouse_focus {
             let (w,h) = self.mouse_location;
-            self.callback.lock().unwrap().send_event(Event::MouseMoved { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                                                         position: (w, h) }, make_wid(window));
+            self.callback.lock().unwrap().send_event(Event::CursorMoved { device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                                                          position: (w, h) }, make_wid(window));
         }
     }
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -338,7 +338,7 @@ impl EventsLoop {
                     return;
                 }
 
-                use events::WindowEvent::{Focused, MouseEntered, MouseInput, MouseLeft, MouseMoved, MouseWheel, AxisMoved};
+                use events::WindowEvent::{Focused, CursorEntered, MouseInput, CursorLeft, CursorMoved, MouseWheel, AxisMoved};
                 use events::ElementState::{Pressed, Released};
                 use events::MouseButton::{Left, Right, Middle, Other};
                 use events::MouseScrollDelta::LineDelta;
@@ -389,7 +389,7 @@ impl EventsLoop {
                                 true
                             } else { false }
                         } {
-                            callback(Event::WindowEvent { window_id: wid, event: MouseMoved {
+                            callback(Event::WindowEvent { window_id: wid, event: CursorMoved {
                                 device_id: did,
                                 position: new_cursor_pos
                             }});
@@ -435,11 +435,11 @@ impl EventsLoop {
 
                     ffi::XI_Enter => {
                         let xev: &ffi::XIEnterEvent = unsafe { &*(xev.data as *const _) };
-                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: MouseEntered { device_id: mkdid(xev.deviceid) } })
+                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: CursorEntered { device_id: mkdid(xev.deviceid) } })
                     }
                     ffi::XI_Leave => {
                         let xev: &ffi::XILeaveEvent = unsafe { &*(xev.data as *const _) };
-                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: MouseLeft { device_id: mkdid(xev.deviceid) } })
+                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: CursorLeft { device_id: mkdid(xev.deviceid) } })
                     }
                     ffi::XI_FocusIn => {
                         let xev: &ffi::XIFocusInEvent = unsafe { &*(xev.data as *const _) };

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -441,8 +441,8 @@ impl EventsLoop {
             appkit::NSOtherMouseDown => { Some(into_event(WindowEvent::MouseInput { device_id: DEVICE_ID, state: ElementState::Pressed, button: MouseButton::Middle })) },
             appkit::NSOtherMouseUp => { Some(into_event(WindowEvent::MouseInput { device_id: DEVICE_ID, state: ElementState::Released, button: MouseButton::Middle })) },
 
-            appkit::NSMouseEntered => { Some(into_event(WindowEvent::MouseEntered { device_id: DEVICE_ID })) },
-            appkit::NSMouseExited => { Some(into_event(WindowEvent::MouseLeft { device_id: DEVICE_ID })) },
+            appkit::NSCursorEntered => { Some(into_event(WindowEvent::CursorEntered { device_id: DEVICE_ID })) },
+            appkit::NSMouseExited => { Some(into_event(WindowEvent::CursorLeft { device_id: DEVICE_ID })) },
 
             appkit::NSMouseMoved |
             appkit::NSLeftMouseDragged |
@@ -470,7 +470,7 @@ impl EventsLoop {
 
                 let x = (scale_factor * view_point.x as f32) as f64;
                 let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
-                let window_event = WindowEvent::MouseMoved { device_id: DEVICE_ID, position: (x, y) };
+                let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
                 let event = Event::WindowEvent { window_id: ::WindowId(window.id()), event: window_event };
                 Some(event)
             },

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -339,7 +339,7 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
         }
 
         winapi::WM_MOUSEMOVE => {
-            use events::WindowEvent::{MouseEntered, MouseMoved};
+            use events::WindowEvent::{CursorEntered, CursorMoved};
             let mouse_outside_window = CONTEXT_STASH.with(|context_stash| {
                 let mut context_stash = context_stash.borrow_mut();
                 if let Some(context_stash) = context_stash.as_mut() {
@@ -358,7 +358,7 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
             if mouse_outside_window {
                 send_event(Event::WindowEvent {
                     window_id: SuperWindowId(WindowId(window)),
-                    event: MouseEntered { device_id: DEVICE_ID },
+                    event: CursorEntered { device_id: DEVICE_ID },
                 });
                 
                 // Calling TrackMouseEvent in order to receive mouse leave events.
@@ -375,14 +375,14 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
 
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
-                event: MouseMoved { device_id: DEVICE_ID, position: (x, y) },
+                event: CursorMoved { device_id: DEVICE_ID, position: (x, y) },
             });
 
             0
         },
 
         winapi::WM_MOUSELEAVE => {
-            use events::WindowEvent::MouseLeft;
+            use events::WindowEvent::CursorLeft;
             let mouse_in_window = CONTEXT_STASH.with(|context_stash| {
                 let mut context_stash = context_stash.borrow_mut();
                 if let Some(context_stash) = context_stash.as_mut() {
@@ -401,7 +401,7 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
             if mouse_in_window {
                 send_event(Event::WindowEvent {
                     window_id: SuperWindowId(WindowId(window)),
-                    event: MouseLeft { device_id: DEVICE_ID }
+                    event: CursorLeft { device_id: DEVICE_ID }
                 });
             }
 


### PR DESCRIPTION
This makes the API more intuitive for common use-cases and allows us to better propagate platform knowledge of motion semantics.

My original design for `DeviceEvent` from #164 attempted to be very abstract in the interest of supporting the broadest possible range of input device types, at the cost of being somewhat less obvious. Thanks in large part to discussion with @LPGhatguy, I now believe this was unnecessary. In particular, I believe that the set of input device types supported by major platforms' windowing APIs is very small, and hence merits richer, more semantic event types to improve winit's ease-of-use.

Generic events are retained to ensure we never need to discard data, but I think we should in general try to add handling for every device type we encounter in practice. On the flip side, I think we should be careful to keep the scope of input devices handled as narrow as possible, exposing only events that cannot reasonably be accessed without winit's cooperation.

Do these changes make sense to people?

I also took the opportunity to normalize event naming slightly.