### PR TITLE
X11: Convert window geometry from pixels to points

### DIFF
--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -520,7 +520,13 @@ impl Window {
                 return None;
             }
 
-            Some((x as i32, y as i32, width as u32, height as u32, border as u32))
+            let scale = self.hidpi_factor();
+
+            Some(((x as f32 / scale) as i32,
+                  (y as f32 / scale) as i32,
+                  (width as f32 / scale) as u32,
+                  (height as f32 / scale) as u32,
+                  (border as f32 / scale) as u32))
         }
     }
 


### PR DESCRIPTION
XGetGeometry returns geometry in pixels. Callers of get_geometry expect
results in points (ie. pixels / hidpi_factor). Prior to this change,
get_geometry returned its results in pixels. This resulted in
get_inner_size_pixels returning incorrect sizes when a hidpi factor
other than 1 was used.

This is a bit of a mess. I know these values will be converted back into pixels later by multiplying by the hidpi factor.

Also, all the documentation I can find about `XGetGeometry` is really vague about whether it returns pixels. The observations I've made when testing suggest it returns pixels. Here's some code in gtk that seems to be converting from pixels into points: https://github.com/GNOME/gtk/blob/master/gdk/x11/gdkwindow-x11.c#L2574 . This man page says that it returns the border width in pixels (but doesn't specify units for position or size): https://linux.die.net/man/3/xgetgeometry.

The problem this solves manifested when trying to use https://github.com/tomaka/glutin to make windows for use with https://github.com/gfx-rs/gfx. The size of the opengl area would be larger than the window by a factor of the hidpi factor. With a hidpi factor of >1, the size reported by `get_inner_size` was the size in pixels, and the size reported by `get_inner_size_pixels` was hidpi_factor times larger.

I've tested this on two different linux machines with a variety of hidpi factors configured (with `xrandr --dpi`) and it looks like it behaves correctly.

I think this addresses https://github.com/tomaka/winit/issues/169