### PR TITLE
Implement MonitorId::get_dimensions for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Implement `MonitorId::get_dimensions` for Android.
+
 # Version 0.10.1 (2018-02-05)
 
 - Added method `os::macos::WindowBuilderExt::with_movable_by_window_background(bool)` that allows to move a window without a titlebar - `with_decorations(false)`

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -161,7 +161,10 @@ impl MonitorId {
 
     #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
-        unimplemented!()
+        unsafe {
+            let window = android_glue::get_native_window();
+            (ffi::ANativeWindow_getWidth(window) as u32, ffi::ANativeWindow_getHeight(window) as u32)
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This is not absolutely right (the window could be smaller than the screen), but it's as good as get_position and get_hidpi_factor.