### PR TITLE
Rework MonitorId::get_native_identifier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@ extern crate wayland_client;
 
 pub use events::*;
 pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
-pub use native_monitor::NativeMonitorId;
 
 #[macro_use]
 mod api_transition;
@@ -451,21 +450,5 @@ impl Default for WindowAttributes {
             decorations: true,
             multitouch: false,
         }
-    }
-}
-
-mod native_monitor {
-    /// Native platform identifier for a monitor. Different platforms use fundamentally different types
-    /// to represent a monitor ID.
-    #[derive(Clone, PartialEq, Eq)]
-    pub enum NativeMonitorId {
-        /// Cocoa and X11 use a numeric identifier to represent a monitor.
-        Numeric(u32),
-
-        /// Win32 uses a Unicode string to represent a monitor.
-        Name(String),
-
-        /// Other platforms (Android) don't support monitor identification.
-        Unavailable
     }
 }

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -3,7 +3,7 @@
 use std::convert::From;
 use std::os::raw::c_void;
 use cocoa::appkit::NSApplicationActivationPolicy;
-use {Window, WindowBuilder};
+use {MonitorId, Window, WindowBuilder};
 
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExt {
@@ -71,5 +71,18 @@ impl WindowBuilderExt for WindowBuilder {
     fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder {
         self.platform_specific.activation_policy = activation_policy;
         self
+    }
+}
+
+/// Additional methods on `MonitorId` that are specific to MacOS.
+pub trait MonitorIdExt {
+    /// Returns the identifier of the monitor for Cocoa.
+    fn native_id(&self) -> u32;
+}
+
+impl MonitorIdExt for MonitorId {
+    #[inline]
+    fn native_id(&self) -> u32 {
+        self.inner.get_native_identifier()
     }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -158,7 +158,7 @@ pub trait MonitorIdExt {
 
 impl MonitorIdExt for MonitorId {
     #[inline]
-    fn native_id(&self) -> String {
+    fn native_id(&self) -> Option<u32> {
         self.inner.get_native_identifier()
     }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -152,13 +152,13 @@ impl WindowBuilderExt for WindowBuilder {
 
 /// Additional methods on `MonitorId` that are specific to Linux.
 pub trait MonitorIdExt {
-    /// Returns the identifier of the monitor for X11, and `None` for Wayland.
-    fn native_id(&self) -> Option<u32>;
+    /// Returns the inner identifier of the monitor.
+    fn native_id(&self) -> u32;
 }
 
 impl MonitorIdExt for MonitorId {
     #[inline]
-    fn native_id(&self) -> Option<u32> {
+    fn native_id(&self) -> u32 {
         self.inner.get_native_identifier()
     }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::ptr;
 use libc;
+use MonitorId;
 use Window;
 use platform::Window2 as LinuxWindow;
 use platform::{UnixBackend, UNIX_BACKEND};
@@ -146,5 +147,18 @@ impl WindowBuilderExt for WindowBuilder {
     fn with_x11_screen(mut self, screen_id: i32) -> WindowBuilder {
         self.platform_specific.screen_id = Some(screen_id);
         self
+    }
+}
+
+/// Additional methods on `MonitorId` that are specific to Linux.
+pub trait MonitorIdExt {
+    /// Returns the identifier of the monitor for X11, and `None` for Wayland.
+    fn native_id(&self) -> Option<u32>;
+}
+
+impl MonitorIdExt for MonitorId {
+    #[inline]
+    fn native_id(&self) -> String {
+        self.inner.get_native_identifier()
     }
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,6 +1,7 @@
 #![cfg(target_os = "windows")]
 
 use libc;
+use MonitorId;
 use Window;
 use WindowBuilder;
 use winapi;
@@ -33,5 +34,18 @@ impl WindowBuilderExt for WindowBuilder {
     fn with_parent_window(mut self, parent: winapi::HWND) -> WindowBuilder {
         self.platform_specific.parent = Some(parent);
         self
+    }
+}
+
+/// Additional methods on `MonitorId` that are specific to Windows.
+pub trait MonitorIdExt {
+    /// Returns the name of the monitor specific to the Win32 API.
+    fn native_id(&self) -> String;
+}
+
+impl MonitorIdExt for MonitorId {
+    #[inline]
+    fn native_id(&self) -> String {
+        self.inner.get_native_identifier()
     }
 }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -48,11 +48,6 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        NativeMonitorId::Unavailable
-    }
-
-    #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
         unimplemented!()
     }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -16,7 +16,6 @@ use std::collections::VecDeque;
 use CursorState;
 use WindowAttributes;
 use FullScreenState;
-use native_monitor::NativeMonitorId;
 
 gen_api_transition!();
 

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -70,7 +70,6 @@ use libc::c_int;
 use objc::runtime::{Class, Object, Sel, BOOL, YES };
 use objc::declare::{ ClassDecl };
 
-use native_monitor::NativeMonitorId;
 use { CreationError, CursorState, MouseCursor, WindowAttributes, FullScreenState };
 use WindowEvent as Event;
 use events::{ Touch, TouchPhase };
@@ -151,11 +150,6 @@ impl MonitorId {
     #[inline]
     pub fn get_name(&self) -> Option<String> {
         Some("Primary".to_string())
-    }
-
-    #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        NativeMonitorId::Unavailable
     }
 
     #[inline]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -142,10 +142,10 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_native_identifier(&self) -> Option<u32> {
+    pub fn get_native_identifier(&self) -> u32 {
         match self {
-            &MonitorId::X(ref m) => Some(m.get_native_identifier()),
-            &MonitorId::Wayland(ref m) => None,
+            &MonitorId::X(ref m) => m.get_native_identifier(),
+            &MonitorId::Wayland(ref m) => m.get_native_identifier(),
             &MonitorId::None => unimplemented!()        // FIXME:
         }
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -142,10 +142,10 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_native_identifier(&self) -> ::native_monitor::NativeMonitorId {
+    pub fn get_native_identifier(&self) -> Option<u32> {
         match self {
-            &MonitorId::X(ref m) => m.get_native_identifier(),
-            &MonitorId::Wayland(ref m) => m.get_native_identifier(),
+            &MonitorId::X(ref m) => Some(m.get_native_identifier()),
+            &MonitorId::Wayland(ref m) => None,
             &MonitorId::None => unimplemented!()        // FIXME:
         }
     }

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -371,11 +371,6 @@ impl MonitorId {
         None
     }
 
-    #[inline]
-    pub fn get_native_identifier(&self) -> ::native_monitor::NativeMonitorId {
-        ::native_monitor::NativeMonitorId::Unavailable
-    }
-
     pub fn get_dimensions(&self) -> (u32, u32) {
         let mut guard = self.ctxt.evq.lock().unwrap();
         let state = guard.state();

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -371,6 +371,11 @@ impl MonitorId {
         None
     }
 
+    #[inline]
+    pub fn get_native_identifier(&self) -> u32 {
+        self.id
+    }
+
     pub fn get_dimensions(&self) -> (u32, u32) {
         let mut guard = self.ctxt.evq.lock().unwrap();
         let state = guard.state();

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -56,7 +56,7 @@ impl Window {
                 *(decorated.handler()) = Some(DecoratedHandler::new());
 
                 // set fullscreen if necessary
-                if let FullScreenState::Exclusive(RootMonitorId(PlatformMonitorId::Wayland(ref monitor_id))) = attributes.fullscreen {
+                if let FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
                     ctxt.with_output(monitor_id.clone(), |output| {
                         decorated.set_fullscreen(Some(output))
                     });

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use super::XConnection;
-use native_monitor::NativeMonitorId;
 
 #[derive(Clone)]
 pub struct MonitorId(pub Arc<XConnection>, pub u32);
@@ -30,8 +29,8 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        NativeMonitorId::Numeric(self.1)
+    pub fn get_native_identifier(&self) -> u32 {
+        self.1
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -215,7 +215,7 @@ impl Window {
         let screen_id = match pl_attribs.screen_id {
             Some(id) => id,
             None => match window_attrs.fullscreen {
-                FullScreenState::Exclusive(RootMonitorId(PlatformMonitorId::X(X11MonitorId(_, monitor)))) => monitor as i32,
+                FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::X(X11MonitorId(_, monitor)) }) => monitor as i32,
                 _ => unsafe { (display.xlib.XDefaultScreen)(display.display) },
             }
         };
@@ -458,7 +458,7 @@ impl Window {
               self.x.switch_from_fullscreen_mode();
               Window::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", true);
             },
-            FullScreenState::Exclusive(RootMonitorId(PlatformMonitorId::X(X11MonitorId(_, monitor)))) => {
+            FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::X(X11MonitorId(_, monitor)) }) => {
               if let Some(dimensions) = self.get_inner_size() {
                 self.x.switch_to_fullscreen_mode(monitor as i32, dimensions.0 as u16, dimensions.1 as u16);
                 Window::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", true);

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -1,6 +1,5 @@
 use core_graphics::display;
 use std::collections::VecDeque;
-use native_monitor::NativeMonitorId;
 
 #[derive(Clone)]
 pub struct MonitorId(u32);
@@ -33,9 +32,8 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        let MonitorId(display_id) = *self;
-        NativeMonitorId::Numeric(display_id)
+    pub fn get_native_identifier(&self) -> u32 {
+        self.0;
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -33,7 +33,7 @@ impl MonitorId {
 
     #[inline]
     pub fn get_native_identifier(&self) -> u32 {
-        self.0;
+        self.0
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -4,7 +4,6 @@ use libc;
 
 use WindowAttributes;
 use FullScreenState;
-use native_monitor::NativeMonitorId;
 use os::macos::ActivationPolicy;
 use os::macos::WindowExt;
 
@@ -386,10 +385,7 @@ impl Window {
         unsafe {
             let screen = match attrs.fullscreen {
                 FullScreenState::Exclusive(ref monitor_id) => {
-                    let native_id = match monitor_id.get_native_identifier() {
-                        NativeMonitorId::Numeric(num) => num,
-                        _ => panic!("OS X monitors should always have a numeric native ID")
-                    };
+                    let native_id = monitor_id.inner.get_native_identifier();
                     let matching_screen = {
                         let screens = appkit::NSScreen::screens(nil);
                         let count: NSUInteger = msg_send![screens, count];

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -4,8 +4,6 @@ use user32;
 use std::collections::VecDeque;
 use std::mem;
 
-use native_monitor::NativeMonitorId;
-
 /// Win32 implementation of the main `MonitorId` object.
 #[derive(Clone)]
 pub struct MonitorId {
@@ -158,8 +156,8 @@ impl MonitorId {
 
     /// See the docs of the crate root file.
     #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        NativeMonitorId::Name(self.monitor_name.clone())
+    pub fn get_native_identifier(&self) -> String {
+        self.monitor_name.clone()
     }
 
     /// See the docs if the crate root file.

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -329,8 +329,8 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
     // switching to fullscreen if necessary
     // this means adjusting the window's position so that it overlaps the right monitor,
     //  and change the monitor's resolution if necessary
-    let fullscreen = if let FullScreenState::Exclusive(RootMonitorId(ref monitor)) = window.fullscreen {
-        try!(switch_to_fullscreen(&mut rect, monitor));
+    let fullscreen = if let FullScreenState::Exclusive(RootMonitorId { ref inner }) = window.fullscreen {
+        try!(switch_to_fullscreen(&mut rect, inner));
         true
     } else {
         false

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,7 +8,6 @@ use Window;
 use WindowBuilder;
 use WindowId;
 use FullScreenState;
-use native_monitor::NativeMonitorId;
 
 use libc;
 use platform;
@@ -331,7 +330,7 @@ impl Iterator for AvailableMonitorsIter {
 
     #[inline]
     fn next(&mut self) -> Option<MonitorId> {
-        self.data.next().map(|id| MonitorId(id))
+        self.data.next().map(|id| MonitorId { inner: id })
     }
 
     #[inline]
@@ -349,6 +348,7 @@ impl Iterator for AvailableMonitorsIter {
 /// > and if it fails will fallback on x11.
 /// >
 /// > If this variable is set with any other value, winit will panic.
+// Note: should be replaced with `-> impl Iterator` once stable.
 #[inline]
 pub fn get_available_monitors() -> AvailableMonitorsIter {
     let data = platform::get_available_monitors();
@@ -366,32 +366,27 @@ pub fn get_available_monitors() -> AvailableMonitorsIter {
 /// > If this variable is set with any other value, winit will panic.
 #[inline]
 pub fn get_primary_monitor() -> MonitorId {
-    MonitorId(platform::get_primary_monitor())
+    MonitorId { inner: platform::get_primary_monitor() }
 }
 
 /// Identifier for a monitor.
 #[derive(Clone)]
-pub struct MonitorId(pub platform::MonitorId);
+pub struct MonitorId {
+    pub(crate) inner: platform::MonitorId
+}
 
 impl MonitorId {
     /// Returns a human-readable name of the monitor.
+    ///
+    /// Returns `None` if the monitor doesn't exist anymore.
     #[inline]
     pub fn get_name(&self) -> Option<String> {
-        let &MonitorId(ref id) = self;
-        id.get_name()
-    }
-
-    /// Returns the native platform identifier for this monitor.
-    #[inline]
-    pub fn get_native_identifier(&self) -> NativeMonitorId {
-        let &MonitorId(ref id) = self;
-        id.get_native_identifier()
+        self.inner.get_name()
     }
 
     /// Returns the number of pixels currently displayed on the monitor.
     #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
-        let &MonitorId(ref id) = self;
-        id.get_dimensions()
+        self.inner.get_dimensions()
     }
 }


### PR DESCRIPTION
This PR removes `MonitorId::get_native_identifer()` and replaces it with platform-specific functions in the various `os` modules.

This makes the design consistent with the other platform-specific retrieval methods.