### PR TITLE
Remove dependency on cgl on OSX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ objc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
-cgl = "0.2"
 cocoa = "0.9"
 core-foundation = "0.4"
 core-graphics = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,6 @@ extern crate dwmapi;
 #[macro_use]
 extern crate objc;
 #[cfg(target_os = "macos")]
-extern crate cgl;
-#[cfg(target_os = "macos")]
 extern crate cocoa;
 #[cfg(target_os = "macos")]
 extern crate core_foundation;


### PR DESCRIPTION
I was wondering why my Vulkan projects had a dependency on `gl_generator`.
@mitchmindtree I suppose this was a mistake?