### PR TITLE
x11: uniformize keyboard scancodes with linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Uniformize keyboard scancode values accross Wayland and X11 (#297).
+
 # Version 0.8.1 (2017-09-22)
 
 - Added various methods to `os::linux::EventsLoopExt`, plus some hidden items necessary to make

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -290,7 +290,7 @@ impl EventsLoop {
                     device_id: mkdid(3),
                     input: KeyboardInput {
                         state: state,
-                        scancode: xkev.keycode,
+                        scancode: xkev.keycode - 8,
                         virtual_keycode: vkey,
                         modifiers: ev_mods,
                     },
@@ -537,7 +537,7 @@ impl EventsLoop {
                         let xev: &ffi::XIRawEvent = unsafe { &*(xev.data as *const _) };
                         let xkeysym = unsafe { (self.display.xlib.XKeycodeToKeysym)(self.display.display, xev.detail as ffi::KeyCode, 0) };
                         callback(Event::DeviceEvent { device_id: mkdid(xev.deviceid), event: DeviceEvent::Key(KeyboardInput {
-                            scancode: xev.detail as u32,
+                            scancode: (xev.detail - 8) as u32,
                             virtual_keycode: events::keysym_to_element(xkeysym as libc::c_uint),
                             state: match xev.evtype {
                                 ffi::XI_RawKeyPress => Pressed,


### PR DESCRIPTION
Remove the `+8` offset from x11 keyboard scancodes, thus uniformizing them with wayland (and linux's definition).

Fixes #293 