### PR TITLE
Fix X11 on 32bit architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,15 @@ install:
       if [ $TRAVIS_OS_NAME = osx ]; then
         rustup target add x86_64-apple-ios
       fi
+  - |
+      if [ $TRAVIS_OS_NAME = linux ]; then
+        rustup target add i686-unknown-linux-gnu
+      fi
 
 script:
   - cargo build --verbose
   - if [ $TRAVIS_OS_NAME = osx ]; then cargo build --target x86_64-apple-ios --verbose; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then cargo build --target i686-unknown-linux-gnu --verbose; fi
   - cargo test --verbose
 
 os:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Fixed issue of calls to `set_inner_size` blocking on Windows.
+- Fixed the X11 backed on 32bit targets
 
 # Version 0.8.2 (2017-09-28)
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -251,7 +251,7 @@ impl Window2 {
         Ok(window)
     }
 
-    fn set_netwm(display: &Arc<XConnection>, window: u64, root: u64, property: &str, val: bool) {
+    fn set_netwm(display: &Arc<XConnection>, window: ffi::Window, root: ffi::Window, property: &str, val: bool) {
         let state_atom = unsafe {
             with_c_str("_NET_WM_STATE", |state|
                 (display.xlib.XInternAtom)(display.display, state, 0)
@@ -276,7 +276,7 @@ impl Window2 {
             data: {
                 let mut data = ffi::ClientMessageData::new();
                 // This first `long` is the action; `1` means add/set following property.
-                data.set_long(0, val as i64);
+                data.set_long(0, val as c_long);
                 // This second `long` is the property to set (fullscreen)
                 data.set_long(1, atom as c_long);
                 data


### PR DESCRIPTION
One would hope 32bit X11 was dead by now but apparently not :). Fix the window hint setting code to not assume window IDs are 32bit as apparently they are not in 32bit arches.