### PR TITLE
Fix x11 DeviceEvent ModifiersStates

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -95,7 +95,7 @@ pub enum DeviceEvent {
     Removed,
     Motion { axis: AxisId, value: f64 },
     Button { button: ButtonId, state: ElementState },
-    Key(KeyboardInput),
+    Key(DeviceKeyboardInput),
     Text { codepoint: char },
 }
 
@@ -121,6 +121,24 @@ pub struct KeyboardInput {
     /// This is tracked internally to avoid tracking errors arising from modifier key state changes when events from
     /// this device are not being delivered to the application, e.g. due to keyboard focus being elsewhere.
     pub modifiers: ModifiersState
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DeviceKeyboardInput {
+    /// Identifies the physical key pressed
+    ///
+    /// This should not change if the user adjusts the host's keyboard map. Use when the physical location of the
+    /// key is more important than the key's host GUI semantics, such as for movement controls in a first-person
+    /// game.
+    pub scancode: ScanCode,
+
+    pub state: ElementState,
+
+    /// Identifies the semantic meaning of the key
+    ///
+    /// Use when the semantics of the key are more important than the physical location of the key, such as when
+    /// implementing appropriate behavior for "page up."
+    pub virtual_keycode: Option<VirtualKeyCode>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -8,7 +8,7 @@ pub mod ffi;
 
 use platform::PlatformSpecificWindowBuilderAttributes;
 use {CreationError, Event, EventsLoopClosed, WindowEvent, DeviceEvent, AxisId, ButtonId,
-     KeyboardInput, ControlFlow};
+     KeyboardInput, DeviceKeyboardInput, ControlFlow};
 
 use std::{mem, ptr, slice};
 use std::sync::{Arc, Mutex, Weak};
@@ -533,7 +533,7 @@ impl EventsLoop {
                         // TODO: Use xkbcommon for keysym and text decoding
                         let xev: &ffi::XIRawEvent = unsafe { &*(xev.data as *const _) };
                         let xkeysym = unsafe { (self.display.xlib.XKeycodeToKeysym)(self.display.display, xev.detail as ffi::KeyCode, 0) };
-                        callback(Event::DeviceEvent { device_id: mkdid(xev.deviceid), event: DeviceEvent::Key(KeyboardInput {
+                        callback(Event::DeviceEvent { device_id: mkdid(xev.deviceid), event: DeviceEvent::Key(DeviceKeyboardInput {
                             scancode: xev.detail as u32,
                             virtual_keycode: events::keysym_to_element(xkeysym as libc::c_uint),
                             state: match xev.evtype {
@@ -541,7 +541,6 @@ impl EventsLoop {
                                 ffi::XI_RawKeyRelease => Released,
                                 _ => unreachable!(),
                             },
-                            modifiers: ::events::ModifiersState::default(),
                         })});
                     }
 


### PR DESCRIPTION
The other half of the fix for https://github.com/tomaka/winit/issues/226
I put this into a seperate PR because it will likely be held up by discussion.

Ralith said on IRC: "looks like I just didn't implement modifiers for raw kb input"
However looking into it I couldnt find a way to do so.
(Because the XIRawEvent doesnt have the state field that XKeyEvent does)

Because DeviceEvents dont require ModifierStates like WindowEvents do, as ALL events are received regardless of focus, I decided to create a seperate DeviceKeyboardInput without ModifierStates.

There are currently no other backends returning KeyboardInputs in DeviceEvent's so I couldnt check how they handled it.

Interested to hear your thoughts @tomaka @Ralith 
