### PR TITLE
Publish 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Unreleased
+
+# Version 0.8.0 (2017-09-21)
+
+- Added `Window::set_maximized`, `WindowAttributes::maximized` and `WindowBuilder::with_maximized`.
+- Added `Window::set_fullscreen`.
+- Changed `with_fullscreen` to take a `FullscreenState` instead of a `MonitorId`.
+- Removed `MonitorId::get_native_identifer()` in favor of platform-specific traits in the `os`
+  module.
+- Changed `get_available_monitors()` and `get_primary_monitor()` to be methods of `EventsLoop`
+  instead of stand-alone methods.
+- Changed `EventsLoop` to be tied to a specific X11 or Wayland connection.
+- Added a `os::linux::EventsLoopExt` trait that makes it possible to configure the connection.
+- Fixed the emscripten code, which now compiles.
+- Changed the X11 fullscreen code to use `xrandr` instead of `xxf86vm`.
+- Fixed the Wayland backend to produce `Refresh` event after window creation.
+- Changed the `Suspended` event to be outside of `WindowEvent`.
+- Fixed the X11 backend sometimes reporting the wrong virtual key (#273).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]


### PR DESCRIPTION
Now with a changelog.
If relevant, PRs should now modify the changelog before being merged.
