### PR TITLE
Implement hidpi support for wayland

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -110,7 +110,7 @@ impl MonitorId {
     pub fn get_hidpi_factor(&self) -> f32 {
         match self {
             &MonitorId::X(ref m) => m.get_hidpi_factor(),
-            &MonitorId::Wayland(ref m) => m.get_hidpi_factor(),
+            &MonitorId::Wayland(ref m) => m.get_hidpi_factor() as f32,
         }
     }
 }

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -250,12 +250,13 @@ impl EventsLoop {
         }
         // process pending resize/refresh
         self.store.lock().unwrap().for_each(
-            |newsize, refresh, frame_refresh, closed, wid, frame| {
+            |newsize, size, refresh, frame_refresh, closed, wid, frame| {
                 if let Some(frame) = frame {
                     if let Some((w, h)) = newsize {
-                        frame.resize(w as u32, h as u32);
+                        frame.resize(w, h);
                         frame.refresh();
-                        sink.send_event(::WindowEvent::Resized(w as u32, h as u32), wid);
+                        sink.send_event(::WindowEvent::Resized(w, h), wid);
+                        *size = (w, h);
                     } else if frame_refresh {
                         frame.refresh();
                     }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -6,7 +6,7 @@ use window::MonitorId as RootMonitorId;
 
 use sctk::window::{BasicFrame, Event as WEvent, Window as SWindow};
 use sctk::reexports::client::{Display, Proxy};
-use sctk::reexports::client::protocol::{wl_seat, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_surface, wl_output};
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 
@@ -15,7 +15,7 @@ use super::{make_wid, EventsLoop, MonitorId, WindowId};
 pub struct Window {
     surface: Proxy<wl_surface::WlSurface>,
     frame: Arc<Mutex<SWindow<BasicFrame>>>,
-    monitors: Arc<Mutex<Vec<MonitorId>>>,
+    monitors: Arc<Mutex<MonitorList>>,
     size: Arc<Mutex<(u32, u32)>>,
     kill_switch: (Arc<Mutex<bool>>, Arc<Mutex<bool>>),
     display: Arc<Display>,
@@ -29,18 +29,35 @@ impl Window {
         let size = Arc::new(Mutex::new((width, height)));
 
         // monitor tracking
-        let monitor_list = Arc::new(Mutex::new(Vec::new()));
+        let monitor_list = Arc::new(Mutex::new(MonitorList::new()));
 
         let surface = evlp.env.compositor.create_surface().unwrap().implement({
             let list = monitor_list.clone();
             let omgr = evlp.env.outputs.clone();
-            move |event, _| match event {
-                wl_surface::Event::Enter { output } => list.lock().unwrap().push(MonitorId {
-                    proxy: output,
-                    mgr: omgr.clone(),
-                }),
+            let window_store = evlp.store.clone();
+            move |event, surface: Proxy<wl_surface::WlSurface>| match event {
+                wl_surface::Event::Enter { output } => {
+                    let dpi_change = list.lock().unwrap().add_output(MonitorId {
+                        proxy: output,
+                        mgr: omgr.clone(),
+                    });
+                    if let Some(dpi) = dpi_change {
+                        if surface.version() >= 3 {
+                            // without version 3 we can't be dpi aware
+                            window_store.lock().unwrap().dpi_change(&surface, dpi);
+                            surface.set_buffer_scale(dpi);
+                        }
+                    }
+                },
                 wl_surface::Event::Leave { output } => {
-                    list.lock().unwrap().retain(|m| !m.proxy.equals(&output));
+                    let dpi_change = list.lock().unwrap().del_output(&output);
+                    if let Some(dpi) = dpi_change {
+                        if surface.version() >= 3 {
+                            // without version 3 we can't be dpi aware
+                            window_store.lock().unwrap().dpi_change(&surface, dpi);
+                            surface.set_buffer_scale(dpi);
+                        }
+                    }
                 }
             }
         });
@@ -121,6 +138,8 @@ impl Window {
             surface: surface.clone(),
             kill_switch: kill_switch.clone(),
             frame: Arc::downgrade(&frame),
+            current_dpi: 1,
+            new_dpi: None,
         });
         evlp.evq.borrow_mut().sync_roundtrip().unwrap();
 
@@ -185,6 +204,9 @@ impl Window {
     #[inline]
     // NOTE: This will only resize the borders, the contents must be updated by the user
     pub fn set_inner_size(&self, x: u32, y: u32) {
+        let dpi = self.monitors.lock().unwrap().compute_hidpi_factor();
+        let x = x / dpi as u32;
+        let y = y / dpi as u32;
         self.frame.lock().unwrap().resize(x, y);
         *(self.size.lock().unwrap()) = (x, y);
     }
@@ -217,13 +239,7 @@ impl Window {
 
     #[inline]
     pub fn hidpi_factor(&self) -> f32 {
-        let mut factor: f32 = 1.0;
-        let guard = self.monitors.lock().unwrap();
-        for monitor_id in guard.iter() {
-            let hidpif = monitor_id.get_hidpi_factor();
-            factor = factor.max(hidpif);
-        }
-        factor
+        self.monitors.lock().unwrap().compute_hidpi_factor() as f32
     }
 
     pub fn set_decorations(&self, decorate: bool) {
@@ -271,7 +287,7 @@ impl Window {
         // we don't know how much each monitor sees us so...
         // just return the most recent one ?
         let guard = self.monitors.lock().unwrap();
-        guard.last().unwrap().clone()
+        guard.monitors.last().unwrap().clone()
     }
 }
 
@@ -295,6 +311,8 @@ struct InternalWindow {
     closed: bool,
     kill_switch: Arc<Mutex<bool>>,
     frame: Weak<Mutex<SWindow<BasicFrame>>>,
+    current_dpi: i32,
+    new_dpi: Option<i32>
 }
 
 pub struct WindowStore {
@@ -340,9 +358,17 @@ impl WindowStore {
         }
     }
 
+    fn dpi_change(&mut self, surface: &Proxy<wl_surface::WlSurface>, new: i32) {
+        for window in &mut self.windows {
+            if surface.equals(&window.surface) {
+                window.new_dpi = Some(new);
+            }
+        }
+    }
+
     pub fn for_each<F>(&mut self, mut f: F)
     where
-        F: FnMut(Option<(u32, u32)>, &mut (u32, u32), bool, bool, bool, WindowId, Option<&mut SWindow<BasicFrame>>),
+        F: FnMut(Option<(u32, u32)>, &mut (u32, u32), i32, Option<i32>, bool, bool, bool, WindowId, Option<&mut SWindow<BasicFrame>>),
     {
         for window in &mut self.windows {
             let opt_arc = window.frame.upgrade();
@@ -350,15 +376,67 @@ impl WindowStore {
             f(
                 window.newsize.take(),
                 &mut *(window.size.lock().unwrap()),
+                window.current_dpi,
+                window.new_dpi,
                 window.need_refresh,
                 ::std::mem::replace(&mut *window.need_frame_refresh.lock().unwrap(), false),
                 window.closed,
                 make_wid(&window.surface),
                 opt_mutex_lock.as_mut().map(|m| &mut **m),
             );
+            if let Some(dpi) = window.new_dpi.take() {
+                window.current_dpi = dpi;
+            }
             window.need_refresh = false;
             // avoid re-spamming the event
             window.closed = false;
+        }
+    }
+}
+
+/*
+ * Monitor list with some covenience method to compute DPI
+ */
+
+struct MonitorList {
+    monitors: Vec<MonitorId>
+}
+
+impl MonitorList {
+    fn new() -> MonitorList {
+        MonitorList {
+            monitors: Vec::new()
+        }
+    }
+
+    fn compute_hidpi_factor(&self) -> i32 {
+        let mut factor = 1;
+        for monitor_id in &self.monitors {
+            let monitor_dpi = monitor_id.get_hidpi_factor();
+            if monitor_dpi > factor { factor = monitor_dpi; }
+        }
+        factor
+    }
+
+    fn add_output(&mut self, monitor: MonitorId) -> Option<i32> {
+        let old_dpi = self.compute_hidpi_factor();
+        let monitor_dpi = monitor.get_hidpi_factor();
+        self.monitors.push(monitor);
+        if monitor_dpi > old_dpi {
+            Some(monitor_dpi)
+        } else {
+            None
+        }
+    }
+
+    fn del_output(&mut self, output: &Proxy<wl_output::WlOutput>) -> Option<i32> {
+        let old_dpi = self.compute_hidpi_factor();
+        self.monitors.retain(|m| !m.proxy.equals(output));
+        let new_dpi = self.compute_hidpi_factor();
+        if new_dpi != old_dpi {
+            Some(new_dpi)
+        } else {
+            None
         }
     }
 }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -326,15 +326,6 @@ impl WindowStore {
         }
     }
 
-    pub fn find_wid(&self, surface: &Proxy<wl_surface::WlSurface>) -> Option<WindowId> {
-        for window in &self.windows {
-            if surface.equals(&window.surface) {
-                return Some(make_wid(surface));
-            }
-        }
-        None
-    }
-
     pub fn cleanup(&mut self) -> Vec<WindowId> {
         let mut pruned = Vec::new();
         self.windows.retain(|w| {
@@ -364,6 +355,15 @@ impl WindowStore {
                 window.new_dpi = Some(new);
             }
         }
+    }
+
+    pub fn get_dpi(&self, surface: &Proxy<wl_surface::WlSurface>) -> i32 {
+        for window in &self.windows {
+            if surface.equals(&window.surface) {
+                return window.current_dpi;
+            }
+        }
+        return 1;
     }
 
     pub fn for_each<F>(&mut self, mut f: F)


### PR DESCRIPTION
This fixes as few bug regarding size managing in wayland and implements proper HiDPI support.

This follows the workflow as I described in https://github.com/tomaka/winit/issues/105#issuecomment-341964817 :

1. the window is created with requested size assuming a 1.0 dpi factor
2. once the dpi is known, appropriate `HiDPIFactorChanged` and `Resized` events are generated.

As this kind of behavior should be uniform over platforms, I think we need to decide what we wish to do regarding that before merging this PR or #332 