### PR TITLE
wayland: Implement key repetition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ dwmapi-sys = "0.1"
 wayland-client = { version = "0.12.0", features = ["dlopen"] }
 wayland-protocols = { version = "0.12.0", features = ["unstable_protocols"] }
 wayland-kbd = "0.13.0"
-wayland-window = "0.13.0"
+wayland-window = "0.13.2"
 x11-dl = "2.8"
 percent-encoding = "1.0"
+tokio-core = "0.1"
+tokio-timer = "0.1"
+futures = "0.1"

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 use {WindowId, DeviceId};
 
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+use wayland_client::protocol::wl_keyboard;
+
 /// Describes a generic event.
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -211,6 +214,17 @@ pub type ButtonId = u32;
 pub enum ElementState {
     Pressed,
     Released,
+}
+
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+impl From<wl_keyboard::KeyState> for ElementState {
+    #[inline(always)]
+    fn from(state: wl_keyboard::KeyState) -> ElementState {
+        match state {
+            wl_keyboard::KeyState::Pressed => ElementState::Pressed,
+            wl_keyboard::KeyState::Released => ElementState::Released,
+        }
+    }
 }
 
 /// Describes a button of a mouse controller.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,12 @@ extern crate percent_encoding;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
 #[macro_use]
 extern crate wayland_client;
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+extern crate tokio_core;
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+extern crate tokio_timer;
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+extern crate futures;
 
 pub use events::*;
 pub use window::{AvailableMonitorsIter, MonitorId};

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -14,6 +14,7 @@ mod event_loop;
 mod pointer;
 mod touch;
 mod keyboard;
+mod streams;
 mod window;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform/linux/wayland/streams.rs
+++ b/src/platform/linux/wayland/streams.rs
@@ -1,0 +1,16 @@
+use futures::{ Async, Poll, Stream };
+use std::cell::RefCell;
+use std::rc::Weak;
+
+pub struct WhileExists<S: Stream>(pub Weak<RefCell<S>>);
+
+impl<S: Stream> Stream for WhileExists<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        self.0.upgrade()
+            .map(|s| s.borrow_mut().poll())
+            .unwrap_or(Ok(Async::Ready(None)))
+    }
+}

--- a/src/platform/linux/wayland/streams.rs
+++ b/src/platform/linux/wayland/streams.rs
@@ -2,6 +2,7 @@ use futures::{ Async, Poll, Stream };
 use std::cell::RefCell;
 use std::rc::Weak;
 
+/// Stream that will end when the internal `Weak` reference is no longer upgradable
 pub struct WhileExists<S: Stream>(pub Weak<RefCell<S>>);
 
 impl<S: Stream> Stream for WhileExists<S> {


### PR DESCRIPTION
**NOTE**: This still needs cleanup. I'm just getting the base implementation out there to get comments before I spend a bunch of time cleaning it up.

This implements key repitition for wayland. I could use some comments on the high-level approach, as there are plenty of cleanup tasks that came from code-churn while debugging.

I wound up having to pass an `EventsLoopProxy` handle through the `wl_seat` and `wl_keyboard` implementations so that the underlying timer event thread would be able to wake up the `EventsLoop` that's reading from the sink.

Comments appreciated. I'm using this locally with jwilm/alacritty (with a few patches to update glutin to use this version of winit), and it seems to work alright. The threading overhead is a bit of a bummer, but it seems to be fairly minimal.

# TODO List

- [x] Audit + fix error handling with internal queues + async wakeups of `EventsLoop`.
- [x] Cleanup (read: unwrap) the `HashMap` usage for storing state in the timer thread, since we only track one key repeat at a time (I didn't know this initially until I actually played around with it in Xorg)
- [ ] Break up the monolith of nesting that occurs inside `KeyboardIData::new`
- [x] Think about the currently hard-coded channel capacities to make sure they're sensible.
- [ ] Dynamically configure the `tokio_timer::Timer` implementation based on the current `RepeatInfo` config. (This will just allow for more efficiency in the timer thread, and potentially more granular repeat intervals. 10ms is a decent preset, but dynamic-configuration is probably more correct).