### PR TITLE
Events loop backend

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -4,9 +4,11 @@ use std::io::{self, Write};
 use winit::{ControlFlow, Event, WindowEvent, FullScreenState};
 
 fn main() {
+    let mut events_loop = winit::EventsLoop::new();
+
     // enumerating monitors
     let monitor = {
-        for (num, monitor) in winit::get_available_monitors().enumerate() {
+        for (num, monitor) in events_loop.get_available_monitors().enumerate() {
             println!("Monitor #{}: {:?}", num, monitor.get_name());
         }
 
@@ -16,14 +18,12 @@ fn main() {
         let mut num = String::new();
         io::stdin().read_line(&mut num).unwrap();
         let num = num.trim().parse().ok().expect("Please enter a number");
-        let monitor = winit::get_available_monitors().nth(num).expect("Please enter a valid ID");
+        let monitor = events_loop.get_available_monitors().nth(num).expect("Please enter a valid ID");
 
         println!("Using {:?}", monitor.get_name());
 
         monitor
     };
-
-    let mut events_loop = winit::EventsLoop::new();
 
     let _window = winit::WindowBuilder::new()
         .with_title("Hello world!")

--- a/src/api_transition.rs
+++ b/src/api_transition.rs
@@ -24,6 +24,16 @@ macro_rules! gen_api_transition {
                 }
             }
 
+            #[inline]
+            pub fn get_available_monitors(&self) -> ::std::collections::VecDeque<MonitorId> {
+                get_available_monitors()
+            }
+
+            #[inline]
+            pub fn get_primary_monitor(&self) -> MonitorId {
+                get_primary_monitor()
+            }
+
             pub fn poll_events<F>(&mut self, mut callback: F)
                 where F: FnMut(::Event)
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ extern crate x11_dl;
 extern crate wayland_client;
 
 pub use events::*;
-pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
+pub use window::{AvailableMonitorsIter, MonitorId};
 
 #[macro_use]
 mod api_transition;
@@ -199,6 +199,36 @@ impl EventsLoop {
         EventsLoop {
             events_loop: platform::EventsLoop::new(),
         }
+    }
+
+    /// Returns the list of all available monitors.
+    ///
+    /// Usage will result in display backend initialisation, this can be controlled on linux
+    /// using an environment variable `WINIT_UNIX_BACKEND`.
+    /// > Legal values are `x11` and `wayland`. If this variable is set only the named backend
+    /// > will be tried by winit. If it is not set, winit will try to connect to a wayland connection,
+    /// > and if it fails will fallback on x11.
+    /// >
+    /// > If this variable is set with any other value, winit will panic.
+    // Note: should be replaced with `-> impl Iterator` once stable.
+    #[inline]
+    pub fn get_available_monitors(&self) -> AvailableMonitorsIter {
+        let data = self.events_loop.get_available_monitors();
+        AvailableMonitorsIter{ data: data.into_iter() }
+    }
+
+    /// Returns the primary monitor of the system.
+    ///
+    /// Usage will result in display backend initialisation, this can be controlled on linux
+    /// using an environment variable `WINIT_UNIX_BACKEND`.
+    /// > Legal values are `x11` and `wayland`. If this variable is set only the named backend
+    /// > will be tried by winit. If it is not set, winit will try to connect to a wayland connection,
+    /// > and if it fails will fallback on x11.
+    /// >
+    /// > If this variable is set with any other value, winit will panic.
+    #[inline]
+    pub fn get_primary_monitor(&self) -> MonitorId {
+        MonitorId { inner: self.events_loop.get_primary_monitor() }
     }
 
     /// Fetches all the events that are pending, calls the callback function for each of them,

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -6,20 +6,11 @@ use libc;
 use MonitorId;
 use Window;
 use platform::Window2 as LinuxWindow;
-use platform::{UnixBackend, UNIX_BACKEND};
 use WindowBuilder;
 use platform::x11::XConnection;
 use platform::x11::ffi::XVisualInfo;
 
 pub use platform::x11;
-
-// TODO: do not expose XConnection
-pub fn get_x11_xconnection() -> Option<Arc<XConnection>> {
-    match *UNIX_BACKEND {
-        UnixBackend::X(ref connec) => Some(connec.clone()),
-        _ => None,
-    }
-}
 
 /// Additional methods on `Window` that are specific to Unix.
 pub trait WindowExt {

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -3,14 +3,47 @@
 use std::sync::Arc;
 use std::ptr;
 use libc;
+use EventsLoop;
 use MonitorId;
 use Window;
+use platform::EventsLoop as LinuxEventsLoop;
 use platform::Window2 as LinuxWindow;
 use WindowBuilder;
 use platform::x11::XConnection;
 use platform::x11::ffi::XVisualInfo;
 
 pub use platform::x11;
+
+/// Additional methods on `EventsLoop` that are specific to Linux.
+pub trait EventsLoopExt {
+    /// Builds a new `EventsLoop` that is forced to use X11.
+    fn new_x11() -> Self;
+
+    /// Builds a new `EventsLoop` that is forced to use Wayland.
+    fn new_wayland() -> Self;
+}
+
+impl EventsLoopExt for EventsLoop {
+    #[inline]
+    fn new_x11() -> Self {
+        EventsLoop {
+            events_loop: match LinuxEventsLoop::new_x11() {
+                Ok(e) => e,
+                Err(_) => panic!()      // TODO: propagate
+            }
+        }
+    }
+
+    #[inline]
+    fn new_wayland() -> Self {
+        EventsLoop {
+            events_loop: match LinuxEventsLoop::new_wayland() {
+                Ok(e) => e,
+                Err(_) => panic!()      // TODO: propagate
+            }
+        }
+    }
+}
 
 /// Additional methods on `Window` that are specific to Unix.
 pub trait WindowExt {

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -12,26 +12,23 @@ use WindowBuilder;
 use platform::x11::XConnection;
 use platform::x11::ffi::XVisualInfo;
 
-pub use platform::x11;
+pub use platform::XNotSupported;
 
 /// Additional methods on `EventsLoop` that are specific to Linux.
 pub trait EventsLoopExt {
     /// Builds a new `EventsLoop` that is forced to use X11.
-    fn new_x11() -> Self;
+    fn new_x11() -> Result<Self, XNotSupported>
+        where Self: Sized;
 
     /// Builds a new `EventsLoop` that is forced to use Wayland.
-    fn new_wayland() -> Self;
+    fn new_wayland() -> Self
+        where Self: Sized;
 }
 
 impl EventsLoopExt for EventsLoop {
     #[inline]
-    fn new_x11() -> Self {
-        EventsLoop {
-            events_loop: match LinuxEventsLoop::new_x11() {
-                Ok(e) => e,
-                Err(_) => panic!()      // TODO: propagate
-            }
-        }
+    fn new_x11() -> Result<Self, XNotSupported> {
+        LinuxEventsLoop::new_x11().map(|ev| EventsLoop { events_loop: ev })
     }
 
     #[inline]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -98,30 +98,6 @@ pub enum MonitorId {
     None,
 }
 
-#[inline]
-pub fn get_available_monitors() -> VecDeque<MonitorId> {
-    match *UNIX_BACKEND {
-        UnixBackend::Wayland(ref ctxt) => wayland::get_available_monitors(ctxt)
-                                .into_iter()
-                                .map(MonitorId::Wayland)
-                                .collect(),
-        UnixBackend::X(ref connec) => x11::get_available_monitors(connec)
-                                    .into_iter()
-                                    .map(MonitorId::X)
-                                    .collect(),
-        UnixBackend::Error(..) => { let mut d = VecDeque::new(); d.push_back(MonitorId::None); d},
-    }
-}
-
-#[inline]
-pub fn get_primary_monitor() -> MonitorId {
-    match *UNIX_BACKEND {
-        UnixBackend::Wayland(ref ctxt) => MonitorId::Wayland(wayland::get_primary_monitor(ctxt)),
-        UnixBackend::X(ref connec) => MonitorId::X(x11::get_primary_monitor(connec)),
-        UnixBackend::Error(..) => MonitorId::None,
-    }
-}
-
 impl MonitorId {
     #[inline]
     pub fn get_name(&self) -> Option<String> {
@@ -355,6 +331,30 @@ impl EventsLoop {
             UnixBackend::Error(..) => {
                 panic!("Attempted to create an EventsLoop while no backend was available.")
             }
+        }
+    }
+
+    #[inline]
+    pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
+        match *UNIX_BACKEND {
+            UnixBackend::Wayland(ref ctxt) => wayland::get_available_monitors(ctxt)
+                                    .into_iter()
+                                    .map(MonitorId::Wayland)
+                                    .collect(),
+            UnixBackend::X(ref connec) => x11::get_available_monitors(connec)
+                                        .into_iter()
+                                        .map(MonitorId::X)
+                                        .collect(),
+            UnixBackend::Error(..) => { let mut d = VecDeque::new(); d.push_back(MonitorId::None); d},
+        }
+    }
+
+    #[inline]
+    pub fn get_primary_monitor(&self) -> MonitorId {
+        match *UNIX_BACKEND {
+            UnixBackend::Wayland(ref ctxt) => MonitorId::Wayland(wayland::get_primary_monitor(ctxt)),
+            UnixBackend::X(ref connec) => MonitorId::X(x11::get_primary_monitor(connec)),
+            UnixBackend::Error(..) => MonitorId::None,
         }
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -75,35 +75,26 @@ lazy_static!(
 
 
 pub enum Window2 {
-    #[doc(hidden)]
     X(x11::Window2),
-    #[doc(hidden)]
     Wayland(wayland::Window)
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowId {
-    #[doc(hidden)]
     X(x11::WindowId),
-    #[doc(hidden)]
     Wayland(wayland::WindowId)
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceId {
-    #[doc(hidden)]
     X(x11::DeviceId),
-    #[doc(hidden)]
     Wayland(wayland::DeviceId)
 }
 
 #[derive(Clone)]
 pub enum MonitorId {
-    #[doc(hidden)]
     X(x11::MonitorId),
-    #[doc(hidden)]
     Wayland(wayland::MonitorId),
-    #[doc(hidden)]
     None,
 }
 
@@ -167,24 +158,14 @@ impl Window2 {
                pl_attribs: &PlatformSpecificWindowBuilderAttributes)
                -> Result<Self, CreationError>
     {
-        match *UNIX_BACKEND {
-            UnixBackend::Wayland(ref ctxt) => {
-                if let EventsLoop::Wayland(ref evlp) = *events_loop {
-                    wayland::Window::new(evlp, ctxt.clone(), window).map(Window2::Wayland)
-                } else {
-                    // It is not possible to instanciate an EventsLoop not matching its backend
-                    unreachable!()
-                }
+        match *events_loop {
+            EventsLoop::Wayland(ref evlp) => {
+                wayland::Window::new(evlp, window).map(Window2::Wayland)
             },
 
-            UnixBackend::X(_) => {
-                x11::Window2::new(events_loop, window, pl_attribs).map(Window2::X)
+            EventsLoop::X(ref el) => {
+                x11::Window2::new(el, window, pl_attribs).map(Window2::X)
             },
-            UnixBackend::Error(..) => {
-                // If the Backend is Error(), it is not possible to instanciate an EventsLoop at all,
-                // thus this function cannot be called!
-                unreachable!()
-            }
         }
     }
 
@@ -351,9 +332,7 @@ unsafe extern "C" fn x_error_callback(dpy: *mut x11::ffi::Display, event: *mut x
 }
 
 pub enum EventsLoop {
-    #[doc(hidden)]
     Wayland(wayland::EventsLoop),
-    #[doc(hidden)]
     X(x11::EventsLoop)
 }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -282,6 +282,25 @@ pub enum EventsLoopProxy {
 
 impl EventsLoop {
     pub fn new() -> EventsLoop {
+        if let Ok(env_var) = env::var(BACKEND_PREFERENCE_ENV_VAR) {
+            match env_var.as_str() {
+                "x11" => {
+                    match EventsLoop::new_x11() {
+                        Ok(e) => return e,
+                        Err(_) => panic!()      // TODO: propagate
+                    }
+                },
+                "wayland" => {
+                    match EventsLoop::new_wayland() {
+                        Ok(e) => return e,
+                        Err(_) => panic!()      // TODO: propagate
+                    }
+                },
+                _ => panic!("Unknown environment variable value for {}, try one of `x11`,`wayland`",
+                            BACKEND_PREFERENCE_ENV_VAR),
+            }
+        }
+
         if let Ok(el) = EventsLoop::new_wayland() {
             return el;
         }

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -122,6 +122,11 @@ impl EventsLoop {
         }
     }
 
+    #[inline]
+    pub fn context(&self) -> &Arc<WaylandContext> {
+        &self.ctxt
+    }
+
     pub fn create_proxy(&self) -> EventsLoopProxy {
         EventsLoopProxy {
             ctxt: Arc::downgrade(&self.ctxt),

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -37,8 +37,9 @@ pub fn make_wid(s: &wl_surface::WlSurface) -> WindowId {
 }
 
 impl Window {
-    pub fn new(evlp: &EventsLoop, ctxt: Arc<WaylandContext>, attributes: &WindowAttributes)  -> Result<Window, CreationError>
+    pub fn new(evlp: &EventsLoop, attributes: &WindowAttributes) -> Result<Window, CreationError>
     {
+        let ctxt = evlp.context().clone();
         let (width, height) = attributes.dimensions.unwrap_or((800,600));
 
         let (surface, decorated) = ctxt.create_window::<DecoratedHandler>(width, height);

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -675,12 +675,11 @@ lazy_static! {      // TODO: use a static mutex when that's possible, and put me
 }
 
 impl Window2 {
-    pub fn new(events_loop: &::platform::EventsLoop,
+    pub fn new(x_events_loop: &EventsLoop,
                window: &::WindowAttributes,
                pl_attribs: &PlatformSpecificWindowBuilderAttributes)
                -> Result<Self, CreationError>
     {
-        let x_events_loop = if let ::platform::EventsLoop::X(ref e) = *events_loop { e } else { unreachable!() };
         let win = ::std::sync::Arc::new(try!(Window::new(&x_events_loop, window, pl_attribs)));
 
         // creating IM

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -120,6 +120,12 @@ impl EventsLoop {
         result
     }
 
+    /// Returns the `XConnection` of this events loop.
+    #[inline]
+    pub fn x_connection(&self) -> &Arc<XConnection> {
+        &self.display
+    }
+
     pub fn create_proxy(&self) -> EventsLoopProxy {
         EventsLoopProxy {
             pending_wakeup: Arc::downgrade(&self.pending_wakeup),

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "macos")]
 
 pub use self::events_loop::{EventsLoop, Proxy as EventsLoopProxy};
-pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
+pub use self::monitor::MonitorId;
 pub use self::window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, Window};
 use std::sync::Arc;
 

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -1,27 +1,30 @@
 use core_graphics::display;
 use std::collections::VecDeque;
+use super::EventsLoop;
 
 #[derive(Clone)]
 pub struct MonitorId(u32);
 
-pub fn get_available_monitors() -> VecDeque<MonitorId> {
-    let mut monitors = VecDeque::new();
-    unsafe {
-        let max_displays = 10u32;
-        let mut active_displays = [0u32; 10];
-        let mut display_count = 0;
-        display::CGGetActiveDisplayList(max_displays, &mut active_displays[0], &mut display_count);
-        for i in 0..display_count as usize {
-            monitors.push_back(MonitorId(active_displays[i]));
+impl EventsLoop {
+    pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
+        let mut monitors = VecDeque::new();
+        unsafe {
+            let max_displays = 10u32;
+            let mut active_displays = [0u32; 10];
+            let mut display_count = 0;
+            display::CGGetActiveDisplayList(max_displays, &mut active_displays[0], &mut display_count);
+            for i in 0..display_count as usize {
+                monitors.push_back(MonitorId(active_displays[i]));
+            }
         }
+        monitors
     }
-    monitors
-}
 
-#[inline]
-pub fn get_primary_monitor() -> MonitorId {
-    let id = unsafe { MonitorId(display::CGMainDisplayID()) };
-    id
+    #[inline]
+    pub fn get_primary_monitor(&self) -> MonitorId {
+        let id = unsafe { MonitorId(display::CGMainDisplayID()) };
+        id
+    }
 }
 
 impl MonitorId {

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -3,7 +3,7 @@
 use winapi;
 
 pub use self::events_loop::{EventsLoop, EventsLoopProxy};
-pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
+pub use self::monitor::MonitorId;
 pub use self::window::Window;
 
 #[derive(Clone, Default)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -322,7 +322,7 @@ impl Window {
 // Implementation note: we retreive the list once, then serve each element by one by one.
 // This may change in the future.
 pub struct AvailableMonitorsIter {
-    data: VecDequeIter<platform::MonitorId>,
+    pub(crate) data: VecDequeIter<platform::MonitorId>,
 }
 
 impl Iterator for AvailableMonitorsIter {
@@ -337,36 +337,6 @@ impl Iterator for AvailableMonitorsIter {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.data.size_hint()
     }
-}
-
-/// Returns the list of all available monitors.
-///
-/// Usage will result in display backend initialisation, this can be controlled on linux
-/// using an environment variable `WINIT_UNIX_BACKEND`.
-/// > Legal values are `x11` and `wayland`. If this variable is set only the named backend
-/// > will be tried by winit. If it is not set, winit will try to connect to a wayland connection,
-/// > and if it fails will fallback on x11.
-/// >
-/// > If this variable is set with any other value, winit will panic.
-// Note: should be replaced with `-> impl Iterator` once stable.
-#[inline]
-pub fn get_available_monitors() -> AvailableMonitorsIter {
-    let data = platform::get_available_monitors();
-    AvailableMonitorsIter{ data: data.into_iter() }
-}
-
-/// Returns the primary monitor of the system.
-///
-/// Usage will result in display backend initialisation, this can be controlled on linux
-/// using an environment variable `WINIT_UNIX_BACKEND`.
-/// > Legal values are `x11` and `wayland`. If this variable is set only the named backend
-/// > will be tried by winit. If it is not set, winit will try to connect to a wayland connection,
-/// > and if it fails will fallback on x11.
-/// >
-/// > If this variable is set with any other value, winit will panic.
-#[inline]
-pub fn get_primary_monitor() -> MonitorId {
-    MonitorId { inner: platform::get_primary_monitor() }
 }
 
 /// Identifier for a monitor.


### PR DESCRIPTION
Based on #267 
cc @alexheretic

This PR ties the `EventsLoop` to a specific X11 or Wayland connection on Linux. Creating the `EventsLoop` also creates the connection. We still use a `lazy_static` for the X11 connection though, because of the badly-designed `XSetErrorHandler` function.

Also adds an `EventsLoopExt` trait in `os::linux` that allows choosing whether the `EventsLoop` uses X11 or Wayland. The default `new()` function has the same behaviour as today.

Breaking changes:

- Removes `os::linux::get_x_connection()`. I don't remember what it was used for, but it was a bad design anyway. We can always reintroduce an equivalent through the `EventsLoopExt` trait if required.
- `get_available_monitors()` and `get_primary_monitor()` are now methods of `EventsLoop` instead of being stand-alone.
