### PR TITLE
Fix thread blocking during resize on win32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed issue of calls to `set_inner_size` blocking on Windows.
+
 # Version 0.8.2 (2017-09-28)
 
 - Uniformize keyboard scancode values accross Wayland and X11 (#297).

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -99,7 +99,7 @@ impl Window {
     pub fn set_position(&self, x: i32, y: i32) {
         unsafe {
             user32::SetWindowPos(self.window.0, ptr::null_mut(), x as raw::c_int, y as raw::c_int,
-                                 0, 0, winapi::SWP_NOZORDER | winapi::SWP_NOSIZE);
+                                 0, 0, winapi::SWP_ASYNCWINDOWPOS | winapi::SWP_NOZORDER | winapi::SWP_NOSIZE);
             user32::UpdateWindow(self.window.0);
         }
     }
@@ -147,7 +147,7 @@ impl Window {
             let outer_y = (rect.top - rect.bottom).abs() as raw::c_int;
 
             user32::SetWindowPos(self.window.0, ptr::null_mut(), 0, 0, outer_x, outer_y,
-                winapi::SWP_NOZORDER | winapi::SWP_NOREPOSITION | winapi::SWP_NOMOVE);
+                winapi::SWP_ASYNCWINDOWPOS | winapi::SWP_NOZORDER | winapi::SWP_NOREPOSITION | winapi::SWP_NOMOVE);
             user32::UpdateWindow(self.window.0);
         }
     }


### PR DESCRIPTION
Right now, this example will not terminate on windows:
```
extern crate winit;

fn main() {
    let events_loop = winit::EventsLoop::new();
    let window = winit::WindowBuilder::new().build(&events_loop).unwrap();
    window.set_inner_size(200, 200);
}
```

According to [this](https://msdn.microsoft.com/en-us/library/windows/desktop/ms633545(v=vs.85).aspx), `user32::SetWindowPos` can block if it is called from a thread other than the one that created the window, without the flag `SWP_ASYNCWINDOWPOS`. Since windows are created in the event loop background thread, calling `Window::set_inner_size` anywhere else will block the calling thread.

For some reason that is not clear to me, the same problem doesn't happen on my machine using `Window::set_position`, which also calls `user32::SetWindowPos`, so I didn't add it there, but maybe the flag should be added there as well?