### PR TITLE
unix::WindowExt no longer returns pointers for things that aren't actually pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for `Touch` for emscripten backend.
 - Added support for `DroppedFile`, `HoveredFile`, and `HoveredFileCancelled` to X11 backend.
+- **Breaking:** `unix::WindowExt` no longer returns pointers for things that aren't actually pointers; `get_xlib_window` now returns `Option<std::os::raw::c_ulong>` and `get_xlib_screen_id` returns `Option<std::os::raw::c_int>`. Additionally, methods that previously returned `libc::c_void` have been changed to return `std::os::raw::c_void`, which are not interchangeable types, so users wanting the former will need to explicitly cast.
 
 # Version 0.9.0 (2017-12-01)
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,8 +1,8 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
+use std::os::raw;
 use std::sync::Arc;
 use std::ptr;
-use libc;
 use EventsLoop;
 use MonitorId;
 use Window;
@@ -78,46 +78,44 @@ impl EventsLoopExt for EventsLoop {
 
 /// Additional methods on `Window` that are specific to Unix.
 pub trait WindowExt {
-    /// Returns a pointer to the `Window` object of xlib that is used by this window.
+    /// Returns the ID of the `Window` xlib object that is used by this window.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    ///
-    /// The pointer will become invalid when the glutin `Window` is destroyed.
-    fn get_xlib_window(&self) -> Option<*mut libc::c_void>;
+    fn get_xlib_window(&self) -> Option<raw::c_ulong>;
 
     /// Returns a pointer to the `Display` object of xlib that is used by this window.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
-    fn get_xlib_display(&self) -> Option<*mut libc::c_void>;
+    fn get_xlib_display(&self) -> Option<*mut raw::c_void>;
 
-    fn get_xlib_screen_id(&self) -> Option<*mut libc::c_void>;
+    fn get_xlib_screen_id(&self) -> Option<raw::c_int>;
 
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>>;
 
     fn send_xim_spot(&self, x: i16, y: i16);
-    
+
     /// This function returns the underlying `xcb_connection_t` of an xlib `Display`.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
-    fn get_xcb_connection(&self) -> Option<*mut libc::c_void>;
+    fn get_xcb_connection(&self) -> Option<*mut raw::c_void>;
 
     /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
     ///
     /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
-    fn get_wayland_surface(&self) -> Option<*mut libc::c_void>;
+    fn get_wayland_surface(&self) -> Option<*mut raw::c_void>;
 
     /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
     ///
     /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
     ///
     /// The pointer will become invalid when the glutin `Window` is destroyed.
-    fn get_wayland_display(&self) -> Option<*mut libc::c_void>;
+    fn get_wayland_display(&self) -> Option<*mut raw::c_void>;
 
     /// Check if the window is ready for drawing
     ///
@@ -131,7 +129,7 @@ pub trait WindowExt {
 
 impl WindowExt for Window {
     #[inline]
-    fn get_xlib_window(&self) -> Option<*mut libc::c_void> {
+    fn get_xlib_window(&self) -> Option<raw::c_ulong> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.get_xlib_window()),
             _ => None
@@ -139,14 +137,14 @@ impl WindowExt for Window {
     }
 
     #[inline]
-    fn get_xlib_display(&self) -> Option<*mut libc::c_void> {
+    fn get_xlib_display(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.get_xlib_display()),
             _ => None
         }
     }
 
-    fn get_xlib_screen_id(&self) -> Option<*mut libc::c_void> {
+    fn get_xlib_screen_id(&self) -> Option<raw::c_int> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.get_xlib_screen_id()),
             _ => None
@@ -160,7 +158,7 @@ impl WindowExt for Window {
         }
     }
 
-    fn get_xcb_connection(&self) -> Option<*mut libc::c_void> {
+    fn get_xcb_connection(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.get_xcb_connection()),
             _ => None
@@ -174,7 +172,7 @@ impl WindowExt for Window {
     }
 
     #[inline]
-    fn get_wayland_surface(&self) -> Option<*mut libc::c_void> {
+    fn get_wayland_surface(&self) -> Option<*mut raw::c_void> {
         use wayland_client::Proxy;
         match self.window {
             LinuxWindow::Wayland(ref w) => Some(w.get_surface().ptr() as *mut _),
@@ -183,7 +181,7 @@ impl WindowExt for Window {
     }
 
     #[inline]
-    fn get_wayland_display(&self) -> Option<*mut libc::c_void> {
+    fn get_wayland_display(&self) -> Option<*mut raw::c_void> {
         use wayland_client::Proxy;
         match self.window {
             LinuxWindow::Wayland(ref w) => Some(w.get_display().ptr() as *mut _),

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -5,7 +5,7 @@ use libc;
 use std::borrow::Borrow;
 use std::{mem, cmp};
 use std::sync::{Arc, Mutex};
-use std::os::raw::{c_int, c_long, c_uchar};
+use std::os::raw::{c_int, c_long, c_uchar, c_ulong, c_void};
 use std::thread;
 use std::time::Duration;
 
@@ -537,13 +537,13 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn get_xlib_display(&self) -> *mut libc::c_void {
-        self.x.display.display as *mut libc::c_void
+    pub fn get_xlib_display(&self) -> *mut c_void {
+        self.x.display.display as _
     }
 
     #[inline]
-    pub fn get_xlib_screen_id(&self) -> *mut libc::c_void {
-        self.x.screen_id as *mut libc::c_void
+    pub fn get_xlib_screen_id(&self) -> c_int {
+        self.x.screen_id
     }
 
     #[inline]
@@ -553,20 +553,20 @@ impl Window2 {
 
     #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
-        self.x.display.display as *mut libc::c_void
+        self.x.display.display as _
     }
 
     #[inline]
-    pub fn get_xlib_window(&self) -> *mut libc::c_void {
-        self.x.window as *mut libc::c_void
+    pub fn get_xlib_window(&self) -> c_ulong {
+        self.x.window
     }
 
     #[inline]
     pub fn platform_window(&self) -> *mut libc::c_void {
-        self.x.window as *mut libc::c_void
+        self.x.window as _
     }
 
-    pub fn get_xcb_connection(&self) -> *mut libc::c_void {
+    pub fn get_xcb_connection(&self) -> *mut c_void {
         unsafe {
             (self.x.display.xlib_xcb.XGetXCBConnection)(self.get_xlib_display() as *mut _) as *mut _
         }


### PR DESCRIPTION
Fixes #256

`get_xlib_window` and `get_xlib_screen_id` previously returned `Option<*mut c_void>` by casting integer IDs into pointers, which while producing no functionality issues, is semantically incorrect and rather surprising. Worse still, the docs for `get_xlib_window` stated that it was in fact a valid pointer.

This is a breaking change, and will require some trivial changes to glutin. 

I chose to have `get_xlib_window` return `Option<libc::c_ulong>` rather than `Option<ffi::Window>`, since I assume `ffi::Window` isn't supposed to be exposed.