### PR TITLE
Stop exposing wayland_client's types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ kernel32-sys = "0.2"
 dwmapi-sys = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
-wayland-client = { version = "0.8.6", features = ["dlopen"] }
-wayland-kbd = "0.8.0"
-wayland-window = "0.5.0"
+wayland-client = { version = "0.9.9", features = ["dlopen"] }
+wayland-kbd = "0.9.1"
+wayland-window = "0.6.1"
 tempfile = "2.1"
 x11-dl = "2.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ extern crate core_graphics;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 extern crate x11_dl;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
-#[macro_use(wayland_env,declare_handler)]
+#[macro_use]
 extern crate wayland_client;
 
 pub use events::*;

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -10,9 +10,6 @@ use WindowBuilder;
 use platform::x11::XConnection;
 use platform::x11::ffi::XVisualInfo;
 
-use wayland_client::protocol::wl_display::WlDisplay;
-use wayland_client::protocol::wl_surface::WlSurface;
-
 pub use platform::x11;
 
 // TODO: do not expose XConnection
@@ -63,24 +60,6 @@ pub trait WindowExt {
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
     fn get_wayland_display(&self) -> Option<*mut libc::c_void>;
-
-    /// Returns a reference to the `WlSurface` object of wayland that is used by this window.
-    ///
-    /// For use with the `wayland-client` crate.
-    ///
-    /// **This function is not part of winit's public API.**
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    fn get_wayland_client_surface(&self) -> Option<&WlSurface>;
-
-    /// Returns a pointer to the `WlDisplay` object of wayland that is used by this window.
-    ///
-    /// For use with the `wayland-client` crate.
-    ///
-    /// **This function is not part of winit's public API.**
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    fn get_wayland_client_display(&self) -> Option<&WlDisplay>;
 }
 
 impl WindowExt for Window {
@@ -124,28 +103,17 @@ impl WindowExt for Window {
     #[inline]
     fn get_wayland_surface(&self) -> Option<*mut libc::c_void> {
         use wayland_client::Proxy;
-        self.get_wayland_client_surface().map(|p| p.ptr() as *mut _)
-    }
-
-
-    #[inline]
-    fn get_wayland_display(&self) -> Option<*mut libc::c_void> {
-        use wayland_client::Proxy;
-        self.get_wayland_client_display().map(|p| p.ptr() as *mut _)
-    }
-
-    #[inline]
-    fn get_wayland_client_surface(&self) -> Option<&WlSurface> {
         match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.get_surface()),
+            LinuxWindow::Wayland(ref w) => Some(w.get_surface().ptr() as *mut _),
             _ => None
         }
     }
 
     #[inline]
-    fn get_wayland_client_display(&self) -> Option<&WlDisplay> {
+    fn get_wayland_display(&self) -> Option<*mut libc::c_void> {
+        use wayland_client::Proxy;
         match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.get_display()),
+            LinuxWindow::Wayland(ref w) => Some(w.get_display().ptr() as *mut _),
             _ => None
         }
     }

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{self, AtomicBool};
 use super::{DecoratedHandler, WindowId, DeviceId, WaylandContext};
 
 
-use wayland_client::{EventQueue, EventQueueHandle, Init, Proxy};
+use wayland_client::{EventQueue, EventQueueHandle, Init, Proxy, Liveness};
 use wayland_client::protocol::{wl_seat, wl_surface, wl_pointer, wl_keyboard};
 
 use super::make_wid;
@@ -159,13 +159,13 @@ impl EventsLoop {
     }
 
     fn prune_dead_windows(&self) {
-        self.decorated_ids.lock().unwrap().retain(|&(_, ref w)| w.is_alive());
+        self.decorated_ids.lock().unwrap().retain(|&(_, ref w)| w.status() == Liveness::Alive);
         let mut evq_guard = self.evq.lock().unwrap();
         let mut state = evq_guard.state();
         let handler = state.get_mut_handler::<InputHandler>(self.hid);
-        handler.windows.retain(|w| w.is_alive());
+        handler.windows.retain(|w| w.status() == Liveness::Alive);
         if let Some(w) = handler.mouse_focus.take() {
-            if w.is_alive() {
+            if w.status() == Liveness::Alive {
                 handler.mouse_focus = Some(w)
             }
         }


### PR DESCRIPTION
This PR removes the two methods from the unix `WindowExt` trait exposing wayland_client's types, as glutin does not need them any more (see https://github.com/tomaka/glutin/pull/893) and the next release will already contain breaking changes.

As wayland_client is no longer exposed in winit's API, this also upgrades the wayland dependencies.