### PR TITLE
[macOS] Get the NSView for a window with NSWindow::contentView

### DIFF
--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -456,16 +456,17 @@ impl EventsLoop {
                     None => return None,
                 };
 
+                let view = window.window.contentView();
                 let window_point = ns_event.locationInWindow();
                 let view_point = if ns_window == cocoa::base::nil {
                     let ns_size = foundation::NSSize::new(0.0, 0.0);
                     let ns_rect = foundation::NSRect::new(window_point, ns_size);
                     let window_rect = window.window.convertRectFromScreen_(ns_rect);
-                    window.view.convertPoint_fromView_(window_rect.origin, cocoa::base::nil)
+                    view.convertPoint_fromView_(window_rect.origin, cocoa::base::nil)
                 } else {
-                    window.view.convertPoint_fromView_(window_point, cocoa::base::nil)
+                    view.convertPoint_fromView_(window_point, cocoa::base::nil)
                 };
-                let view_rect = NSView::frame(*window.view);
+                let view_rect = NSView::frame(view);
                 let scale_factor = window.hidpi_factor();
 
                 let mut events = std::collections::VecDeque::new();


### PR DESCRIPTION
Instead of holding a reference to the original `NSView` in `Window`, only hold the `NSWindow` and get its view by calling `NSWindow::contentView`. This allows the user to set a new `contentView` without breaking winit's resize handling. My specific use case is to replace the `contentView` with an `MTKView` allowing me to render with Metal.