### PR TITLE
wayland: commit the empty surface at init

### DIFF
--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -76,6 +76,10 @@ impl Window {
 
             decorated_id
         };
+        // send our configuration to the compositor
+        // if we're in xdg mode, no buffer is attached yet, so this
+        // is fine (and more or less required actually)
+        surface.commit();
         let me = Window {
             ctxt: ctxt,
             cleanup_signal: cleanup_signal,


### PR DESCRIPTION
This should trigger the compositor's mechanism for sending a configure event, which should most of the time be processed before any winit user actually tries to draw.

This fixes the crash of glutin examples at init under weston.