### PR TITLE
X11: Add OverrideRedirect attribute to new windows

### DIFF
--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -190,7 +190,8 @@ impl Window {
             swa
         };
 
-        let mut window_attributes = ffi::CWBorderPixel | ffi::CWColormap | ffi::CWEventMask;
+        let mut window_attributes = ffi::CWBorderPixel | ffi::CWColormap | ffi::CWEventMask |
+            ffi::CWOverrideRedirect;
 
         if window_attrs.transparent {
             window_attributes |= ffi::CWBackPixel;


### PR DESCRIPTION
This flag allows windows to avoid capture by tiling window managers such
as i3. Following this change, windows created with a minimum and maximum
size will not be tiled by the WM when first created. Note that the logic
for specifying the size hints of the window to prevent scaling was
already present. This change just adds the OverrideRedirect flag which
allow them to take effect.

I've tested this change on my laptop with archlinux + i3. i3 is a tiling window manager.

Prior to this change, regardless of a window's size, it would be tiled by the window manager. If I removed the window from tiling, it would take on its specified size.

Following this change, the behaviour above is still exhibited **unless** the window has a max size **and** min size specified, in which case it the window appears with its specified size, and isn't managed by the tiling window manager unless explicitly added.

Relevant docs:
Override Redirect Flag: https://tronche.com/gui/x/xlib/window/attributes/override-redirect.html
Window Attributes: https://tronche.com/gui/x/xlib/window/attributes
SDL2 source I used as a reference: https://github.com/SDL-mirror/SDL/blob/master/src/video/x11/SDL_x11window.c#L502