### PR TITLE
Derive Clone for EventsLoopProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `MonitorId::get_position` now returns `(i32, i32)` instead of `(u32, u32)`.
 - Rewrite of the wayland backend to use wayland-client-0.11
 - Support for dead keys on wayland for keyboard utf8 input
+- Impl `Clone` for `EventsLoopProxy`
 
 # Version 0.8.3 (2017-10-11)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ impl EventsLoop {
 }
 
 /// Used to wake up the `EventsLoop` from another thread.
+#[derive(Clone)]
 pub struct EventsLoopProxy {
     events_loop_proxy: platform::EventsLoopProxy,
 }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -20,6 +20,7 @@ pub struct EventsLoop {
     event_rx: Receiver<android_glue::Event>,
 }
 
+#[derive(Clone)]
 pub struct EventsLoopProxy;
 
 impl EventsLoop {

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -68,6 +68,7 @@ pub fn set_main_loop_callback<F>(callback : F) where F : FnMut() {
     }
 }
 
+#[derive(Clone)]
 pub struct EventsLoopProxy;
 
 impl EventsLoopProxy {

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -156,6 +156,7 @@ pub struct EventsLoop {
     delegate_state: *mut DelegateState
 }
 
+#[derive(Clone)]
 pub struct EventsLoopProxy;
 
 impl EventsLoop {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -297,6 +297,7 @@ pub enum EventsLoop {
     X(x11::EventsLoop)
 }
 
+#[derive(Clone)]
 pub enum EventsLoopProxy {
     X(x11::EventsLoopProxy),
     Wayland(wayland::EventsLoopProxy),

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -76,6 +76,7 @@ pub struct EventsLoop {
 // A handle that can be sent across threads and used to wake up the `EventsLoop`.
 //
 // We should only try and wake up the `EventsLoop` if it still exists, so we hold Weak ptrs.
+#[derive(Clone)]
 pub struct EventsLoopProxy {
     display: Weak<wl_display::WlDisplay>,
     pending_wakeup: Weak<AtomicBool>,

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -43,6 +43,7 @@ pub struct EventsLoop {
     wakeup_dummy_window: ffi::Window,
 }
 
+#[derive(Clone)]
 pub struct EventsLoopProxy {
     pending_wakeup: Weak<AtomicBool>,
     display: Weak<XConnection>,

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -29,6 +29,7 @@ pub struct Shared {
     user_callback: UserCallback,
 }
 
+#[derive(Clone)]
 pub struct Proxy {}
 
 struct Modifiers {

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -243,6 +243,7 @@ impl Drop for EventsLoop {
     }
 }
 
+#[derive(Clone)]
 pub struct EventsLoopProxy {
     thread_id: winapi::DWORD,
 }


### PR DESCRIPTION
For context, this is needed to use winit with the latest webrender, which needs to wake up the event loop from a `RenderNotifier` which must be both `Send` and `Clone`. Servo doesn't have this issue because it still uses an old version of glutin with `WindowProxy` which can be cloned.