### PR TITLE
Add support for Caret (^) Key in OSX (de_DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added method `os::macos::WindowBuilderExt::with_movable_by_window_background(bool)` that allows to move a window without a titlebar - `with_decorations(false)`
 - Implement `Window::set_fullscreen`, `Window::set_maximized` and `Window::set_decorations` for Wayland.
+- Added `Caret` as VirtualKeyCode and support OSX ^-Key with german input.
 
 # Version 0.10.0 (2017-12-27)
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -344,6 +344,8 @@ pub enum VirtualKeyCode {
     /// The "Compose" key on Linux.
     Compose,
 
+    Caret,
+
     Numlock,
     Numpad0,
     Numpad1,

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -746,6 +746,7 @@ fn to_virtual_key_code(code: u16) -> Option<events::VirtualKeyCode> {
         0x7e => events::VirtualKeyCode::Up,
         //0x7f =>  unkown,
 
+        10 => events::VirtualKeyCode::Caret,
         _ => return None,
     })
 }

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -746,7 +746,7 @@ fn to_virtual_key_code(code: u16) -> Option<events::VirtualKeyCode> {
         0x7e => events::VirtualKeyCode::Up,
         //0x7f =>  unkown,
 
-        10 => events::VirtualKeyCode::Caret,
+        0xa => events::VirtualKeyCode::Caret,
         _ => return None,
     })
 }


### PR DESCRIPTION
I'm using alacritty and got the problem that my caret key (^) in OSX, German Keyboard is not recognized correctly (Event returns None). This maps the keycode and makes it useable.

Reference: https://github.com/jwilm/alacritty/issues/680

