### PR TITLE
x11: Send window maximization hints correctly

### DIFF
--- a/src/platform/linux/x11/dnd.rs
+++ b/src/platform/linux/x11/dnd.rs
@@ -55,7 +55,9 @@ impl DndAtoms {
             );
         }
         xconn.check_errors()?;
-        unsafe { atoms.set_len(DND_ATOMS_LEN); }
+        unsafe {
+            atoms.set_len(DND_ATOMS_LEN);
+        }
         Ok(DndAtoms {
             aware: atoms[0],
             enter: atoms[1],
@@ -137,7 +139,7 @@ impl Dnd {
         this_window: c_ulong,
         target_window: c_ulong,
         state: DndState,
-    ) {
+    ) -> Result<(), XError> {
         let (accepted, action) = match state {
             DndState::Accepted => (1, self.atoms.action_private as c_long),
             DndState::Rejected => (0, self.atoms.none as c_long),
@@ -145,9 +147,11 @@ impl Dnd {
         util::send_client_msg(
             &self.xconn,
             target_window,
+            target_window,
             self.atoms.status,
+            None,
             (this_window as c_long, accepted, 0, 0, action),
-        );
+        )
     }
 
     pub unsafe fn send_finished(
@@ -155,7 +159,7 @@ impl Dnd {
         this_window: c_ulong,
         target_window: c_ulong,
         state: DndState,
-    ) {
+    ) -> Result<(), XError> {
         let (accepted, action) = match state {
             DndState::Accepted => (1, self.atoms.action_private as c_long),
             DndState::Rejected => (0, self.atoms.none as c_long),
@@ -163,9 +167,11 @@ impl Dnd {
         util::send_client_msg(
             &self.xconn,
             target_window,
+            target_window,
             self.atoms.finished,
+            None,
             (this_window as c_long, accepted, action, 0, 0),
-        );
+        )
     }
 
     pub unsafe fn get_type_list(

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -276,12 +276,15 @@ impl EventsLoop {
                                 // This results in the SelectionNotify event below
                                 self.dnd.convert_selection(xwindow, time);
                             }
-                            self.dnd.send_status(xwindow, source_window, DndState::Accepted);
+                            self.dnd.send_status(xwindow, source_window, DndState::Accepted)
+                                .expect("Failed to send XDnD status message.");
                         }
                     } else {
                         unsafe {
-                            self.dnd.send_status(xwindow, source_window, DndState::Rejected);
-                            self.dnd.send_finished(xwindow, source_window, DndState::Rejected);
+                            self.dnd.send_status(xwindow, source_window, DndState::Rejected)
+                                .expect("Failed to send XDnD status message.");
+                            self.dnd.send_finished(xwindow, source_window, DndState::Rejected)
+                                .expect("Failed to send XDnD finished message.");
                         }
                         self.dnd.reset();
                     }
@@ -296,7 +299,8 @@ impl EventsLoop {
                             }
                         }
                         unsafe {
-                            self.dnd.send_finished(xwindow, source_window, DndState::Accepted);
+                            self.dnd.send_finished(xwindow, source_window, DndState::Accepted)
+                                .expect("Failed to send XDnD finished message.");
                         }
                     }
                     self.dnd.reset();


### PR DESCRIPTION
Previously, the maximization hints were being sent as two separate client messages: one for horizontal, and one for vertical. That resulted in the window only being maximized horizontally (at least with my WM). The corrected client message sets both of these hints at once.

In the process of implementing that, the relevant components were refactored to use the util module, as we gradually move towards a hopeful future of a more readable X11 backend.