### PR TITLE
Update wayland-window to support xdg_shell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ dwmapi-sys = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 wayland-client = { version = "0.9.9", features = ["dlopen"] }
+wayland-protocols = { version = "0.9.9", features = ["unstable_protocols"] }
 wayland-kbd = "0.9.1"
-wayland-window = "0.6.1"
+wayland-window = "0.7.0"
 tempfile = "2.1"
 x11-dl = "2.8"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -11,6 +11,12 @@ fn main() {
     let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::NoneCursor, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];
     let mut cursor_idx = 0;
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         match event {
             Event::WindowEvent { event: WindowEvent::KeyboardInput { input: KeyboardInput { state: ElementState::Pressed, .. }, .. }, .. } => {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -31,6 +31,12 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -10,6 +10,12 @@ fn main() {
 
     let mut grabbed = false;
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -9,6 +9,12 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -9,6 +9,12 @@ fn main() {
 
     let mut num_windows = 3;
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         match event {
             winit::Event::WindowEvent { event: winit::WindowEvent::Closed, window_id } => {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -10,6 +10,12 @@ fn main() {
 
     let proxy = events_loop.create_proxy();
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     std::thread::spawn(move || {
         // Wake up the `events_loop` once every second.
         loop {

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -9,6 +9,12 @@ fn main() {
 
     window.set_title("A fantastic window!");
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,6 +8,12 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
+    if cfg!(target_os = "linux") {
+        println!("Running this example under wayland may not display a window at all.\n\
+                  This is normal and because this example does not actually draw anything in the window,\
+                  thus the compositor does not display it.");
+    }
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -155,6 +155,15 @@ impl EventsLoop {
                     }
                 );
             }
+            if decorated.handler().as_ref().map(|h| h.is_closed()).unwrap_or(false) {
+                 callback(
+                    ::Event::WindowEvent {
+                        window_id: ::WindowId(::platform::WindowId::Wayland(make_wid(&window))),
+                        event: ::WindowEvent::Closed
+                    }
+                );
+
+            }
         }
     }
 

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -10,6 +10,7 @@ use self::event_loop::EventsLoopSink;
 
 extern crate wayland_kbd;
 extern crate wayland_window;
+extern crate wayland_protocols;
 extern crate tempfile;
 
 mod context;

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -1,9 +1,8 @@
-use std::fs::File;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
 
 use wayland_client::{EventQueue, EventQueueHandle, Proxy};
-use wayland_client::protocol::{wl_display,wl_surface,wl_shell_surface,wl_buffer};
+use wayland_client::protocol::{wl_display,wl_surface};
 
 use {CreationError, MouseCursor, CursorState, WindowAttributes};
 use platform::MonitorId as PlatformMonitorId;
@@ -40,26 +39,16 @@ impl Window {
     {
         let (width, height) = attributes.dimensions.unwrap_or((800,600));
 
-        let (surface, decorated, buffer, tmpfile) = ctxt.create_window::<DecoratedHandler>(width, height);
+        let (surface, decorated) = ctxt.create_window::<DecoratedHandler>(width, height);
 
         // init DecoratedSurface
         let (evq, cleanup_signal) = evlp.get_window_init();
         let decorated_id = {
             let mut evq_guard = evq.lock().unwrap();
-            // create a handler to clean up initial buffer
-            let initial_buffer_handler_id = evq_guard.add_handler(InitialBufferHandler::new());
-            // register the buffer to it
-            evq_guard.register::<_, InitialBufferHandler>(&buffer, initial_buffer_handler_id);
             // store the DecoratedSurface handler
             let decorated_id = evq_guard.add_handler_with_init(decorated);
             {
                 let mut state = evq_guard.state();
-                {
-                    // store the buffer and tempfile in the handler, to be cleanded up at the right
-                    // time
-                    let initial_buffer_h = state.get_mut_handler::<InitialBufferHandler>(initial_buffer_handler_id);
-                    initial_buffer_h.initial_buffer = Some((buffer, tmpfile));
-                }
                 // initialize the DecoratedHandler
                 let decorated = state.get_mut_handler::<DecoratedSurface<DecoratedHandler>>(decorated_id);
                 *(decorated.handler()) = Some(DecoratedHandler::new());
@@ -67,11 +56,7 @@ impl Window {
                 // set fullscreen if necessary
                 if let Some(PlatformMonitorId::Wayland(ref monitor_id)) = attributes.monitor {
                     ctxt.with_output(monitor_id.clone(), |output| {
-                        decorated.set_fullscreen(
-                            wl_shell_surface::FullscreenMethod::Default,
-                            0,
-                            Some(output)
-                        )
+                        decorated.set_fullscreen(Some(output))
                     });
                 } else if attributes.decorations {
                     decorated.set_decorate(true);
@@ -147,6 +132,7 @@ impl Window {
         let mut state = guard.state();
         let mut decorated = state.get_mut_handler::<DecoratedSurface<DecoratedHandler>>(self.decorated_id);
         decorated.resize(x as i32, y as i32);
+        *(self.size.lock().unwrap()) = (x, y);
     }
 
     #[inline]
@@ -194,50 +180,38 @@ impl Drop for Window {
 }
 
 pub struct DecoratedHandler {
-    newsize: Option<(u32, u32)>
+    newsize: Option<(u32, u32)>,
+    closed: bool,
 }
 
 impl DecoratedHandler {
-    fn new() -> DecoratedHandler { DecoratedHandler { newsize: None }}
+    fn new() -> DecoratedHandler {
+        DecoratedHandler {
+            newsize: None,
+            closed: false,
+        }
+    }
 
     pub fn take_newsize(&mut self) -> Option<(u32, u32)> {
         self.newsize.take()
     }
+
+    pub fn is_closed(&self) -> bool { self.closed }
 }
 
 impl wayland_window::Handler for DecoratedHandler {
     fn configure(&mut self,
                  _: &mut EventQueueHandle,
-                 _: wl_shell_surface::Resize,
+                 _: wayland_window::Configure,
                  width: i32, height: i32)
     {
         use std::cmp::max;
         self.newsize = Some((max(width,1) as u32, max(height,1) as u32));
     }
-}
 
-// a handler to release the ressources acquired to draw the initial white screen as soon as
-// the compositor does not use them any more
-
-pub struct InitialBufferHandler {
-    initial_buffer: Option<(wl_buffer::WlBuffer, File)>
-}
-
-impl InitialBufferHandler {
-    fn new() -> InitialBufferHandler {
-        InitialBufferHandler {
-            initial_buffer: None,
-        }
+    fn close(&mut self, _: &mut EventQueueHandle) {
+        self.closed = true;
     }
 }
 
 
-impl wl_buffer::Handler for InitialBufferHandler {
-    fn release(&mut self, _: &mut EventQueueHandle, buffer: &wl_buffer::WlBuffer) {
-        // release the ressources we've acquired for initial white window
-        buffer.destroy();
-        self.initial_buffer = None;
-    }
-}
-
-declare_handler!(InitialBufferHandler, wl_buffer::Handler, wl_buffer::WlBuffer);


### PR DESCRIPTION
This upgrades the wayland-window dependency to support the xdg_shell wayland protocol, which is largely recognized as the way forward for wayland apps (thanks to @mitchmindtree for helping implementing that).

As a result, winit has a slightly different behavior, depending on which of wl_shell or xdg_shell is used, and I don't see any reasonable way to fix that, however I believe it's relatively minor.

- If using wl_shell (the legacy protocol), winit will blank the window at creation. This is necessary because otherwise the window don't exist in wayland while it has not yet been drawn, and the events loop gets stuck receiving nothing.
- if using xdg_shell, we cannot blank it at this point of time (the protocol forbids doing it this early). However, the events loop cannot get stuck. This means that the window are not displayed as long as no drawing occurs, which in practice should not be an issue as most usages will draw right away, and try to use an empty window.

However, the winit examples don't draw in the window. This means that running these examples in wayland will most of the time don't display a window... (systems without xdg_shell are basically non-existent).

Now, trying to schedule a blanking slightly later in the process would be the solution, but I'm afraid it would interfere with downstream drawing initialization (glutin or vulkano), and would require adding a consequent boilerplate for something relatively minor.

Opinions on this are welcome.