### PR TITLE
wayland: Fix drop order for display

### DIFF
--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -55,8 +55,6 @@ impl EventsLoopSink {
 }
 
 pub struct EventsLoop {
-    // The wayland display
-    pub display: Arc<wl_display::WlDisplay>,
     // The Event Queue
     pub evq: RefCell<EventQueue>,
     // our sink, shared with some handlers, buffering the events
@@ -70,7 +68,9 @@ pub struct EventsLoop {
     // the ctxt
     pub ctxt_token: StateToken<StateContext>,
     // a cleanup switch to prune dead windows
-    pub cleanup_needed: Arc<Mutex<bool>>
+    pub cleanup_needed: Arc<Mutex<bool>>,
+    // The wayland display
+    pub display: Arc<wl_display::WlDisplay>,
 }
 
 // A handle that can be sent across threads and used to wake up the `EventsLoop`.

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -12,13 +12,13 @@ use super::wayland_window::{DecoratedSurface, DecoratedSurfaceImplementation};
 use super::event_loop::StateContext;
 
 pub struct Window {
-    display: Arc<wl_display::WlDisplay>,
     surface: wl_surface::WlSurface,
     decorated: Arc<Mutex<DecoratedSurface>>,
     monitors: Arc<Mutex<MonitorList>>,
     ready: Arc<Mutex<bool>>,
     size: Arc<Mutex<(u32, u32)>>,
     kill_switch: (Arc<Mutex<bool>>, Arc<Mutex<bool>>),
+    display: Arc<wl_display::WlDisplay>,
 }
 
 impl Window {


### PR DESCRIPTION
This ensures the `WlDisplay` is the last thing to be dropped, whatever the order in which the `EventsLoop` or `Window`s are dropped (thanks to [RFC#1857](https://github.com/rust-lang/rfcs/blob/master/text/1857-stabilize-drop-order.md) we can rely on this drop order).

Not doing so could lead in a winit program segfaulting on exit when all its destructors are run, rather than exiting cleanly. This is because dropping the `WlDisplay` kills the wayland connection and frees its resources, so it must be the last wayland thing to be dropped.