### PR TITLE
Add an example of activating XIM

### DIFF
--- a/examples/xim.rs
+++ b/examples/xim.rs
@@ -5,8 +5,11 @@ extern crate x11_dl;
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
     unsafe {
+        // using empty c string to fallback to LC_CTYPE in environment variables
         libc::setlocale(libc::LC_CTYPE, b"\0".as_ptr() as *const _);
         let xlib = x11_dl::xlib::Xlib::open().expect("get xlib");
+        // using empty c string for implementation dependent behavior,
+        // which might be the XMODIFIERS set in env
         (xlib.XSetLocaleModifiers)(b"\0".as_ptr() as *const _);
     }
     let _window = winit::Window::new(&events_loop)

--- a/examples/xim.rs
+++ b/examples/xim.rs
@@ -1,0 +1,27 @@
+extern crate winit;
+extern crate libc;
+extern crate x11_dl;
+
+fn main() {
+    let mut events_loop = winit::EventsLoop::new();
+    unsafe {
+        libc::setlocale(libc::LC_CTYPE, b"\0".as_ptr() as *const _);
+        let xlib = x11_dl::xlib::Xlib::open().expect("get xlib");
+        (xlib.XSetLocaleModifiers)(b"\0".as_ptr() as *const _);
+    }
+    let _window = winit::Window::new(&events_loop)
+        .unwrap();
+    events_loop.run_forever(|event| {
+        match event {
+            winit::Event::WindowEvent {
+                event: winit::WindowEvent::ReceivedCharacter(chr), ..} => {
+                println!("{:?}", chr);
+                winit::ControlFlow::Continue
+            }
+            winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => {
+                winit::ControlFlow::Break
+            },
+            _ => winit::ControlFlow::Continue,
+        }
+    });
+}

--- a/examples/xim.rs
+++ b/examples/xim.rs
@@ -1,32 +1,47 @@
-#![cfg(target_os = "linux")]
+macro_rules! group_attr {
+    (#[cfg($attr:meta)] $($yes:item)*) => {
+        $(#[cfg($attr)] $yes)*
+    }
+}
 
-extern crate winit;
-extern crate libc;
-extern crate x11_dl;
+group_attr! {
+
+    #[cfg(target_os = "linux")]
+
+    extern crate winit;
+    extern crate libc;
+    extern crate x11_dl;
+
+    fn main() {
+        let mut events_loop = winit::EventsLoop::new();
+        unsafe {
+            // using empty c string to fallback to LC_CTYPE in environment variables
+            libc::setlocale(libc::LC_CTYPE, b"\0".as_ptr() as *const _);
+            let xlib = x11_dl::xlib::Xlib::open().expect("get xlib");
+            // using empty c string for implementation dependent behavior,
+            // which might be the XMODIFIERS set in env
+            (xlib.XSetLocaleModifiers)(b"\0".as_ptr() as *const _);
+        }
+        let _window = winit::Window::new(&events_loop)
+            .unwrap();
+        events_loop.run_forever(|event| {
+            match event {
+                winit::Event::WindowEvent {
+                    event: winit::WindowEvent::ReceivedCharacter(chr), ..} => {
+                        println!("{:?}", chr);
+                        winit::ControlFlow::Continue
+                    }
+                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => {
+                    winit::ControlFlow::Break
+                },
+                _ => winit::ControlFlow::Continue,
+            }
+        });
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
 
 fn main() {
-    let mut events_loop = winit::EventsLoop::new();
-    unsafe {
-        // using empty c string to fallback to LC_CTYPE in environment variables
-        libc::setlocale(libc::LC_CTYPE, b"\0".as_ptr() as *const _);
-        let xlib = x11_dl::xlib::Xlib::open().expect("get xlib");
-        // using empty c string for implementation dependent behavior,
-        // which might be the XMODIFIERS set in env
-        (xlib.XSetLocaleModifiers)(b"\0".as_ptr() as *const _);
-    }
-    let _window = winit::Window::new(&events_loop)
-        .unwrap();
-    events_loop.run_forever(|event| {
-        match event {
-            winit::Event::WindowEvent {
-                event: winit::WindowEvent::ReceivedCharacter(chr), ..} => {
-                println!("{:?}", chr);
-                winit::ControlFlow::Continue
-            }
-            winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => {
-                winit::ControlFlow::Break
-            },
-            _ => winit::ControlFlow::Continue,
-        }
-    });
+    // do nothing, xim is not available
 }

--- a/examples/xim.rs
+++ b/examples/xim.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "linux")]
+
 extern crate winit;
 extern crate libc;
 extern crate x11_dl;


### PR DESCRIPTION
This follows up and closes #195.

To make this example work, one should ensure he/she configures `LC_CTYPE` and `XMODIFIERS` correctly in environment. An example is `LC_CTYPE=zh_CN.utf8` and `XMODIFIERS='@im=fcitx'` for fcitx-base IMEs.