### PR TITLE
Add mouse event capturing when click-dragging out of a win32 window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Implement `MonitorId::get_dimensions` for Android.
+- Fixed windows not receiving mouse events when click-dragging the mouse outside the client area of a window, on Windows platforms.
 
 # Version 0.10.1 (2018-02-05)
 

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -296,13 +296,9 @@ lazy_static! {
 thread_local!(static CONTEXT_STASH: RefCell<Option<ThreadLocalData>> = RefCell::new(None));
 struct ThreadLocalData {
     sender: mpsc::Sender<Event>,
-// <<<<<<< HEAD
     windows: HashMap<HWND, Arc<Mutex<WindowState>>>,
-//     win32_block_loop: Arc<(Mutex<bool>, Condvar)>
-// =======
     win32_block_loop: Arc<(Mutex<bool>, Condvar)>,
     mouse_buttons_down: u32
-// >>>>>>> Add mouse event capturing when click-dragging out of a win32 window
 }
 
 // Utility function that dispatches an event on the current thread.

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -102,7 +102,8 @@ impl EventsLoop {
                 *context_stash.borrow_mut() = Some(ThreadLocalData {
                     sender: tx,
                     windows: HashMap::with_capacity(4),
-                    win32_block_loop: win32_block_loop_child
+                    win32_block_loop: win32_block_loop_child,
+                    mouse_buttons_down: 0
                 });
             });
 
@@ -295,8 +296,13 @@ lazy_static! {
 thread_local!(static CONTEXT_STASH: RefCell<Option<ThreadLocalData>> = RefCell::new(None));
 struct ThreadLocalData {
     sender: mpsc::Sender<Event>,
+// <<<<<<< HEAD
     windows: HashMap<HWND, Arc<Mutex<WindowState>>>,
-    win32_block_loop: Arc<(Mutex<bool>, Condvar)>
+//     win32_block_loop: Arc<(Mutex<bool>, Condvar)>
+// =======
+    win32_block_loop: Arc<(Mutex<bool>, Condvar)>,
+    mouse_buttons_down: u32
+// >>>>>>> Add mouse event capturing when click-dragging out of a win32 window
 }
 
 // Utility function that dispatches an event on the current thread.
@@ -305,6 +311,32 @@ fn send_event(event: Event) {
         let context_stash = context_stash.borrow();
 
         let _ = context_stash.as_ref().unwrap().sender.send(event);   // Ignoring if closed
+    });
+}
+
+/// Capture mouse input, allowing `window` to receive mouse events when the cursor is outside of
+/// the window.
+unsafe fn capture_mouse(window: HWND) {
+    CONTEXT_STASH.with(|context_stash| {
+        let mut context_stash = context_stash.borrow_mut();
+        if let Some(context_stash) = context_stash.as_mut() {
+            context_stash.mouse_buttons_down += 1;
+            winuser::SetCapture(window);
+        }
+    });
+}
+
+/// Release mouse input, stopping windows on this thread from receiving mouse input when the cursor
+/// is outside the window.
+unsafe fn release_mouse() {
+    CONTEXT_STASH.with(|context_stash| {
+        let mut context_stash = context_stash.borrow_mut();
+        if let Some(context_stash) = context_stash.as_mut() {
+            context_stash.mouse_buttons_down = context_stash.mouse_buttons_down.saturating_sub(1);
+            if context_stash.mouse_buttons_down == 0 {
+                winuser::ReleaseCapture();
+            }
+        }
     });
 }
 
@@ -550,6 +582,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Left;
             use events::ElementState::Pressed;
+
+            capture_mouse(window);
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Left, modifiers: event::get_key_mods() }
@@ -561,6 +596,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Left;
             use events::ElementState::Released;
+
+            release_mouse();
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Left, modifiers: event::get_key_mods() }
@@ -572,6 +610,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Right;
             use events::ElementState::Pressed;
+
+            capture_mouse(window);
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Right, modifiers: event::get_key_mods() }
@@ -583,6 +624,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Right;
             use events::ElementState::Released;
+
+            release_mouse();
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Right, modifiers: event::get_key_mods() }
@@ -594,6 +638,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Middle;
             use events::ElementState::Pressed;
+
+            capture_mouse(window);
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Middle, modifiers: event::get_key_mods() }
@@ -605,6 +652,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::WindowEvent::MouseInput;
             use events::MouseButton::Middle;
             use events::ElementState::Released;
+
+            release_mouse();
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Middle, modifiers: event::get_key_mods() }
@@ -617,6 +667,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::MouseButton::Other;
             use events::ElementState::Pressed;
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
+
+            capture_mouse(window);
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Other(xbutton as u8), modifiers: event::get_key_mods() }
@@ -629,6 +682,9 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             use events::MouseButton::Other;
             use events::ElementState::Released;
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
+
+            release_mouse();
+
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Other(xbutton as u8), modifiers: event::get_key_mods() }


### PR DESCRIPTION
This PR updates the win32 backend to capture mouse input when a user clicks and hold a mouse button in a window, allowing movement and other mouse events to be sent to a window without the cursor necessarily hovering over said window.

This feature is quite useful in GUI applications, where users may click-drag something and end up with the mouse outside the window. An example can be seen in Firefox or Chrome, by dragging the scroll bar and moving the mouse outside the window - the bar can still be moved, even though the mouse is outside the window and it wouldn't be receiving events had it not explicitly captured the mouse.