### PR TITLE
wayland: internal event buffer & wait for xdg configure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ dwmapi-sys = "0.1"
 wayland-client = { version = "0.9.9", features = ["dlopen"] }
 wayland-protocols = { version = "0.9.9", features = ["unstable_protocols"] }
 wayland-kbd = "0.9.1"
-wayland-window = "0.7.0"
+wayland-window = "0.8.0"
 tempfile = "2.1"
 x11-dl = "2.8"

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -64,6 +64,9 @@ impl Window {
                 // Finally, set the decorations size
                 decorated.resize(width as i32, height as i32);
             }
+
+            evq_guard.sync_roundtrip().unwrap();
+
             decorated_id
         };
         let me = Window {
@@ -202,11 +205,12 @@ impl DecoratedHandler {
 impl wayland_window::Handler for DecoratedHandler {
     fn configure(&mut self,
                  _: &mut EventQueueHandle,
-                 _: wayland_window::Configure,
-                 width: i32, height: i32)
+                 _cfg: wayland_window::Configure,
+                 newsize: Option<(i32, i32)>)
     {
-        use std::cmp::max;
-        self.newsize = Some((max(width,1) as u32, max(height,1) as u32));
+        if let Some((w, h)) = newsize {
+            self.newsize = Some((w as u32, h as u32));
+        }
     }
 
     fn close(&mut self, _: &mut EventQueueHandle) {


### PR DESCRIPTION
This PR does three things:

- fix #254 by properly waiting for the configure xdg event from the compositor, this is done by introducing an internal buffer to collect events dispatched internally, while `Window::new()` may be blocking
- automatically insert a `WindowEvent::Refresh` in this internal buffer whenever a window is created, this guarantees the event loop will have something to dispatch when first started, and should solve for good any issue of deadlock of the event loop as previously saw with wayland (without that, the multiwindow example of glutin _still_ deadlocked)
- update the `wayland_window` dependency, which provides a better handling of said configure event