### PR TITLE
Fixes window inner size calc for hidpi windows X11

### DIFF
--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -535,7 +535,7 @@ impl Window {
 
     #[inline]
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
-        self.get_geometry().map(|(_, _, w, h, _)| (w, h))
+        self.get_geometry().map(|(_, _, w, h, _)| ((w as f32 / self.hidpi_factor()) as u32, (h as f32 / self.hidpi_factor()) as u32))
     }
 
     #[inline]


### PR DESCRIPTION
X11 always return the geometry in pixel units. Since
window.get_inner_size returns the size in points in other window manager
implementations X11 should also return in points instead of pixels.

This commit also fixes https://github.com/tomaka/glutin/issues/903