### PR TITLE
[macOS] Move the window if there is no title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added method `os::macos::WindowBuilderExt::with_movable_by_window_background(bool)` that allows to move a window without a titlebar - `with_decorations(false)`
+
 # Version 0.10.0 (2017-12-27)
 
 - Add support for `Touch` for emscripten backend.

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -63,6 +63,7 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 /// Additional methods on `WindowBuilder` that are specific to MacOS.
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
+    fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -70,6 +71,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder {
         self.platform_specific.activation_policy = activation_policy;
+        self
+    }
+
+    /// Enables click-and-drag behavior for the entire window, not just the titlebar
+    #[inline]
+    fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> WindowBuilder {
+        self.platform_specific.movable_by_window_background = movable_by_window_background;
         self
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -447,6 +447,7 @@ impl Window2 {
                 if !attrs.decorations {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                     window.setTitlebarAppearsTransparent_(YES);
+                    window.setMovableByWindowBackground_(YES);
                 }
 
                 if screen.is_some() {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -254,6 +254,7 @@ impl Drop for WindowDelegate {
 #[derive(Clone, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub activation_policy: ActivationPolicy,
+    pub movable_by_window_background: bool,
 }
 
 pub struct Window2 {
@@ -312,7 +313,7 @@ impl Window2 {
             None      => { return Err(OsError(format!("Couldn't create NSApplication"))); },
         };
 
-        let window = match Window2::create_window(win_attribs)
+        let window = match Window2::create_window(win_attribs, pl_attribs)
         {
             Some(window) => window,
             None         => { return Err(OsError(format!("Couldn't create NSWindow"))); },
@@ -381,7 +382,10 @@ impl Window2 {
         }
     }
 
-    fn create_window(attrs: &WindowAttributes) -> Option<IdRef> {
+    fn create_window(
+        attrs: &WindowAttributes,
+        pl_attrs: &PlatformSpecificWindowBuilderAttributes)
+        -> Option<IdRef> {
         unsafe {
             let screen = match attrs.fullscreen {
                 Some(ref monitor_id) => {
@@ -447,6 +451,9 @@ impl Window2 {
                 if !attrs.decorations {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                     window.setTitlebarAppearsTransparent_(YES);
+                }
+
+                if pl_attrs.movable_by_window_background {
                     window.setMovableByWindowBackground_(YES);
                 }
 


### PR DESCRIPTION
On macOS by default windows can only be moved by clicking and
dragging on the titlebar, if we spawn a window without one we
need to set the `movableByWindowBackground` property.

Partial fix for #368