### PR TITLE
Fix macOS window sizes to follow convention

### DIFF
--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -522,22 +522,25 @@ impl Window2 {
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         unsafe {
             let view_frame = NSView::frame(*self.view);
-            Some((view_frame.size.width as u32, view_frame.size.height as u32))
+            let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
+            Some(((view_frame.size.width*factor) as u32, (view_frame.size.height*factor) as u32))
         }
     }
 
     #[inline]
     pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
         unsafe {
             let window_frame = NSWindow::frame(*self.window);
-            Some((window_frame.size.width as u32, window_frame.size.height as u32))
+            Some(((window_frame.size.width*factor) as u32, (window_frame.size.height*factor) as u32))
         }
     }
 
     #[inline]
     pub fn set_inner_size(&self, width: u32, height: u32) {
+        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
         unsafe {
-            NSWindow::setContentSize_(*self.window, NSSize::new(width as f64, height as f64));
+            NSWindow::setContentSize_(*self.window, NSSize::new((width as f64)/factor, (height as f64)/factor));
         }
     }
 


### PR DESCRIPTION
In https://github.com/tomaka/winit/commit/48902297b7bd02fc20f3ae7012074c6b93674980 the `get_inner_size_pixels` method was changed to assume that platform implementations return their sizes in physical pixels rather than points. 

The Linux implementation was updated to reflect this but the macOS implementation was not, leading to the `get_inner_size_pixels` returning size in layout points and the `get_inner_size_points` method returning a size that doesn't correspond to anything.

This PR updates the macOS implementation to follow the convention.

I didn't update the window min and max size APIs, they are still in points, which I think is correct since the user of the library can't even know if they have to adjust their sizes until the window is created and they can check the hidpi factor. That's a problem with going all physical pixels I guess, you actually can't reasonably do so everywhere.

cc @kryptan @mitchmindtree @tomaka 