### PR TITLE
Send mouse position after focused/cursorenter events

### DIFF
--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -464,7 +464,7 @@ impl EventsLoop {
 
                         let new_cursor_pos = (xev.event_x, xev.event_y);
                         callback(Event::WindowEvent { window_id: wid, event: CursorMoved {
-                            device_id: did,
+                            device_id: mkdid(xev.deviceid),
                             position: new_cursor_pos
                         }})
                     }

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -483,7 +483,7 @@ impl EventsLoop {
 
                         let new_cursor_pos = (xev.event_x, xev.event_y);
                         callback(Event::WindowEvent { window_id: wid, event: CursorMoved {
-                            device_id: did,
+                            device_id: mkdid(xev.deviceid),
                             position: new_cursor_pos
                         }})
                     }

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -460,8 +460,13 @@ impl EventsLoop {
                                 physical_device.reset_scroll_position(info);
                             }
                         }
+                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: CursorEntered { device_id: mkdid(xev.deviceid) } });
 
-                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: CursorEntered { device_id: mkdid(xev.deviceid) } })
+                        let new_cursor_pos = (xev.event_x, xev.event_y);
+                        callback(Event::WindowEvent { window_id: wid, event: CursorMoved {
+                            device_id: did,
+                            position: new_cursor_pos
+                        }})
                     }
                     ffi::XI_Leave => {
                         let xev: &ffi::XILeaveEvent = unsafe { &*(xev.data as *const _) };
@@ -474,7 +479,13 @@ impl EventsLoop {
                             let window_data = windows.get_mut(&WindowId(xev.event)).unwrap();
                             (self.display.xlib.XSetICFocus)(window_data.ic);
                         }
-                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: Focused(true) })
+                        callback(Event::WindowEvent { window_id: mkwid(xev.event), event: Focused(true) });
+
+                        let new_cursor_pos = (xev.event_x, xev.event_y);
+                        callback(Event::WindowEvent { window_id: wid, event: CursorMoved {
+                            device_id: did,
+                            position: new_cursor_pos
+                        }})
                     }
                     ffi::XI_FocusOut => {
                         let xev: &ffi::XIFocusOutEvent = unsafe { &*(xev.data as *const _) };

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -463,9 +463,8 @@ impl EventsLoop {
                 let x = (scale_factor * view_point.x as f32) as f64;
                 let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
                 let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
-                let events = vec![Event::WindowEvent { window_id: ::WindowId(window.id()), event: window_event }];
 
-                self.shared.pending_events.lock().unwrap().extend(events.into_iter());
+                self.shared.pending_events.lock().unwrap().extend(window_event);
                 Some(into_event(WindowEvent::CursorEntered { device_id: DEVICE_ID }))
             },
             appkit::NSMouseExited => { Some(into_event(WindowEvent::CursorLeft { device_id: DEVICE_ID })) },

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -460,15 +460,10 @@ impl EventsLoop {
                 let view_rect = NSView::frame(*window.view);
                 let scale_factor = window.hidpi_factor();
 
-                let mut events = std::collections::VecDeque::new();
-
-                {
-                    let x = (scale_factor * view_point.x as f32) as f64;
-                    let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
-                    let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
-                    let event = Event::WindowEvent { window_id: ::WindowId(window.id()), event: window_event };
-                    events.push_back(event);
-                }
+                let x = (scale_factor * view_point.x as f32) as f64;
+                let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
+                let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
+                let events = vec![Event::WindowEvent { window_id: ::WindowId(window.id()), event: window_event }];
 
                 self.shared.pending_events.lock().unwrap().extend(events.into_iter());
                 Some(into_event(WindowEvent::CursorEntered { device_id: DEVICE_ID }))

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -463,8 +463,9 @@ impl EventsLoop {
                 let x = (scale_factor * view_point.x as f32) as f64;
                 let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
                 let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
+                let event = Event::WindowEvent { window_id: ::WindowId(window.id()), event: window_event };
 
-                self.shared.pending_events.lock().unwrap().push_back(window_event);
+                self.shared.pending_events.lock().unwrap().push_back(event);
                 Some(into_event(WindowEvent::CursorEntered { device_id: DEVICE_ID }))
             },
             appkit::NSMouseExited => { Some(into_event(WindowEvent::CursorLeft { device_id: DEVICE_ID })) },

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -464,7 +464,7 @@ impl EventsLoop {
                 let y = (scale_factor * (view_rect.size.height - view_point.y) as f32) as f64;
                 let window_event = WindowEvent::CursorMoved { device_id: DEVICE_ID, position: (x, y) };
 
-                self.shared.pending_events.lock().unwrap().extend(window_event);
+                self.shared.pending_events.lock().unwrap().push_back(window_event);
                 Some(into_event(WindowEvent::CursorEntered { device_id: DEVICE_ID }))
             },
             appkit::NSMouseExited => { Some(into_event(WindowEvent::CursorLeft { device_id: DEVICE_ID })) },

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -669,6 +669,14 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
                 window_id: SuperWindowId(WindowId(window)),
                 event: Focused(true)
             });
+
+            let x = winapi::GET_X_LPARAM(lparam) as f64;
+            let y = winapi::GET_Y_LPARAM(lparam) as f64;
+
+            send_event(Event::WindowEvent {
+                window_id: SuperWindowId(WindowId(window)),
+                event: CursorMoved { device_id: DEVICE_ID, position: (x, y) },
+            });
             0
         },
 

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -664,7 +664,7 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
         },
 
         winapi::WM_SETFOCUS => {
-            use events::WindowEvent::Focused;
+            use events::WindowEvent::{Focused, CursorMoved};
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: Focused(true)


### PR DESCRIPTION
This is a first pass at updating the mouse's position after a CursorEntered/Focused event. I ran `cargo test` but haven't done any manual testing.

There's a lot of copy/paste in the macos code. I'm also not sure how best to send a second event in that situation.

fixes #348 