### PR TITLE
Make ISO_Left_Tab generate VirtualKeyCode::Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixed issue of calls to `set_inner_size` blocking on Windows.
+- Mapped `ISO_Left_Tab` to `VirtualKeyCode::Tab` to make the key work with modifiers
 - Fixed the X11 backed on 32bit targets
 
 # Version 0.8.2 (2017-09-28)

--- a/src/platform/linux/x11/events.rs
+++ b/src/platform/linux/x11/events.rs
@@ -171,6 +171,7 @@ pub fn keysym_to_element(keysym: libc::c_uint) -> Option<VirtualKeyCode> {
         //ffi::XK_Super_R => events::VirtualKeyCode::Super_r,
         //ffi::XK_Hyper_L => events::VirtualKeyCode::Hyper_l,
         //ffi::XK_Hyper_R => events::VirtualKeyCode::Hyper_r,
+        ffi::XK_ISO_Left_Tab => events::VirtualKeyCode::Tab,
         ffi::XK_space => events::VirtualKeyCode::Space,
         //ffi::XK_exclam => events::VirtualKeyCode::Exclam,
         //ffi::XK_quotedbl => events::VirtualKeyCode::Quotedbl,


### PR DESCRIPTION
On practically all keyboard layouts on Linux, Shift+Tab generates ISO_Left_Tab. This keysym is currently ignored, so applications can't detect Shift-Tab.