### PR TITLE
Fix docs rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,8 +443,8 @@ pub struct WindowAttributes {
     /// The default is `true`.
     pub decorations: bool,
 
-    /// [iOS only] Enable multitouch, see [UIView#multipleTouchEnabled]
-    /// (https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/instp/UIView/multipleTouchEnabled)
+    /// [iOS only] Enable multitouch,
+    /// see [multipleTouchEnabled](https://developer.apple.com/documentation/uikit/uiview/1622519-multipletouchenabled)
     pub multitouch: bool,
 }
 


### PR DESCRIPTION
Generating the crate's docs on the latest nightly produces the following warning:

```
WARNING: documentation for this crate may be rendered differently using the new Pulldown renderer.
    See https://github.com/rust-lang/rust/issues/44229 for details.

WARNING: rendering difference in `[iOS only] Enable multitouch, see [UIView#multipleTouchEnabled]`
```

Basically, the new docs parser requires a link's `[ ]` to be on the same line as the `( )`. This pull request fixes that. Also updated the link, since it linked to an unexistent page.