### PR TITLE
Wayland: rework the event loop & expose readiness signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Uniformize keyboard scancode values accross Wayland and X11 (#297).
+- Internal rework of the wayland event loop
+- Added method `os::linux::WindowExt::is_ready`
 
 # Version 0.8.1 (2017-09-22)
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -112,6 +112,17 @@ pub trait WindowExt {
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
     fn get_wayland_display(&self) -> Option<*mut libc::c_void>;
+
+    /// Check if the window is ready for drawing
+    ///
+    /// On wayland, drawing on a surface before the server has configured
+    /// it using a special event is illegal. As a result, you should wait
+    /// until this method returns `true`.
+    ///
+    /// Once it starts returning `true`, it can never return `false` again.
+    ///
+    /// If the window is X11-based, this will just always return `true`.
+    fn is_ready(&self) -> bool;
 }
 
 impl WindowExt for Window {
@@ -173,6 +184,14 @@ impl WindowExt for Window {
         match self.window {
             LinuxWindow::Wayland(ref w) => Some(w.get_display().ptr() as *mut _),
             _ => None
+        }
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        match self.window {
+            LinuxWindow::Wayland(ref w) => w.is_ready(),
+            LinuxWindow::X(_) => true
         }
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -325,7 +325,7 @@ impl EventsLoop {
 
     pub fn new_wayland() -> Result<EventsLoop, ()> {
         wayland::WaylandContext::init()
-            .map(|ctx| EventsLoop::Wayland(wayland::EventsLoop::new(Arc::new(ctx))))
+            .map(|ctx| EventsLoop::Wayland(wayland::EventsLoop::new(ctx)))
             .ok_or(())
     }
 

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -114,7 +114,6 @@ impl wl_registry::Handler for WaylandEnv {
     {
         if interface == wl_output::WlOutput::interface_name() {
             // intercept outputs
-            // this "expect" cannot trigger (see https://github.com/vberger/wayland-client-rs/issues/69)
             let output = self.registry.bind::<wl_output::WlOutput>(1, name);
             evqh.register::<_, WaylandEnv>(&output, self.my_id);
             self.monitors.push(OutputInfo::new(output, name));
@@ -201,7 +200,7 @@ declare_handler!(WaylandEnv, wl_output::Handler, wl_output::WlOutput);
 
 pub struct WaylandContext {
     pub display: wl_display::WlDisplay,
-    evq: Mutex<EventQueue>,
+    pub evq: Mutex<EventQueue>,
     env_id: usize,
 }
 

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -236,6 +236,14 @@ impl WaylandContext {
         })
     }
 
+    pub fn read_events(&self) {
+        let evq_guard = self.evq.lock().unwrap();
+        // read some events from the socket if some are waiting & queue is empty
+        if let Some(guard) = evq_guard.prepare_read() {
+            guard.read_events().expect("Wayland connection unexpectedly lost");
+        }
+    }
+
     pub fn dispatch_pending(&self) {
         let mut guard = self.evq.lock().unwrap();
         guard.dispatch_pending().expect("Wayland connection unexpectedly lost");

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -300,8 +300,8 @@ impl WaylandContext {
         evq.register::<_, InitialBufferHandler>(&buffer, initial_buffer_handler_id);
     }
 
-    pub fn create_window<H: wayland_window::Handler>(&self, width: u32, height: u32)
-        -> (Arc<wl_surface::WlSurface>, wayland_window::DecoratedSurface<H>)
+    pub fn create_window<H: wayland_window::Handler>(&self, width: u32, height: u32, decorated: bool)
+        -> (Arc<wl_surface::WlSurface>, wayland_window::DecoratedSurface<H>, bool)
     {
         let mut guard = self.evq.lock().unwrap();
         let (surface, decorated, xdg) = {
@@ -315,7 +315,7 @@ impl WaylandContext {
                 &env.inner.shm,
                 env.get_shell(),
                 env.get_seat(),
-                false
+                decorated
             ).expect("Failed to create a tmpfile buffer.");
             let xdg = match env.get_shell() {
                 &Shell::Xdg(_) => true,
@@ -332,7 +332,7 @@ impl WaylandContext {
             // from the compositor
             self.blank_surface(&surface, &mut *guard, width as i32, height as i32);
         }
-        (surface, decorated)
+        (surface, decorated, xdg)
     }
 }
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -134,10 +134,6 @@ impl EventsLoop {
     }
 
     pub fn register_window(&self, decorated_id: usize, surface: Arc<wl_surface::WlSurface>) {
-        self.sink.lock().unwrap().buffer.push_back(::Event::WindowEvent {
-            window_id: ::WindowId(::platform::WindowId::Wayland(make_wid(&surface))),
-            event: ::WindowEvent::Refresh
-        });
         self.decorated_ids.lock().unwrap().push((decorated_id, surface.clone()));
         let mut guard = self.ctxt.evq.lock().unwrap();
         let mut state = guard.state();
@@ -153,6 +149,12 @@ impl EventsLoop {
                 decorated.resize(w as i32, h as i32);
                 sink.send_event(
                      ::WindowEvent::Resized(w,h),
+                     make_wid(&window)
+                );
+            }
+            if decorated.handler().as_mut().map(|h| h.take_refresh()).unwrap_or(false) {
+                sink.send_event(
+                     ::WindowEvent::Refresh,
                      make_wid(&window)
                 );
             }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -1,5 +1,5 @@
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{Ordering, AtomicBool};
 use std::cmp;
 
 use wayland_client::{EventQueueHandle, Proxy};
@@ -42,10 +42,18 @@ impl Window {
         let ctxt = evlp.context().clone();
         let (width, height) = attributes.dimensions.unwrap_or((800,600));
 
-        let (surface, decorated) = ctxt.create_window::<DecoratedHandler>(width, height);
+        let (surface, decorated, xdg) = ctxt.create_window::<DecoratedHandler>(width, height, attributes.decorations);
 
         // init DecoratedSurface
         let cleanup_signal = evlp.get_window_init();
+
+        let mut fullscreen_monitor = None;
+        if let Some(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
+            ctxt.with_output(monitor_id.clone(), |output| {
+                fullscreen_monitor = output.clone();
+            });
+        }
+
         let decorated_id = {
             let mut evq_guard = ctxt.evq.lock().unwrap();
             // store the DecoratedSurface handler
@@ -54,15 +62,11 @@ impl Window {
                 let mut state = evq_guard.state();
                 // initialize the DecoratedHandler
                 let decorated = state.get_mut_handler::<DecoratedSurface<DecoratedHandler>>(decorated_id);
-                *(decorated.handler()) = Some(DecoratedHandler::new());
+                *(decorated.handler()) = Some(DecoratedHandler::new(!xdg));
 
                 // set fullscreen if necessary
-                if let Some(RootMonitorId { inner: PlatformMonitorId::Wayland(ref monitor_id) }) = attributes.fullscreen {
-                    ctxt.with_output(monitor_id.clone(), |output| {
-                        decorated.set_fullscreen(Some(output))
-                    });
-                } else if attributes.decorations {
-                    decorated.set_decorate(true);
+                if let Some(output) = fullscreen_monitor {
+                    decorated.set_fullscreen(Some(&output));
                 }
                 // Finally, set the decorations size
                 decorated.resize(width as i32, height as i32);
@@ -210,30 +214,47 @@ impl Window {
 
         find
     }
+
+    pub fn is_ready(&self) -> bool {
+        let mut guard = self.ctxt.evq.lock().unwrap();
+        let mut state = guard.state();
+        let mut decorated = state.get_mut_handler::<DecoratedSurface<DecoratedHandler>>(self.decorated_id);
+        decorated.handler().as_ref().unwrap().configured
+    }
 }
 
 impl Drop for Window {
     fn drop(&mut self) {
         self.surface.destroy();
-        self.cleanup_signal.store(true, ::std::sync::atomic::Ordering::Relaxed);
+        self.cleanup_signal.store(true, Ordering::Relaxed);
     }
 }
 
 pub struct DecoratedHandler {
     newsize: Option<(u32, u32)>,
+    refresh: bool,
     closed: bool,
+    configured: bool
 }
 
 impl DecoratedHandler {
-    fn new() -> DecoratedHandler {
+    fn new(configured: bool) -> DecoratedHandler {
         DecoratedHandler {
             newsize: None,
+            refresh: false,
             closed: false,
+            configured: configured
         }
     }
 
     pub fn take_newsize(&mut self) -> Option<(u32, u32)> {
         self.newsize.take()
+    }
+
+    pub fn take_refresh(&mut self) -> bool {
+        let refresh = self.refresh;
+        self.refresh = false;
+        refresh
     }
 
     pub fn is_closed(&self) -> bool { self.closed }
@@ -245,9 +266,9 @@ impl wayland_window::Handler for DecoratedHandler {
                  _cfg: wayland_window::Configure,
                  newsize: Option<(i32, i32)>)
     {
-        if let Some((w, h)) = newsize {
-            self.newsize = Some((w as u32, h as u32));
-        }
+        self.newsize = newsize.map(|(w, h)| (w as u32, h as u32));
+        self.refresh = true;
+        self.configured = true;
     }
 
     fn close(&mut self, _: &mut EventQueueHandle) {


### PR DESCRIPTION
This PR does a few things:

- cleanup the wayland implementation of event loop, by not creating a 2nd wayland event queue (it is no longer needed now that each event loop has its own wayland connection)
- buffer the events generated by the wayland dispatch rather than calling the user callback on the go. This has two advantages:
   - it simplifies the events loop code
   - it allows to call Window methods such as `set_inner_size` and `set_title` from within a callback without deadlocking
- add an interface to query readiness of the window for drawing. Indeed, it is illegal to draw on a window before it has been configured by the server with an appropriate event when using xdg_shell. Doing so causes the connection to be terminated by the server. This exposes an `Arc<AtomicBool>` that becomes `true` once the appropriate event has been received.

The idea of this last change is that glutin can retrieve this `Arc<AtomicBool>` and silently ignore calls to `swap_buffers()` as long as this value is still false. Without this, all the glutin examples crash on wayland because the window was drawn on without being configured.

The rationale for this `Arc<AtomicBool>` rather than a simple method returning a `bool` to query the state is that the glutin context does not keep a reference to the winit `Window`, and as such would not be able to query for readiness. If you are okay with this design, I'll make a sibling PR to glutin for the appropriate changes.

The last commit also fixes a few errors in wayland protocol handling by winit found while testing this last changes.