### PR TITLE
Update Mac OS dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ objc = "0.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 cgl = "0.2"
-cocoa = "=0.5.2"
-core-foundation = "0.2"
-core-graphics = "0.4"
+cocoa = "0.9"
+core-foundation = "0.4"
+core-graphics = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.2"

--- a/src/platform/ios/ffi.rs
+++ b/src/platform/ios/ffi.rs
@@ -66,7 +66,7 @@ extern {
     pub fn longjmp(env: *mut libc::c_void, val: libc::c_int);
 }
 
-pub trait NSString {
+pub trait NSString: Sized {
     unsafe fn alloc(_: Self) -> id {
         msg_send![class("NSString"), alloc]
     }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -338,21 +338,17 @@ impl Window {
 
             let masks = if screen.is_some() {
                 // Fullscreen window
-                appkit::NSBorderlessWindowMask as NSUInteger |
-                appkit::NSResizableWindowMask as NSUInteger |
-                appkit::NSTitledWindowMask as NSUInteger
+                appkit::NSBorderlessWindowMask | appkit::NSResizableWindowMask |
+                    appkit::NSTitledWindowMask
             } else if attrs.decorations {
                 // Window with a titlebar
-                appkit::NSClosableWindowMask as NSUInteger |
-                appkit::NSMiniaturizableWindowMask as NSUInteger |
-                appkit::NSResizableWindowMask as NSUInteger |
-                appkit::NSTitledWindowMask as NSUInteger
+                appkit::NSClosableWindowMask | appkit::NSMiniaturizableWindowMask |
+                    appkit::NSResizableWindowMask | appkit::NSTitledWindowMask
             } else {
                 // Window without a titlebar
-                appkit::NSClosableWindowMask as NSUInteger |
-                appkit::NSMiniaturizableWindowMask as NSUInteger |
-                appkit::NSResizableWindowMask as NSUInteger |
-                appkit::NSFullSizeContentViewWindowMask as NSUInteger
+                appkit::NSClosableWindowMask | appkit::NSMiniaturizableWindowMask |
+                    appkit::NSResizableWindowMask |
+                    appkit::NSFullSizeContentViewWindowMask
             };
 
             let window = IdRef::new(NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(


### PR DESCRIPTION
Nightly recently fixed some soundness issues related to `Sized`. This had to be fixed in the cocoa crates as well, and also affects our ios bindings. We'll need to flow this update through to glium and glutin to fix this problem for them as well.