### PR TITLE
Make MonitorId::get_position() return (i32, i32) instead of (u32, u32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added method `MonitorId::get_hidpi_factor`.
 - Deprecated `get_inner_size_pixels` and `get_inner_size_points` methods of `Window` in favor of
 `get_inner_size`.
+- `MonitorId::get_position` now returns `(i32, i32)` instead of `(u32, u32)`.
 
 # Version 0.8.3 (2017-10-11)
 

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -160,7 +160,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         // Android assumes single screen
         (0, 0)
     }

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -34,7 +34,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         unimplemented!()
     }
 

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -141,7 +141,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         // iOS assumes single screen
         (0, 0)
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -88,7 +88,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         match self {
             &MonitorId::X(ref m) => m.get_position(),
             &MonitorId::Wayland(ref m) => m.get_position(),
@@ -97,7 +97,10 @@ impl MonitorId {
 
     #[inline]
     pub fn get_hidpi_factor(&self) -> f32 {
-        1.0
+        match self {
+            &MonitorId::X(ref m) => m.get_hidpi_factor(),
+            &MonitorId::Wayland(ref m) => m.get_hidpi_factor(),
+        }
     }
 }
 

--- a/src/platform/linux/wayland/context.rs
+++ b/src/platform/linux/wayland/context.rs
@@ -37,7 +37,7 @@ struct OutputInfo {
     id: u32,
     scale: f32,
     pix_size: (u32, u32),
-    pix_pos: (u32, u32),
+    pix_pos: (i32, i32),
     name: String
 }
 
@@ -162,7 +162,7 @@ impl wl_output::Handler for WaylandEnv {
     {
         for m in self.monitors.iter_mut().filter(|m| m.output.equals(proxy)) {
             m.name = format!("{} ({})", model, make);
-            m.pix_pos = (x as u32, y as u32);
+            m.pix_pos = (x, y);
             break;
         }
     }
@@ -397,7 +397,7 @@ impl MonitorId {
         (0,0)
     }
 
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         let mut guard = self.ctxt.evq.lock().unwrap();
         let state = guard.state();
         let env = state.get_handler::<WaylandEnv>(self.ctxt.env_id);

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -204,6 +204,8 @@ impl Window {
         let mut find = default;
         for monitor in monitors {
             let (mx, my) = monitor.get_position();
+            let mx = mx as u32;
+            let my = my as u32;
             let (mw, mh) = monitor.get_dimensions();
             let (mxo, myo) = (mx+mw-1, my+mh-1);
             let (ox, oy) = (cmp::max(wx, mx), cmp::max(wy, my));

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -12,7 +12,7 @@ pub struct MonitorId {
     /// The size of the monitor
     dimensions: (u32, u32),
     /// The position of the monitor in the X screen
-    position: (u32, u32),
+    position: (i32, i32),
     /// If the monitor is the primary one
     primary: bool,
 }
@@ -40,7 +40,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
                     id: i as u32,
                     name,
                     dimensions: (monitor.width as u32, monitor.height as u32),
-                    position: (monitor.x as u32, monitor.y as u32),
+                    position: (monitor.x as i32, monitor.y as i32),
                     primary: (monitor.primary != 0),
                 });
             }
@@ -61,7 +61,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> Vec<MonitorId> {
                         id: crtcid as u32,
                         name,
                         dimensions: ((*crtc).width as u32, (*crtc).height as u32),
-                        position: ((*crtc).x as u32, (*crtc).y as u32),
+                        position: ((*crtc).x as i32, (*crtc).y as i32),
                         primary: true,
                     });
                 }
@@ -98,7 +98,7 @@ impl MonitorId {
         self.dimensions
     }
 
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         self.position
     }
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -332,6 +332,8 @@ impl Window2 {
         let mut find = default;
         for monitor in monitors {
             let (mx, my) = monitor.get_position();
+            let mx = mx as u32;
+            let my = my as u32;
             let (mw, mh) = monitor.get_dimensions();
             let (mxo, myo) = (mx+mw-1, my+mh-1);
             let (ox, oy) = (cmp::max(wx, mx), cmp::max(wy, my));

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -50,7 +50,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         unimplemented!()
     }
 

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -27,8 +27,8 @@ pub struct MonitorId {
 
     /// The position of the monitor in pixels on the desktop.
     ///
-    /// A window that is positionned at these coordinates will overlap the monitor.
-    position: (u32, u32),
+    /// A window that is positioned at these coordinates will overlap the monitor.
+    position: (i32, i32),
 
     /// The current resolution in pixels on the monitor.
     dimensions: (u32, u32),
@@ -111,7 +111,7 @@ impl EventsLoop {
                 }
 
                 let point: &winapi::POINTL = mem::transmute(&dev.union1);
-                let position = (point.x as u32, point.y as u32);
+                let position = (point.x as i32, point.y as i32);
 
                 let dimensions = (dev.dmPelsWidth as u32, dev.dmPelsHeight as u32);
 
@@ -176,9 +176,9 @@ impl MonitorId {
         &self.adapter_name
     }
 
-    /// A window that is positionned at these coordinates will overlap the monitor.
+    /// A window that is positioned at these coordinates will overlap the monitor.
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         self.position
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -370,7 +370,7 @@ impl MonitorId {
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
     #[inline]
-    pub fn get_position(&self) -> (u32, u32) {
+    pub fn get_position(&self) -> (i32, i32) {
         self.inner.get_position()
     }
 


### PR DESCRIPTION
At least on Windows monitor position can be negative. Primary monitor always has position (0, 0), if there is a monitor to the left or to the top of it then it will have negative position.

For the sake of experiment I configured my monitors as follows:

![image](https://user-images.githubusercontent.com/11528855/31724347-2372b8ee-b42a-11e7-9a92-8a3ebe27354d.png)

Winit reports the following:

Without these changes:
Monitor 1: size = (3840, 2160), pos = (0, 0)
Monitor 2: size = (1920, 1080), pos = (0, 4294966216)

With these changes:
Monitor 1: size = (3840, 2160), pos = (0, 0)
Monitor 2: size = (1920, 1080), pos = (0, -1080)

