### PR TITLE
wayland: upgrade wayland-window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,4 @@ wayland-client = { version = "0.12.0", features = ["dlopen"] }
 wayland-protocols = { version = "0.12.0", features = ["unstable_protocols"] }
 wayland-kbd = "0.13.0"
 wayland-window = "0.13.0"
-tempfile = "2.1"
 x11-dl = "2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ dwmapi-sys = "0.1"
 wayland-client = { version = "0.12.0", features = ["dlopen"] }
 wayland-protocols = { version = "0.12.0", features = ["unstable_protocols"] }
 wayland-kbd = "0.13.0"
-wayland-window = "0.12.0"
+wayland-window = "0.13.0"
 tempfile = "2.1"
 x11-dl = "2.8"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -11,12 +11,6 @@ fn main() {
     let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::NoneCursor, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];
     let mut cursor_idx = 0;
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         match event {
             Event::WindowEvent { event: WindowEvent::KeyboardInput { input: KeyboardInput { state: ElementState::Pressed, .. }, .. }, .. } => {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -31,12 +31,6 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -10,12 +10,6 @@ fn main() {
 
     let mut grabbed = false;
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -9,12 +9,6 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -9,12 +9,6 @@ fn main() {
 
     let mut num_windows = 3;
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         match event {
             winit::Event::WindowEvent { event: winit::WindowEvent::Closed, window_id } => {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -10,12 +10,6 @@ fn main() {
 
     let proxy = events_loop.create_proxy();
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     std::thread::spawn(move || {
         // Wake up the `events_loop` once every second.
         loop {

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -9,12 +9,6 @@ fn main() {
 
     window.set_title("A fantastic window!");
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,12 +8,6 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
-    if cfg!(target_os = "linux") {
-        println!("Running this example under wayland may not display a window at all.\n\
-                  This is normal and because this example does not actually draw anything in the window,\
-                  thus the compositor does not display it.");
-    }
-
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -121,13 +121,11 @@ pub trait WindowExt {
 
     /// Check if the window is ready for drawing
     ///
-    /// On wayland, drawing on a surface before the server has configured
-    /// it using a special event is illegal. As a result, you should wait
-    /// until this method returns `true`.
+    /// It is a remnant of a previous implementation detail for the
+    /// wayland backend, and is no longer relevant.
     ///
-    /// Once it starts returning `true`, it can never return `false` again.
-    ///
-    /// If the window is X11-based, this will just always return `true`.
+    /// Always return true.
+    #[deprecated]
     fn is_ready(&self) -> bool;
 }
 
@@ -195,10 +193,7 @@ impl WindowExt for Window {
 
     #[inline]
     fn is_ready(&self) -> bool {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => w.is_ready(),
-            LinuxWindow::X(_) => true
-        }
+        true
     }
 }
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -1,8 +1,5 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::fs::File;
-use std::io::Write;
-use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Mutex, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -14,13 +11,11 @@ use super::keyboard::init_keyboard;
 
 use wayland_client::{EnvHandler, EnvNotify, default_connect, EventQueue, EventQueueHandle, Proxy, StateToken};
 use wayland_client::protocol::{wl_compositor, wl_seat, wl_shell, wl_shm, wl_subcompositor,
-                               wl_display, wl_registry, wl_output, wl_surface, wl_buffer,
+                               wl_display, wl_registry, wl_output, wl_surface,
                                wl_pointer, wl_keyboard};
 
 use super::wayland_window::{Frame, Shell, create_frame, FrameImplementation};
 use super::wayland_protocols::unstable::xdg_shell::v6::client::zxdg_shell_v6;
-
-use super::tempfile;
 
 pub struct EventsLoopSink {
     buffer: VecDeque<::Event>

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -6,7 +6,6 @@ pub use self::event_loop::{EventsLoop, EventsLoopProxy, EventsLoopSink, MonitorI
 extern crate wayland_kbd;
 extern crate wayland_window;
 extern crate wayland_protocols;
-extern crate tempfile;
 
 use wayland_client::protocol::wl_surface;
 use wayland_client::Proxy;


### PR DESCRIPTION
This new version of wayland window considerably simplifies the window handling for winit, meaning much of the previous juggling is no longer needed, and the windows will appear even if nothing is drawn.

This also brings some shiny features, such as actual buttons for minimize/maximize/close being displayed, and the color of the border changing depending on whether the window is active or not!

Note that with this, the linux-specific `os::unix::WindowExt::is_ready()` is no longer needed. This PR simply stubs it out by always returning `true`, and marking it as deprecated. Though given next winit release already contains breaking changes, we can also consider removing it.