### PR TITLE
[macOS] WindowBuilderExt additions for the titlebar

### DIFF
--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -64,6 +64,7 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
+    fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -78,6 +79,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> WindowBuilder {
         self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self
+    }
+
+    /// Hides the window title
+    #[inline]
+    fn with_title_hidden(mut self, title_hidden: bool) -> WindowBuilder {
+        self.platform_specific.title_hidden = title_hidden;
         self
     }
 }

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -61,9 +61,16 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to MacOS.
+///
+/// **Note:** Properties dealing with the titlebar will be overwritten by the `with_decorations` method
+/// on the base `WindowBuilder`:
+///
+///  - `with_titlebar_transparent`
+///  - `with_title_hidden`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
+    fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
 }
 
@@ -79,6 +86,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> WindowBuilder {
         self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self
+    }
+
+    /// Makes the titlebar transparent and allows the content to appear behind it
+    #[inline]
+    fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> WindowBuilder {
+        self.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -67,11 +67,13 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 ///
 ///  - `with_titlebar_transparent`
 ///  - `with_title_hidden`
+///  - `with_fullsize_content_view`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
     fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
+    fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -100,6 +102,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> WindowBuilder {
         self.platform_specific.title_hidden = title_hidden;
+        self
+    }
+
+    /// Makes the window content appear behind the titlebar
+    #[inline]
+    fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> WindowBuilder {
+        self.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -255,6 +255,7 @@ impl Drop for WindowDelegate {
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub activation_policy: ActivationPolicy,
     pub movable_by_window_background: bool,
+    pub titlebar_transparent: bool,
     pub title_hidden: bool,
 }
 
@@ -427,15 +428,24 @@ impl Window2 {
                 NSWindowStyleMask::NSBorderlessWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
-            } else if attrs.decorations {
-                // Window2 with a titlebar
-                NSWindowStyleMask::NSClosableWindowMask | NSWindowStyleMask::NSMiniaturizableWindowMask |
-                    NSWindowStyleMask::NSResizableWindowMask | NSWindowStyleMask::NSTitledWindowMask
-            } else {
+            } else if !attrs.decorations {
                 // Window2 without a titlebar
                 NSWindowStyleMask::NSClosableWindowMask |
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSFullSizeContentViewWindowMask
+            } else if !pl_attrs.titlebar_transparent {
+                // Window2 with a titlebar
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask
+            } else {
+                // Window2 with a transparent titlebar
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
             };
 
@@ -451,6 +461,9 @@ impl Window2 {
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
 
+                if pl_attrs.titlebar_transparent {
+                    window.setTitlebarAppearsTransparent_(YES);
+                }
                 if pl_attrs.title_hidden {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -255,6 +255,7 @@ impl Drop for WindowDelegate {
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub activation_policy: ActivationPolicy,
     pub movable_by_window_background: bool,
+    pub title_hidden: bool,
 }
 
 pub struct Window2 {
@@ -423,7 +424,8 @@ impl Window2 {
 
             let masks = if screen.is_some() {
                 // Fullscreen window
-                NSWindowStyleMask::NSBorderlessWindowMask | NSWindowStyleMask::NSResizableWindowMask |
+                NSWindowStyleMask::NSBorderlessWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
             } else if attrs.decorations {
                 // Window2 with a titlebar
@@ -431,7 +433,8 @@ impl Window2 {
                     NSWindowStyleMask::NSResizableWindowMask | NSWindowStyleMask::NSTitledWindowMask
             } else {
                 // Window2 without a titlebar
-                NSWindowStyleMask::NSClosableWindowMask | NSWindowStyleMask::NSMiniaturizableWindowMask |
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
             };
@@ -448,13 +451,16 @@ impl Window2 {
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
 
+                if pl_attrs.title_hidden {
+                    window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
+                }
+                if pl_attrs.movable_by_window_background {
+                    window.setMovableByWindowBackground_(YES);
+                }
+
                 if !attrs.decorations {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                     window.setTitlebarAppearsTransparent_(YES);
-                }
-
-                if pl_attrs.movable_by_window_background {
-                    window.setMovableByWindowBackground_(YES);
                 }
 
                 if screen.is_some() {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -257,6 +257,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub movable_by_window_background: bool,
     pub titlebar_transparent: bool,
     pub title_hidden: bool,
+    pub fullsize_content_view: bool,
 }
 
 pub struct Window2 {
@@ -440,13 +441,19 @@ impl Window2 {
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
-            } else {
-                // Window2 with a transparent titlebar
+            } else if pl_attrs.fullsize_content_view {
+                // Window2 with a transparent titlebar and fullsize content view
                 NSWindowStyleMask::NSClosableWindowMask |
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
+            } else {
+                // Window2 with a transparent titlebar and regular content view
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask
             };
 
             let window = IdRef::new(NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(


### PR DESCRIPTION
Extends the `WindowBuilder` on macOS to allow more fine-grained modifications to the way the titlebar is displayed.

![](https://i.imgur.com/1iWSQtB.jpg)