### PR TITLE
Move fullscreen modes to not touch physical resolutions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ rust:
 
 cache: cargo
 
-addons:
-  apt:
-    packages:
-    - libxxf86vm-dev
-
 install:
   - rustup self update
   - |

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,7 +1,7 @@
 extern crate winit;
 
 use std::io::{self, Write};
-use winit::{ControlFlow, Event, WindowEvent, FullScreenState};
+use winit::{ControlFlow, Event, WindowEvent, FullScreen};
 
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
@@ -27,7 +27,7 @@ fn main() {
 
     let _window = winit::WindowBuilder::new()
         .with_title("Hello world!")
-        .with_fullscreen(FullScreenState::Exclusive(monitor))
+        .with_fullscreen(FullScreen::SpecificMonitor(monitor))
         .build(&events_loop)
         .unwrap();
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,7 +1,7 @@
 extern crate winit;
 
 use std::io::{self, Write};
-use winit::{ControlFlow, Event, WindowEvent, FullScreen};
+use winit::{ControlFlow, Event, WindowEvent};
 
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
@@ -27,7 +27,7 @@ fn main() {
 
     let _window = winit::WindowBuilder::new()
         .with_title("Hello world!")
-        .with_fullscreen(FullScreen::SpecificMonitor(monitor))
+        .with_fullscreen(Some(monitor))
         .build(&events_loop)
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,10 +381,13 @@ pub enum MouseCursor {
 
 /// Describes if the Window is in one of the fullscreen modes
 #[derive(Clone)]
-pub enum FullScreenState {
+pub enum FullScreen {
+    /// Non-fullscreen window with normal decorations
     None,
-    Windowed,
-    Exclusive(MonitorId),
+    /// Set fullscreen in whatever monitor the window happens to be right now
+    CurrentMonitor,
+    /// Set fullscreen in a specific monitor
+    SpecificMonitor(MonitorId),
 }
 
 /// Describes how winit handles the cursor.
@@ -426,7 +429,7 @@ pub struct WindowAttributes {
     /// Whether the window should be set as fullscreen upon creation.
     ///
     /// The default is `None`.
-    pub fullscreen: FullScreenState,
+    pub fullscreen: FullScreen,
 
     /// The title of the window in the title bar.
     ///
@@ -468,7 +471,7 @@ impl Default for WindowAttributes {
             max_dimensions: None,
             title: "winit window".to_owned(),
             maximized: false,
-            fullscreen: FullScreenState::None,
+            fullscreen: FullScreen::None,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,17 +379,6 @@ pub enum MouseCursor {
     RowResize,
 }
 
-/// Describes if the Window is in one of the fullscreen modes
-#[derive(Clone)]
-pub enum FullScreen {
-    /// Non-fullscreen window with normal decorations
-    None,
-    /// Set fullscreen in whatever monitor the window happens to be right now
-    CurrentMonitor,
-    /// Set fullscreen in a specific monitor
-    SpecificMonitor(MonitorId),
-}
-
 /// Describes how winit handles the cursor.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CursorState {
@@ -429,7 +418,7 @@ pub struct WindowAttributes {
     /// Whether the window should be set as fullscreen upon creation.
     ///
     /// The default is `None`.
-    pub fullscreen: FullScreen,
+    pub fullscreen: Option<MonitorId>,
 
     /// The title of the window in the title bar.
     ///
@@ -471,7 +460,7 @@ impl Default for WindowAttributes {
             max_dimensions: None,
             title: "winit window".to_owned(),
             maximized: false,
-            fullscreen: FullScreen::None,
+            fullscreen: None,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -14,7 +14,6 @@ use std::collections::VecDeque;
 
 use CursorState;
 use WindowAttributes;
-use FullScreen;
 
 pub struct EventsLoop {
     event_rx: Receiver<android_glue::Event>,
@@ -261,7 +260,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, _state: FullScreen) {
+    pub fn set_fullscreen(&self, _monitor: Option<MonitorId>) {
     }
 
     pub fn id(&self) -> WindowId {

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -151,6 +151,11 @@ impl MonitorId {
     pub fn get_dimensions(&self) -> (u32, u32) {
         unimplemented!()
     }
+
+    #[inline]
+    pub fn get_position(&self) -> (u32, u32) {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone, Default)]

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 
 use CursorState;
 use WindowAttributes;
-use FullScreenState;
+use FullScreen;
 
 pub struct EventsLoop {
     event_rx: Receiver<android_glue::Event>,
@@ -261,7 +261,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, _state: FullScreenState) {
+    pub fn set_fullscreen(&self, _state: FullScreen) {
     }
 
     pub fn id(&self) -> WindowId {

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -9,6 +9,7 @@ use {CreationError, Event, WindowEvent, MouseCursor};
 use CreationError::OsError;
 use WindowId as RootWindowId;
 use events::{Touch, TouchPhase};
+use window::MonitorId as RootMonitorId;
 
 use std::collections::VecDeque;
 
@@ -265,7 +266,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, _monitor: Option<MonitorId>) {
+    pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+    }
+
+    #[inline]
+    pub fn get_current_monitor(&self) -> RootMonitorId {
+        unimplemented!()
     }
 
     pub fn id(&self) -> WindowId {

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -155,7 +155,8 @@ impl MonitorId {
 
     #[inline]
     pub fn get_position(&self) -> (u32, u32) {
-        unimplemented!()
+        // Android assumes single screen
+        (0, 0)
     }
 }
 
@@ -263,15 +264,17 @@ impl Window {
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        // Android has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        // Android has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
-        unimplemented!()
+        RootMonitorId{inner: MonitorId}
     }
 
     pub fn id(&self) -> WindowId {

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -70,7 +70,7 @@ use libc::c_int;
 use objc::runtime::{Class, Object, Sel, BOOL, YES };
 use objc::declare::{ ClassDecl };
 
-use { CreationError, CursorState, MouseCursor, WindowAttributes, FullScreen };
+use { CreationError, CursorState, MouseCursor, WindowAttributes };
 use WindowId as RootEventId;
 use WindowEvent;
 use Event;
@@ -345,7 +345,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreen) {
+    pub fn set_fullscreen(&self, monitor: Option<MonitorId>) {
     }
 
     #[inline]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -347,7 +347,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_maximized(&self, maximized: bool) {
+    pub fn set_maximized(&self, _maximized: bool) {
     }
 
     #[inline]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -138,6 +138,11 @@ impl MonitorId {
     pub fn get_dimensions(&self) -> (u32, u32) {
         unimplemented!()
     }
+
+    #[inline]
+    pub fn get_position(&self) -> (u32, u32) {
+        unimplemented!()
+    }
 }
 
 pub struct EventsLoop {

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -75,6 +75,7 @@ use WindowId as RootEventId;
 use WindowEvent;
 use Event;
 use events::{ Touch, TouchPhase };
+use window::MonitorId as RootMonitorId;
 
 mod ffi;
 use self::ffi::{
@@ -350,7 +351,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<MonitorId>) {
+    pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+    }
+
+    #[inline]
+    pub fn get_current_monitor(&self) -> RootMonitorId {
+        unimplemented!()
     }
 
     #[inline]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -70,7 +70,7 @@ use libc::c_int;
 use objc::runtime::{Class, Object, Sel, BOOL, YES };
 use objc::declare::{ ClassDecl };
 
-use { CreationError, CursorState, MouseCursor, WindowAttributes, FullScreenState };
+use { CreationError, CursorState, MouseCursor, WindowAttributes, FullScreen };
 use WindowId as RootEventId;
 use WindowEvent;
 use Event;
@@ -345,7 +345,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
     }
 
     #[inline]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -142,7 +142,8 @@ impl MonitorId {
 
     #[inline]
     pub fn get_position(&self) -> (u32, u32) {
-        unimplemented!()
+        // iOS assumes single screen
+        (0, 0)
     }
 }
 
@@ -348,15 +349,17 @@ impl Window {
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        // iOS has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        // iOS has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
-        unimplemented!()
+        RootMonitorId{inner: MonitorId}
     }
 
     #[inline]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -251,6 +251,14 @@ impl Window {
             &Window::Wayland(ref _w) => {},
         }
     }
+
+    #[inline]
+    pub fn get_current_monitor(&self) -> RootMonitorId {
+        match self {
+            &Window::X(ref w) => RootMonitorId{inner: MonitorId::X(w.get_current_monitor())},
+            &Window::Wayland(ref w) => RootMonitorId{inner: MonitorId::Wayland(w.get_current_monitor())},
+        }
+    }
 }
 
 unsafe extern "C" fn x_error_callback(dpy: *mut x11::ffi::Display, event: *mut x11::ffi::XErrorEvent)

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::env;
 
-use {CreationError, CursorState, EventsLoopClosed, MouseCursor, ControlFlow, FullScreenState};
+use {CreationError, CursorState, EventsLoopClosed, MouseCursor, ControlFlow, FullScreen};
 use libc;
 
 use self::x11::XConnection;
@@ -236,7 +236,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
         match self {
             &Window::X(ref w) => w.set_fullscreen(state),
             &Window::Wayland(ref _w) => {},

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -86,6 +86,14 @@ impl MonitorId {
             &MonitorId::Wayland(ref m) => m.get_dimensions(),
         }
     }
+
+    #[inline]
+    pub fn get_position(&self) -> (u32, u32) {
+        match self {
+            &MonitorId::X(ref m) => m.get_position(),
+            &MonitorId::Wayland(ref m) => m.get_position(),
+        }
+    }
 }
 
 impl Window {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::env;
 
-use {CreationError, CursorState, EventsLoopClosed, MouseCursor, ControlFlow, FullScreen};
+use {CreationError, CursorState, EventsLoopClosed, MouseCursor, ControlFlow};
 use libc;
 
 use self::x11::XConnection;
@@ -12,6 +12,7 @@ use self::x11::XError;
 use self::x11::ffi::XVisualInfo;
 
 pub use self::x11::XNotSupported;
+use window::MonitorId as RootMonitorId;
 
 mod dlopen;
 pub mod wayland;
@@ -236,9 +237,9 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreen) {
+    pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         match self {
-            &Window::X(ref w) => w.set_fullscreen(state),
+            &Window::X(ref w) => w.set_fullscreen(monitor),
             &Window::Wayland(ref _w) => {},
         }
     }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use wayland_client::{EventQueue, EventQueueHandle, Proxy};
 use wayland_client::protocol::{wl_display,wl_surface};
 
-use {CreationError, MouseCursor, CursorState, WindowAttributes, FullScreen};
+use {CreationError, MouseCursor, CursorState, WindowAttributes};
 use platform::MonitorId as PlatformMonitorId;
 use window::MonitorId as RootMonitorId;
 
@@ -56,7 +56,7 @@ impl Window {
                 *(decorated.handler()) = Some(DecoratedHandler::new());
 
                 // set fullscreen if necessary
-                if let FullScreen::SpecificMonitor(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
+                if let Some(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
                     ctxt.with_output(monitor_id.clone(), |output| {
                         decorated.set_fullscreen(Some(output))
                     });

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use wayland_client::{EventQueue, EventQueueHandle, Proxy};
 use wayland_client::protocol::{wl_display,wl_surface};
 
-use {CreationError, MouseCursor, CursorState, WindowAttributes, FullScreenState};
+use {CreationError, MouseCursor, CursorState, WindowAttributes, FullScreen};
 use platform::MonitorId as PlatformMonitorId;
 use window::MonitorId as RootMonitorId;
 
@@ -56,7 +56,7 @@ impl Window {
                 *(decorated.handler()) = Some(DecoratedHandler::new());
 
                 // set fullscreen if necessary
-                if let FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
+                if let FullScreen::SpecificMonitor(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
                     ctxt.with_output(monitor_id.clone(), |output| {
                         decorated.set_fullscreen(Some(output))
                     });

--- a/src/platform/linux/x11/ffi.rs
+++ b/src/platform/linux/x11/ffi.rs
@@ -1,8 +1,8 @@
 pub use x11_dl::keysym::*;
 pub use x11_dl::xcursor::*;
-pub use x11_dl::xf86vmode::*;
 pub use x11_dl::xlib::*;
 pub use x11_dl::xinput::*;
 pub use x11_dl::xinput2::*;
 pub use x11_dl::xlib_xcb::*;
 pub use x11_dl::error::OpenError;
+pub use x11_dl::xrandr::*;

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -13,6 +13,8 @@ pub struct MonitorId {
   dimensions: (u32, u32),
   /// The position of the monitor in the X screen
   position: (u32, u32),
+  /// If the monitor is the primary one
+  primary: bool,
 }
 
 pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
@@ -39,6 +41,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
                     name,
                     dimensions: (monitor.width as u32, monitor.height as u32),
                     position: (monitor.x as u32, monitor.y as u32),
+                    primary: (monitor.primary != 0),
                 });
             }
             (x.xrandr.XRRFreeMonitors)(monitors);
@@ -59,6 +62,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
                         name,
                         dimensions: ((*crtc).width as u32, (*crtc).height as u32),
                         position: ((*crtc).x as u32, (*crtc).y as u32),
+                        primary: true,
                     });
                 }
                 (x.xrandr.XRRFreeCrtcInfo)(crtc);
@@ -71,7 +75,13 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
 
 #[inline]
 pub fn get_primary_monitor(x: &Arc<XConnection>) -> MonitorId {
-    get_available_monitors(x)[0].clone()
+    for monitor in get_available_monitors(x) {
+        if monitor.primary {
+            return monitor.clone()
+        }
+    }
+
+    panic!("[winit] Failed to find the primary monitor")
 }
 
 impl MonitorId {

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::sync::Arc;
 use std::slice;
 
@@ -11,8 +10,8 @@ pub struct MonitorId {
   pub name: String,
 }
 
-pub fn get_available_monitors(x: &Arc<XConnection>) -> VecDeque<MonitorId> {
-    let mut monitors = VecDeque::new();
+pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
+    let mut monitors = Vec::new();
     unsafe {
         let root = (x.xlib.XDefaultRootWindow)(x.display);
         let resources = (x.xrandr.XRRGetScreenResources)(x.display, root);
@@ -25,7 +24,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> VecDeque<MonitorId> {
                 let nameslice = slice::from_raw_parts((*output).name as *mut u8, (*output).nameLen as usize);
                 let name = String::from_utf8_lossy(nameslice).into_owned();
                 (x.xrandr.XRRFreeOutputInfo)(output);
-                monitors.push_back(MonitorId{
+                monitors.push(MonitorId{
                     x: x.clone(),
                     crtc: crtcid,
                     name,

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -5,16 +5,16 @@ use super::XConnection;
 
 #[derive(Clone)]
 pub struct MonitorId {
-  /// The actual id
-  id: u32,
-  /// The name of the monitor
-  name: String,
-  /// The size of the monitor
-  dimensions: (u32, u32),
-  /// The position of the monitor in the X screen
-  position: (u32, u32),
-  /// If the monitor is the primary one
-  primary: bool,
+    /// The actual id
+    id: u32,
+    /// The name of the monitor
+    name: String,
+    /// The size of the monitor
+    dimensions: (u32, u32),
+    /// The position of the monitor in the X screen
+    position: (u32, u32),
+    /// If the monitor is the primary one
+    primary: bool,
 }
 
 pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::{ptr, slice};
+use std::slice;
 
 use super::XConnection;
 
@@ -18,10 +18,10 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> VecDeque<MonitorId> {
         let resources = (x.xrandr.XRRGetScreenResources)(x.display, root);
 
         for i in 0..(*resources).ncrtc {
-            let crtcid = ptr::read((*resources).crtcs.offset(i as isize));
+            let crtcid = *((*resources).crtcs.offset(i as isize));
             let crtc = (x.xrandr.XRRGetCrtcInfo)(x.display, resources, crtcid);
             if (*crtc).width > 0 && (*crtc).height > 0 && (*crtc).noutput > 0 {
-                let output = (x.xrandr.XRRGetOutputInfo)(x.display, resources, ptr::read((*crtc).outputs.offset(0)));
+                let output = (x.xrandr.XRRGetOutputInfo)(x.display, resources, *((*crtc).outputs.offset(0)));
                 let nameslice = slice::from_raw_parts((*output).name as *mut u8, (*output).nameLen as usize);
                 let name = String::from_utf8_lossy(nameslice).into_owned();
                 (x.xrandr.XRRFreeOutputInfo)(output);

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use CursorState;
 use WindowAttributes;
-use FullScreen;
 use platform::PlatformSpecificWindowBuilderAttributes;
 
 use platform::MonitorId as PlatformMonitorId;
@@ -294,15 +293,12 @@ impl Window2 {
         }
     }
 
-    pub fn set_fullscreen(&self, state: FullScreen) {
-        match state {
-            FullScreen::None => {
+    pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
+        match monitor {
+            None => {
                 self.set_fullscreen_hint(false);
             },
-            FullScreen::CurrentMonitor => {
-                self.set_fullscreen_hint(true);
-            },
-            FullScreen::SpecificMonitor(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
+            Some(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
                 let screenpos = monitor.get_position();
                 self.set_position(screenpos.0 as i32, screenpos.1 as i32);
                 self.set_fullscreen_hint(true);

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -33,8 +33,7 @@ pub struct XWindow {
     display: Arc<XConnection>,
     window: ffi::Window,
     root: ffi::Window,
-    // screen we're using, original screen mode if we've switched
-    fullscreen: Arc<Mutex<(i32, Option<ffi::XF86VidModeModeInfo>)>>,
+    fullscreen: Arc<Mutex<(i32, Option<(i32,i32)>)>>,
 }
 
 unsafe impl Send for XWindow {}
@@ -44,7 +43,7 @@ unsafe impl Send for Window2 {}
 unsafe impl Sync for Window2 {}
 
 impl XWindow {
-    fn switch_to_fullscreen_mode(&self, monitor: i32, width: u16, height: u16) {
+    fn switch_to_fullscreen_mode(&self, monitor: i32, width: i32, height: i32) {
         let original_monitor = {
             let fullscreen = self.fullscreen.lock().unwrap();
             fullscreen.0
@@ -54,53 +53,48 @@ impl XWindow {
             self.switch_from_fullscreen_mode();
         }
 
-        let current_mode = unsafe {
-            let mut mode_num: libc::c_int = mem::uninitialized();
-            let mut modes: *mut *mut ffi::XF86VidModeModeInfo = mem::uninitialized();
-            if (self.display.xf86vmode.XF86VidModeGetAllModeLines)(self.display.display, monitor, &mut mode_num, &mut modes) == 0 {
-              eprintln!("[winit] Couldn't get current resolution mode");
-              return
-            }
-            ptr::read(*modes.offset(0))
+        let current_resolution = unsafe {
+            let width = (self.display.xlib.XDisplayWidth)(self.display.display, monitor);
+            let height = (self.display.xlib.XDisplayHeight)(self.display.display, monitor);
+            (width, height)
         };
 
-        let new_mode = unsafe {
-            let mut mode_num: libc::c_int = mem::uninitialized();
-            let mut modes: *mut *mut ffi::XF86VidModeModeInfo = mem::uninitialized();
-            if (self.display.xf86vmode.XF86VidModeGetAllModeLines)(self.display.display, monitor, &mut mode_num, &mut modes) == 0 {
-                // There are no modes, mighty weird
-                eprintln!("[winit] X has no valid modes");
+        let new_resolution = unsafe {
+            let mut nsizes: i32 = 0;
+            let sizes = (self.display.xrandr.XRRSizes)(self.display.display, monitor, &mut nsizes);
+            if nsizes <= 0 {
+                eprintln!("[winit] didn't find any XrandR modes");
                 return
-            } else {
-                let matching_mode = (0 .. mode_num).map(|i| {
-                    let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m
-                }).find(|m| m.hdisplay == width && m.vdisplay == height);
+            }
 
-                if let Some(matching_mode) = matching_mode {
-                    matching_mode
-                } else {
-                    let m = (0 .. mode_num).map(|i| {
-                        let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m
-                    }).find(|m| m.hdisplay >= width && m.vdisplay >= height);
+            let mode = ptr::read(sizes.offset(0));
+            let mut new_resolution = (mode.width, mode.height);
+            for i in 1..nsizes {
+                let mode = ptr::read(sizes.offset(i as isize));
 
-                    match m {
-                        Some(m) => m,
-                        None => {
-                          eprintln!("[winit] Could not find a suitable graphics mode");
-                          return
-                        }
-                    }
+                if mode.width == width && mode.height == height {
+                    // Exact match, look no further
+                    new_resolution = (mode.width, mode.height);
+                    break
+                }
+
+                let curr_area = new_resolution.0 * new_resolution.1;
+                let mode_area = mode.width * mode.height;
+                if mode.width >= width && mode.height >= height && mode_area <= curr_area {
+                    // Better match, swap
+                    new_resolution = (mode.width, mode.height);
                 }
             }
+            new_resolution
         };
 
-        if new_mode != current_mode {
+        if new_resolution != current_resolution {
             // We actually need to change modes
-            self.set_mode(monitor, new_mode);
+            self.set_resolution(monitor, new_resolution.0, new_resolution.1);
             let mut fullscreen = self.fullscreen.lock().unwrap();
             if fullscreen.1.is_none() {
-                // It's our first mode switch, save the original mode
-                fullscreen.1 = Some(current_mode);
+                // It's our first mode switch, save the original resolution to be able to go back
+                fullscreen.1 = Some(current_resolution);
             }
         }
     }
@@ -112,24 +106,36 @@ impl XWindow {
         };
 
         if let Some(mode) = mode {
-            self.set_mode(monitor, mode);
+            self.set_resolution(monitor, mode.0, mode.1);
             let mut fullscreen = self.fullscreen.lock().unwrap();
             fullscreen.1 = None;
         }
     }
 
-    pub fn set_mode(&self, monitor: i32, mode: ffi::XF86VidModeModeInfo) {
+    pub fn set_resolution(&self, monitor: i32, width: i32, height: i32) {
         unsafe {
-            let mut mode_to_switch_to = mode;
-            (self.display.xf86vmode.XF86VidModeSwitchToMode)(
-                self.display.display,
-                monitor,
-                &mut mode_to_switch_to
-            );
-            self.display.check_errors().expect("Failed to call XF86VidModeSwitchToMode");
+            let mut nsizes: i32 = 0;
+            let sizes = (self.display.xrandr.XRRSizes)(self.display.display, monitor, &mut nsizes);
+            for i in 0..nsizes {
+                let mode = ptr::read(sizes.offset(i as isize));
+                if mode.width == width && mode.height == height {
+                    return self.set_mode(monitor, i);
+                }
+            }
+        }
+        eprintln!("[winit] Couldn't find mode with size {}x{}", width, height);
+    }
 
-            (self.display.xf86vmode.XF86VidModeSetViewPort)(self.display.display, monitor, 0, 0);
-            self.display.check_errors().expect("Failed to call XF86VidModeSetViewPort");
+    pub fn set_mode(&self, monitor: i32, mode: i32) {
+        unsafe {
+            let mut _cfg_time: ffi::Time = mem::uninitialized();
+            let time = (self.display.xrandr.XRRTimes)(self.display.display, monitor, &mut _cfg_time);
+            let mut rotation: ffi::Rotation = mem::uninitialized();
+            (self.display.xrandr.XRRRotations)(self.display.display, monitor, &mut rotation);
+            let cfg = (self.display.xrandr.XRRGetScreenInfo)(self.display.display, self.window);
+            (self.display.xrandr.XRRSetScreenConfig)(self.display.display, cfg, self.root, mode, rotation, time);
+            (self.display.xrandr.XRRFreeScreenConfigInfo)(cfg);
+            (self.display.xlib.XRaiseWindow)(self.display.display, self.window);
         }
     }
 }
@@ -402,16 +408,16 @@ impl Window2 {
         match state {
             FullScreenState::None => {
               self.x.switch_from_fullscreen_mode();
-              Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", false);
+              self.set_fullscreen_hint(false);
             },
             FullScreenState::Windowed => {
               self.x.switch_from_fullscreen_mode();
-              Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", true);
+              self.set_fullscreen_hint(true);
             },
             FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::X(X11MonitorId(_, monitor)) }) => {
               if let Some(dimensions) = self.get_inner_size() {
-                self.x.switch_to_fullscreen_mode(monitor as i32, dimensions.0 as u16, dimensions.1 as u16);
-                Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", true);
+                self.x.switch_to_fullscreen_mode(monitor as i32, dimensions.0 as i32, dimensions.1 as i32);
+                self.set_fullscreen_hint(true);
               } else {
                 eprintln!("[winit] Couldn't get window dimensions to go fullscreen");
               }
@@ -423,6 +429,10 @@ impl Window2 {
     pub fn set_maximized(&self, maximized: bool) {
         Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_MAXIMIZED_HORZ", maximized);
         Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_MAXIMIZED_VERT", maximized);
+    }
+
+    fn set_fullscreen_hint(&self, fullscreen: bool) {
+        Window2::set_netwm(&self.x.display, self.x.window, self.x.root, "_NET_WM_STATE_FULLSCREEN", fullscreen);
     }
 
     pub fn set_title(&self, title: &str) {

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use CursorState;
 use WindowAttributes;
-use FullScreenState;
+use FullScreen;
 use platform::PlatformSpecificWindowBuilderAttributes;
 
 use platform::MonitorId as PlatformMonitorId;
@@ -294,15 +294,15 @@ impl Window2 {
         }
     }
 
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
         match state {
-            FullScreenState::None => {
+            FullScreen::None => {
                 self.set_fullscreen_hint(false);
             },
-            FullScreenState::Windowed => {
+            FullScreen::CurrentMonitor => {
                 self.set_fullscreen_hint(true);
             },
-            FullScreenState::Exclusive(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
+            FullScreen::SpecificMonitor(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
                 let screenpos = monitor.get_position();
                 self.set_position(screenpos.0 as i32, screenpos.1 as i32);
                 self.set_fullscreen_hint(true);

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -3,7 +3,7 @@ use CreationError;
 use CreationError::OsError;
 use libc;
 use std::borrow::Borrow;
-use std::{mem, ptr, cmp};
+use std::{mem, cmp};
 use std::sync::{Arc, Mutex};
 use std::os::raw::{c_int, c_long, c_uchar};
 use std::thread;
@@ -74,14 +74,14 @@ impl XWindow {
             // Build a hash of the modes to be able to lookup by id
             let mut modes: HashMap<u64, ffi::XRRModeInfo> = HashMap::new();
             for k in 0..(*resources).nmode {
-                let mode = ptr::read((*resources).modes.offset(k as isize));
+                let mode = *((*resources).modes.offset(k as isize));
                 modes.insert(mode.id, mode);
             }
 
-            let output = (self.display.xrandr.XRRGetOutputInfo)(self.display.display, resources, ptr::read((*crtc).outputs.offset(0)));
-            let mut new_mode = modes[&ptr::read((*output).modes.offset(0))];
+            let output = (self.display.xrandr.XRRGetOutputInfo)(self.display.display, resources, *((*crtc).outputs.offset(0)));
+            let mut new_mode = modes[&*((*output).modes.offset(0))];
             for j in 1..(*output).nmode {
-                let modeid = ptr::read((*output).modes.offset(j as isize));
+                let modeid = *((*output).modes.offset(j as isize));
                 let mode = modes[&modeid];
                 let curr_clock = (new_mode.dotClock as f32) / (new_mode.hTotal as f32) / (new_mode.vTotal as f32);
                 let mode_clock = (mode.dotClock as f32) / (mode.hTotal as f32) / (mode.vTotal as f32);

--- a/src/platform/linux/x11/xdisplay.rs
+++ b/src/platform/linux/x11/xdisplay.rs
@@ -10,7 +10,7 @@ use super::ffi;
 /// A connection to an X server.
 pub struct XConnection {
     pub xlib: ffi::Xlib,
-    pub xf86vmode: ffi::Xf86vmode,
+    pub xrandr: ffi::Xrandr,
     pub xcursor: ffi::Xcursor,
     pub xinput2: ffi::XInput2,
     pub xlib_xcb: ffi::Xlib_xcb,
@@ -28,7 +28,7 @@ impl XConnection {
         // opening the libraries
         let xlib = try!(ffi::Xlib::open());
         let xcursor = try!(ffi::Xcursor::open());
-        let xf86vmode = try!(ffi::Xf86vmode::open());
+        let xrandr = try!(ffi::Xrandr::open());
         let xinput2 = try!(ffi::XInput2::open());
         let xlib_xcb = try!(ffi::Xlib_xcb::open());
 
@@ -45,12 +45,12 @@ impl XConnection {
         };
 
         Ok(XConnection {
-            xlib: xlib,
-            xf86vmode: xf86vmode,
-            xcursor: xcursor,
-            xinput2: xinput2,
-            xlib_xcb: xlib_xcb,
-            display: display,
+            xlib,
+            xrandr,
+            xcursor,
+            xinput2,
+            xlib_xcb,
+            display,
             latest_error: Mutex::new(None),
         })
     }

--- a/src/platform/linux/x11/xdisplay.rs
+++ b/src/platform/linux/x11/xdisplay.rs
@@ -45,12 +45,12 @@ impl XConnection {
         };
 
         Ok(XConnection {
-            xlib,
-            xrandr,
-            xcursor,
-            xinput2,
-            xlib_xcb,
-            display,
+            xlib: xlib,
+            xrandr: xrandr,
+            xcursor: xcursor,
+            xinput2: xinput2,
+            xlib_xcb: xlib_xcb,
+            display: display,
             latest_error: Mutex::new(None),
         })
     }

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -48,4 +48,9 @@ impl MonitorId {
         };
         dimension
     }
+
+    #[inline]
+    pub fn get_position(&self) -> (u32, u32) {
+        unimplemented!()
+    }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -24,7 +24,7 @@ use std::sync::Weak;
 
 use super::events_loop::Shared;
 
-use window::MonitorId;
+use window::MonitorId as RootMonitorId;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id(pub usize);
@@ -640,7 +640,12 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<MonitorId>) {
+    pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+    }
+
+    #[inline]
+    pub fn get_current_monitor(&self) -> RootMonitorId {
+        unimplemented!()
     }
 }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -3,7 +3,6 @@ use CreationError::OsError;
 use libc;
 
 use WindowAttributes;
-use FullScreen;
 use os::macos::ActivationPolicy;
 use os::macos::WindowExt;
 
@@ -384,7 +383,7 @@ impl Window2 {
     fn create_window(attrs: &WindowAttributes) -> Option<IdRef> {
         unsafe {
             let screen = match attrs.fullscreen {
-                FullScreen::SpecificMonitor(ref monitor_id) => {
+                Some(ref monitor_id) => {
                     let native_id = monitor_id.inner.get_native_identifier();
                     let matching_screen = {
                         let screens = appkit::NSScreen::screens(nil);
@@ -640,7 +639,7 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreen) {
+    pub fn set_fullscreen(&self, monitor: Option<MonitorId>) {
     }
 }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -637,10 +637,12 @@ impl Window2 {
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        unimplemented!()
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        unimplemented!()
     }
 
     #[inline]

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -24,6 +24,7 @@ use std::sync::Weak;
 
 use super::events_loop::Shared;
 
+use window::MonitorId;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id(pub usize);

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -636,7 +636,7 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn set_maximized(&self, maximized: bool) {
+    pub fn set_maximized(&self, _maximized: bool) {
     }
 
     #[inline]

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -3,7 +3,7 @@ use CreationError::OsError;
 use libc;
 
 use WindowAttributes;
-use FullScreenState;
+use FullScreen;
 use os::macos::ActivationPolicy;
 use os::macos::WindowExt;
 
@@ -384,7 +384,7 @@ impl Window2 {
     fn create_window(attrs: &WindowAttributes) -> Option<IdRef> {
         unsafe {
             let screen = match attrs.fullscreen {
-                FullScreenState::Exclusive(ref monitor_id) => {
+                FullScreen::SpecificMonitor(ref monitor_id) => {
                     let native_id = monitor_id.inner.get_native_identifier();
                     let matching_screen = {
                         let screens = appkit::NSScreen::screens(nil);
@@ -640,7 +640,7 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
     }
 }
 

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -176,8 +176,6 @@ impl MonitorId {
         &self.adapter_name
     }
 
-    /// This is a Win32-only function for `MonitorId` that returns the position of the
-    ///  monitor on the desktop.
     /// A window that is positionned at these coordinates will overlap the monitor.
     #[inline]
     pub fn get_position(&self) -> (u32, u32) {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -285,6 +285,11 @@ impl Window {
     #[inline]
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
     }
+
+    #[inline]
+    pub fn get_current_monitor(&self) -> RootMonitorId {
+        unimplemented!()
+    }
 }
 
 impl Drop for Window {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -280,10 +280,12 @@ impl Window {
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        unimplemented!()
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        unimplemented!()
     }
 
     #[inline]

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -279,11 +279,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_maximized(&self, maximized: bool) {
+    pub fn set_maximized(&self, _maximized: bool) {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
+    pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
     }
 
     #[inline]

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -20,7 +20,7 @@ use CreationError;
 use CursorState;
 use MouseCursor;
 use WindowAttributes;
-use FullScreenState;
+use FullScreen;
 use MonitorId as RootMonitorId;
 
 use dwmapi;
@@ -284,7 +284,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
     }
 }
 
@@ -329,7 +329,7 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
     // switching to fullscreen if necessary
     // this means adjusting the window's position so that it overlaps the right monitor,
     //  and change the monitor's resolution if necessary
-    let fullscreen = if let FullScreenState::Exclusive(RootMonitorId { ref inner }) = window.fullscreen {
+    let fullscreen = if let FullScreen::SpecificMonitor(RootMonitorId { ref inner }) = window.fullscreen {
         try!(switch_to_fullscreen(&mut rect, inner));
         true
     } else {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -20,7 +20,6 @@ use CreationError;
 use CursorState;
 use MouseCursor;
 use WindowAttributes;
-use FullScreen;
 use MonitorId as RootMonitorId;
 
 use dwmapi;
@@ -284,7 +283,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreen) {
+    pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
     }
 }
 
@@ -329,7 +328,7 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
     // switching to fullscreen if necessary
     // this means adjusting the window's position so that it overlaps the right monitor,
     //  and change the monitor's resolution if necessary
-    let fullscreen = if let FullScreen::SpecificMonitor(RootMonitorId { ref inner }) = window.fullscreen {
+    let fullscreen = if let Some(RootMonitorId { ref inner }) = window.fullscreen {
         try!(switch_to_fullscreen(&mut rect, inner));
         true
     } else {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,5 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
+use std::cmp;
 
 use CreationError;
 use CursorState;
@@ -310,6 +311,44 @@ impl Window {
         self.window.set_fullscreen(monitor)
     }
 
+    /// Returns the current monitor the window is on or the primary monitor is nothing
+    /// matches
+    pub fn get_current_monitor(&self, evloop: &EventsLoop) -> MonitorId {
+        // If anything fails we'll just return the primary
+        let primary = evloop.get_primary_monitor();
+
+        let (wx,wy) = match self.get_position() {
+            Some(val) => (cmp::max(0,val.0) as u32, cmp::max(0,val.1) as u32),
+            None=> return primary,
+        };
+        let (ww,wh) = match self.get_outer_size() {
+            Some(val) => val,
+            None=> return primary,
+        };
+        // Opposite corner coordinates
+        let (wxo, wyo) = (wx+ww-1, wy+wh-1);
+
+        // Find the monitor with the biggest overlap with the window
+        let monitors = evloop.get_available_monitors();
+        let mut overlap = 0;
+        let mut find = primary;
+        for monitor in monitors {
+            let (mx, my) = monitor.get_position();
+            let (mw, mh) = monitor.get_dimensions();
+            let (mxo, myo) = (mx+mw-1, my+mh-1);
+            let (ox, oy) = (cmp::max(wx, mx), cmp::max(wy, my));
+            let (oxo, oyo) = (cmp::min(wxo, mxo), cmp::min(wyo, myo));
+            let osize = if ox <= oxo || oy <= oyo { 0 } else { (oxo-ox)*(oyo-oy) };
+
+            if osize > overlap {
+                overlap = osize;
+                find = monitor;
+            }
+        }
+
+        find
+    }
+
     #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.window.id())
@@ -356,5 +395,12 @@ impl MonitorId {
     #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
         self.inner.get_dimensions()
+    }
+
+    /// Returns the top-left corner position of the monitor relative to the larger full
+    /// screen area.
+    #[inline]
+    pub fn get_position(&self) -> (u32, u32) {
+        self.inner.get_position()
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -7,7 +7,6 @@ use MouseCursor;
 use Window;
 use WindowBuilder;
 use WindowId;
-use FullScreen;
 
 use libc;
 use platform;
@@ -56,12 +55,11 @@ impl WindowBuilder {
         self
     }
 
-    /// Sets the fullscreen mode.
-    ///
-    /// If you don't specify dimensions for the window, it will match the monitor's.
+    /// Sets the window fullscreen state. None means a normal window, Some(MonitorId)
+    /// means a fullscreen window on that specific monitor
     #[inline]
-    pub fn with_fullscreen(mut self, state: FullScreen) -> WindowBuilder {
-        self.window.fullscreen = state;
+    pub fn with_fullscreen(mut self, monitor: Option<MonitorId>) -> WindowBuilder {
+        self.window.fullscreen = monitor;
         self
     }
 
@@ -107,7 +105,7 @@ impl WindowBuilder {
     pub fn build(mut self, events_loop: &EventsLoop) -> Result<Window, CreationError> {
         // resizing the window to the dimensions of the monitor when fullscreen
         if self.window.dimensions.is_none() {
-            if let FullScreen::SpecificMonitor(ref monitor) = self.window.fullscreen {
+            if let Some(ref monitor) = self.window.fullscreen {
                 self.window.dimensions = Some(monitor.get_dimensions());
             }
         }
@@ -308,8 +306,8 @@ impl Window {
 
     /// Sets the window to fullscreen or back
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreen) {
-        self.window.set_fullscreen(state)
+    pub fn set_fullscreen(&self, monitor: Option<MonitorId>) {
+        self.window.set_fullscreen(monitor)
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -7,7 +7,7 @@ use MouseCursor;
 use Window;
 use WindowBuilder;
 use WindowId;
-use FullScreenState;
+use FullScreen;
 
 use libc;
 use platform;
@@ -60,7 +60,7 @@ impl WindowBuilder {
     ///
     /// If you don't specify dimensions for the window, it will match the monitor's.
     #[inline]
-    pub fn with_fullscreen(mut self, state: FullScreenState) -> WindowBuilder {
+    pub fn with_fullscreen(mut self, state: FullScreen) -> WindowBuilder {
         self.window.fullscreen = state;
         self
     }
@@ -107,7 +107,7 @@ impl WindowBuilder {
     pub fn build(mut self, events_loop: &EventsLoop) -> Result<Window, CreationError> {
         // resizing the window to the dimensions of the monitor when fullscreen
         if self.window.dimensions.is_none() {
-            if let FullScreenState::Exclusive(ref monitor) = self.window.fullscreen {
+            if let FullScreen::SpecificMonitor(ref monitor) = self.window.fullscreen {
                 self.window.dimensions = Some(monitor.get_dimensions());
             }
         }
@@ -308,7 +308,7 @@ impl Window {
 
     /// Sets the window to fullscreen or back
     #[inline]
-    pub fn set_fullscreen(&self, state: FullScreenState) {
+    pub fn set_fullscreen(&self, state: FullScreen) {
         self.window.set_fullscreen(state)
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,4 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
-use std::cmp;
 
 use CreationError;
 use CursorState;
@@ -313,40 +312,8 @@ impl Window {
 
     /// Returns the current monitor the window is on or the primary monitor is nothing
     /// matches
-    pub fn get_current_monitor(&self, evloop: &EventsLoop) -> MonitorId {
-        // If anything fails we'll just return the primary
-        let primary = evloop.get_primary_monitor();
-
-        let (wx,wy) = match self.get_position() {
-            Some(val) => (cmp::max(0,val.0) as u32, cmp::max(0,val.1) as u32),
-            None=> return primary,
-        };
-        let (ww,wh) = match self.get_outer_size() {
-            Some(val) => val,
-            None=> return primary,
-        };
-        // Opposite corner coordinates
-        let (wxo, wyo) = (wx+ww-1, wy+wh-1);
-
-        // Find the monitor with the biggest overlap with the window
-        let monitors = evloop.get_available_monitors();
-        let mut overlap = 0;
-        let mut find = primary;
-        for monitor in monitors {
-            let (mx, my) = monitor.get_position();
-            let (mw, mh) = monitor.get_dimensions();
-            let (mxo, myo) = (mx+mw-1, my+mh-1);
-            let (ox, oy) = (cmp::max(wx, mx), cmp::max(wy, my));
-            let (oxo, oyo) = (cmp::min(wxo, mxo), cmp::min(wyo, myo));
-            let osize = if ox <= oxo || oy <= oyo { 0 } else { (oxo-ox)*(oyo-oy) };
-
-            if osize > overlap {
-                overlap = osize;
-                find = monitor;
-            }
-        }
-
-        find
+    pub fn get_current_monitor(&self) -> MonitorId {
+        self.window.get_current_monitor()
     }
 
     #[inline]


### PR DESCRIPTION
The previous XF86 resolution switching was broken and everything seems to have moved on to xrandr. Use that instead while cleaning up the code a bit as well. Right now everything seems to work fine. The only bug I've noticed is that at least in Unity after the resolution change the top bar is still there. Doing an alt-tab from and to the app again makes `_NET_WM_STATE_FULLSCREEN` take effect. Don't know how to fix that right now but this is already much better than what was before.