### PR TITLE
Fix x11 WindowEvent ModifiersState

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]


### PR DESCRIPTION
Fixes half of https://github.com/tomaka/winit/issues/226

The modifier fields were changed AFTER callback(..) is callled.