### PR TITLE
Marked deprecated functions as #[deprecated], added panic message.

### DIFF
--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -151,13 +151,14 @@ impl Window {
         }
     }
 
-    // TODO: remove
+    #[deprecated]
     pub fn platform_display(&self) -> *mut ::libc::c_void {
-        panic!()        // Deprecated function ; we don't care anymore
+        panic!("Error! Function platform_display is deprecated.")
     }
-    // TODO: remove
+
+    #[deprecated]
     pub fn platform_window(&self) -> *mut ::libc::c_void {
-        panic!()        // Deprecated function ; we don't care anymore
+        panic!("Error! Function platform_window is deprecated.")
     }
 
     /// Returns the `hwnd` of this window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -193,6 +193,7 @@ impl Window {
     /// Returns `None` if the window no longer exists.
     ///
     /// DEPRECATED
+    #[deprecated]
     #[inline]
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         self.window.get_inner_size()


### PR DESCRIPTION
I encountered problems while running a gfx-rs example on windows, which were due to the use of a deprecated function call. To make the issue more explicit, I've marked in some missing #[deprecated] attributes and added a message to the panic macro it called. I've also added #[deprecated] to another function that is marked as such in the comments.