### PR TITLE
Transparent axis/button IDs

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use {WindowId, DeviceId, AxisId, ButtonId};
+use {WindowId, DeviceId};
 
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -156,6 +156,12 @@ pub struct Touch {
 }
 
 pub type ScanCode = u32;
+
+/// Identifier for a specific analog axis on some device.
+pub type AxisId = u32;
+
+/// Identifier for a specific button on some device.
+pub type ButtonId = u32;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum ElementState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,14 +170,6 @@ pub struct WindowId(platform::WindowId);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(platform::DeviceId);
 
-/// Identifier for a specific analog axis on some device.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AxisId(u32);
-
-/// Identifier for a specific button on some device.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ButtonId(u32);
-
 /// Provides a way to retreive events from the windows that were registered to it.
 ///
 /// To wake up an `EventsLoop` from a another thread, see the `EventsLoopProxy` docs.

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -7,7 +7,7 @@ pub use self::xdisplay::{XConnection, XNotSupported, XError};
 pub mod ffi;
 
 use platform::PlatformSpecificWindowBuilderAttributes;
-use {CreationError, Event, EventsLoopClosed, WindowEvent, DeviceEvent, AxisId, ButtonId,
+use {CreationError, Event, EventsLoopClosed, WindowEvent, DeviceEvent,
      KeyboardInput, ControlFlow};
 
 use std::{mem, ptr, slice};
@@ -419,7 +419,7 @@ impl EventsLoop {
                                     } else {
                                         events.push(Event::WindowEvent { window_id: wid, event: AxisMotion {
                                             device_id: did,
-                                            axis: AxisId(i as u32),
+                                            axis: i as u32,
                                             value: unsafe { *value },
                                         }});
                                     }
@@ -470,7 +470,7 @@ impl EventsLoop {
                         let xev: &ffi::XIRawEvent = unsafe { &*(xev.data as *const _) };
                         if xev.flags & ffi::XIPointerEmulated == 0 {
                             callback(Event::DeviceEvent { device_id: mkdid(xev.deviceid), event: DeviceEvent::Button {
-                                button: ButtonId(xev.detail as u32),
+                                button: xev.detail as u32,
                                 state: match xev.evtype {
                                     ffi::XI_RawButtonPress => Pressed,
                                     ffi::XI_RawButtonRelease => Released,
@@ -489,7 +489,7 @@ impl EventsLoop {
                         for i in 0..xev.valuators.mask_len*8 {
                             if ffi::XIMaskIsSet(mask, i) {
                                 callback(Event::DeviceEvent { device_id: did, event: DeviceEvent::Motion {
-                                    axis: AxisId(i as u32),
+                                    axis: i as u32,
                                     value: unsafe { *value },
                                 }});
                                 value = unsafe { value.offset(1) };


### PR DESCRIPTION
Per IRC discussion, this replaces the `AxisId`/`ButtonId` newtypes with type aliases, and relocates them to the `events` module. This makes generic input events usable in practice, and is more consistent with the existing `ScanCode` type.

Replaces #172.