### PR TITLE
Mac file drag and drop

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -26,6 +26,9 @@ pub enum WindowEvent {
     /// The window has been closed.
     Closed,
 
+    /// A file is being hovered over the window.
+    HoveredFile(PathBuf),
+
     /// A file has been dropped into the window.
     DroppedFile(PathBuf),
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -26,11 +26,14 @@ pub enum WindowEvent {
     /// The window has been closed.
     Closed,
 
+    /// A file has been dropped into the window.
+    DroppedFile(PathBuf),
+
     /// A file is being hovered over the window.
     HoveredFile(PathBuf),
 
-    /// A file has been dropped into the window.
-    DroppedFile(PathBuf),
+    /// A file was hovered, but has exited the window.
+    HoveredFileCancelled,
 
     /// The window received a unicode character.
     ReceivedCharacter(char),

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -143,9 +143,7 @@ impl WindowDelegate {
         }
 
         /// Invoked when the image is released
-        extern fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) {
-            println!("prepare_for_drag_operation");
-        }
+        extern fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) {}
 
         /// Invoked after the released image has been removed from the screen
         extern fn perform_drag_operation(this: &Object, _: Sel, sender: id) -> BOOL {
@@ -174,13 +172,15 @@ impl WindowDelegate {
         }
 
         /// Invoked when the dragging operation is complete
-        extern fn conclude_drag_operation(_: &Object, _: Sel, _: id) {
-            println!("conclude_drag_operation");
-        }
+        extern fn conclude_drag_operation(_: &Object, _: Sel, _: id) {}
 
         /// Invoked when the dragging operation is cancelled
-        extern fn dragging_exited(_: &Object, _: Sel, _: id) {
-            println!("dragging_exited");
+        extern fn dragging_exited(this: &Object, _: Sel, _: id) {
+            unsafe {
+                let state: *mut c_void = *this.get_ivar("winitState");
+                let state = &mut *(state as *mut DelegateState);
+                emit_event(state, WindowEvent::HoveredFileCancelled);
+            }
         }
 
         static mut DELEGATE_CLASS: *const Class = 0 as *const Class;
@@ -204,7 +204,7 @@ impl WindowDelegate {
             decl.add_method(sel!(windowDidResignKey:),
                 window_did_resign_key as extern fn(&Object, Sel, id));
 
-            // callback for drag events
+            // callbacks for drag and drop events
             decl.add_method(sel!(draggingEntered:),
                 dragging_entered as extern fn(&Object, Sel, id) -> BOOL);
            decl.add_method(sel!(prepareForDragOperation:),


### PR DESCRIPTION
Here's an implementation for drag and dropping files on Mac OS. I needed to add two events for `HoveredFile` and `HoveredFileCancelled`, as without them how are you supposed to update your gui? :)

At the moment, the DropFile only supports one FileBuf, and not an array... which is harder to deal with and you can't reject the drop during hover based on a file filter (say the user drops four valid files and one invalid one). But since there's a windows implementation of this (though it seems buggy/limited to 255 chars) I decided to leave it for now.

I wasn't too sure of winits code conventions, it seems to repeat code in places (like dispatching events) so I have stayed away from adding convenience methods etc. Please let me know if I should do something else to conform to winits approach more.