### PR TITLE
[emscripten] request canvas size instead of CSS size

### DIFF
--- a/src/platform/emscripten/ffi.rs
+++ b/src/platform/emscripten/ffi.rs
@@ -3,6 +3,8 @@
 #![allow(non_camel_case_types)]
 
 use std::os::raw::{c_int, c_char, c_void, c_ulong, c_double, c_long, c_ushort};
+#[cfg(test)]
+use std::mem;
 
 pub type EM_BOOL = c_int;
 pub type EM_UTF8 = c_char;
@@ -219,6 +221,15 @@ fn bindgen_test_layout_EmscriptenPointerlockChangeEvent() {
 }
 
 extern "C" {
+    pub fn emscripten_set_canvas_size(
+        width: c_int, height: c_int)
+        -> EMSCRIPTEN_RESULT;
+
+    pub fn emscripten_get_canvas_size(
+        width: *mut c_int, height: *mut c_int,
+        is_fullscreen: *mut c_int)
+        -> EMSCRIPTEN_RESULT;
+
     pub fn emscripten_set_element_css_size(
         target: *const c_char, width: c_double,
         height: c_double) -> EMSCRIPTEN_RESULT;

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::os::raw::{c_char, c_void, c_double, c_ulong, c_int};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Arc, Weak};
+use std::sync::{Mutex, Arc};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 
@@ -415,10 +415,11 @@ impl Window {
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         unsafe {
             use std::{mem, ptr};
-            let mut width = mem::uninitialized();
-            let mut height = mem::uninitialized();
+            let mut width = 0;
+            let mut height = 0;
+            let mut fullscreen = 0;
 
-            if ffi::emscripten_get_element_css_size(ptr::null(), &mut width, &mut height)
+            if ffi::emscripten_get_canvas_size(&mut width, &mut height, &mut fullscreen)
                 != ffi::EMSCRIPTEN_RESULT_SUCCESS
             {
                 None
@@ -693,7 +694,7 @@ fn key_translate_virt(input: [ffi::EM_UTF8; ffi::EM_HTML5_SHORT_STRING_LEN_BYTES
         "PreviousCandidate" => None,
         "Process" => None,
         "SingleCandidate" => None,
-        
+
         "HangulMode" => None,
         "HanjaMode" => None,
         "JunjaMode" => None,


### PR DESCRIPTION
The old code requested element CSS side, where element is `ptr:null()` which effectively returns the whole window size. It might make sense from the pure window logic, but is rather useless for anything WebGL related. Not exactly sure how to properly address this, but we can hopefully start the discussion here.