### PR TITLE
Add set_decorations method to Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for `Touch` for emscripten backend.
 - Added support for `DroppedFile`, `HoveredFile`, and `HoveredFileCancelled` to X11 backend.
 - **Breaking:** `unix::WindowExt` no longer returns pointers for things that aren't actually pointers; `get_xlib_window` now returns `Option<std::os::raw::c_ulong>` and `get_xlib_screen_id` returns `Option<std::os::raw::c_int>`. Additionally, methods that previously returned `libc::c_void` have been changed to return `std::os::raw::c_void`, which are not interchangeable types, so users wanting the former will need to explicitly cast.
+- Added `set_decorations` method to `Window` to allow decorations to be toggled after the window is built. Presently only implemented on X11.
 
 # Version 0.9.0 (2017-12-01)
 

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -44,7 +44,7 @@ impl EventsLoop {
         MonitorId
     }
 
-  
+
     pub fn poll_events<F>(&mut self, mut callback: F)
         where F: FnMut(::Event)
     {
@@ -101,7 +101,7 @@ impl EventsLoop {
                     None
                 }
             };
-            
+
             if let Some(event) = e {
                 callback(event);
             }
@@ -286,6 +286,11 @@ impl Window {
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
         // Android has single screen maximized apps so nothing to do
+    }
+
+    #[inline]
+    pub fn set_decorations(&self, _decorations: bool) {
+        // N/A
     }
 
     #[inline]

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -518,6 +518,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_decorations(&self, _decorations: bool) {
+        // N/A
+    }
+
+    #[inline]
     pub fn get_current_monitor(&self) -> ::MonitorId {
         ::MonitorId{inner: MonitorId}
     }
@@ -693,7 +698,7 @@ fn key_translate_virt(input: [ffi::EM_UTF8; ffi::EM_HTML5_SHORT_STRING_LEN_BYTES
         "PreviousCandidate" => None,
         "Process" => None,
         "SingleCandidate" => None,
-        
+
         "HangulMode" => None,
         "HanjaMode" => None,
         "JunjaMode" => None,

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -355,6 +355,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_decorations(&self, _decorations: bool) {
+        // N/A
+    }
+
+    #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
         RootMonitorId{inner: MonitorId}
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -248,7 +248,9 @@ impl Window {
     pub fn set_maximized(&self, maximized: bool) {
         match self {
             &Window::X(ref w) => w.set_maximized(maximized),
-            &Window::Wayland(ref _w) => {},
+            &Window::Wayland(ref _w) => {
+                unimplemented!();
+            }
         }
     }
 
@@ -256,7 +258,19 @@ impl Window {
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         match self {
             &Window::X(ref w) => w.set_fullscreen(monitor),
-            &Window::Wayland(ref _w) => {},
+            &Window::Wayland(ref _w) => {
+                unimplemented!();
+            }
+        }
+    }
+
+    #[inline]
+    pub fn set_decorations(&self, decorations: bool) {
+        match self {
+            &Window::X(ref w) => w.set_decorations(decorations),
+            &Window::Wayland(ref _w) => {
+                unimplemented!();
+            }
         }
     }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -644,6 +644,11 @@ impl Window2 {
     }
 
     #[inline]
+    pub fn set_decorations(&self, _decorations: bool) {
+        unimplemented!()
+    }
+
+    #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
         unimplemented!()
     }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -45,7 +45,7 @@ impl Window {
     {
         let mut w_attr = Some(w_attr.clone());
         let mut pl_attr = Some(pl_attr.clone());
-        
+
         let (tx, rx) = channel();
 
         events_loop.execute_in_thread(move |inserter| {
@@ -289,6 +289,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_decorations(&self, _decorations: bool) {
+        unimplemented!()
+    }
+
+    #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
         unimplemented!()
     }
@@ -298,7 +303,7 @@ impl Drop for Window {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            // We are sending WM_CLOSE, and our callback will process this by calling DefWindowProcW, 
+            // We are sending WM_CLOSE, and our callback will process this by calling DefWindowProcW,
             // which in turn will send a WM_DESTROY.
             user32::PostMessageW(self.window.0, winapi::WM_CLOSE, 0, 0);
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -313,6 +313,12 @@ impl Window {
         self.window.set_fullscreen(monitor)
     }
 
+    /// Turn window decorations on or off.
+    #[inline]
+    pub fn set_decorations(&self, decorations: bool) {
+        self.window.set_decorations(decorations)
+    }
+
     /// Returns the current monitor the window is on or the primary monitor is nothing
     /// matches
     pub fn get_current_monitor(&self) -> MonitorId {


### PR DESCRIPTION
This has been stubbed on all platforms other than X11. The X11 implementation has also been revised to toggle correctly, as it was previously only able to remove decorations.

(The various whitespace changes weren't intentional... I guess my editor did that.)