### PR TITLE
Fix window contents not resizing in lockstep with window resize on win32

### DIFF
--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -271,7 +271,7 @@ lazy_static! {
     // WPARAM and LPARAM are unused.
     static ref WAKEUP_MSG_ID: u32 = {
         unsafe {
-            user32::RegisterWindowMessageA("Winit::WakeupMsg".as_ptr() as *const i8)
+            user32::RegisterWindowMessageA("Winit::WakeupMsg\0".as_ptr() as *const i8)
         }
     };
     // Message sent when we want to execute a closure in the thread.
@@ -279,7 +279,7 @@ lazy_static! {
     // and LPARAM is unused.
     static ref EXEC_MSG_ID: u32 = {
         unsafe {
-            user32::RegisterWindowMessageA("Winit::ExecMsg".as_ptr() as *const i8)
+            user32::RegisterWindowMessageA("Winit::ExecMsg\0".as_ptr() as *const i8)
         }
     };
     // Message sent when the parent thread receives a resize event and wants this thread to use any


### PR DESCRIPTION
Before this change, when a `WM_SIZE` message was received it would throw a `Resized` event at the parent `EventLoop` thread and return immediately. There are two issues with that approach: win32 would proceed to resize the window before the application had been redrawn leading to visible black bars, and the immediate return would lead to win32 generating resize events at a rate far higher than any renderer could handle. The result of that is visible [here](https://gfycat.com/DecimalCavernousBlobfish).

This PR makes the win32 event loop thread sleep until the `Resized` event is processed by the `EventsLoop` struct, only returning after the event closure returns. This vastly decreases the number of resize messages sent, and delays resizing until after the application has handled the message. The end result is that resizing looks like [this](https://gfycat.com/AgedAnxiousFlicker), for both `poll_events` and `run_forever`. There's a slight downside here in that the actual window resizing is *slightly* laggier and jutterier than it was previously, but this is an effect that is present even in official Microsoft applications and is far less noticeable than the window's contents failing to resize with the rest of the window.