### PR TITLE
Add ability to change the min/max size of windows at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added `set_min_dimensions` and `set_max_dimensions` methods to `Window`, and implemented on Windows, X11, Wayland, and OSX.
+
 # Version 0.11.0 (2018-02-09)
 
 - Implement `MonitorId::get_dimensions` for Android.

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -3,11 +3,12 @@ extern crate winit;
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
-    let _window = winit::WindowBuilder::new()
-        .with_min_dimensions(400, 200)
-        .with_max_dimensions(800, 400)
+    let window = winit::WindowBuilder::new()
         .build(&events_loop)
         .unwrap();
+
+    window.set_min_dimensions(Some((400, 200)));
+    window.set_max_dimensions(Some((800, 400)));
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -4,13 +4,11 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let window = winit::WindowBuilder::new()
-        .with_min_dimensions(400, 200)
-        .with_max_dimensions(800, 400)
         .build(&events_loop)
         .unwrap();
 
-    // window.set_min_dimensions(Some((400, 200)));
-    // window.set_max_dimensions(Some((800, 400)));
+    window.set_min_dimensions(Some((400, 200)));
+    window.set_max_dimensions(Some((800, 400)));
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -4,11 +4,13 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let window = winit::WindowBuilder::new()
+        .with_min_dimensions(400, 200)
+        .with_max_dimensions(800, 400)
         .build(&events_loop)
         .unwrap();
 
-    window.set_min_dimensions(Some((400, 200)));
-    window.set_max_dimensions(Some((800, 400)));
+    // window.set_min_dimensions(Some((400, 200)));
+    // window.set_max_dimensions(Some((800, 400)));
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -232,6 +232,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_min_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         if self.native_window.is_null() {
             None

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -453,6 +453,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_min_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
     pub fn show(&self) {}
     #[inline]
     pub fn hide(&self) {}

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -307,6 +307,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_min_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+
+    #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
         unimplemented!();
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -189,8 +189,24 @@ impl Window {
     #[inline]
     pub fn set_inner_size(&self, x: u32, y: u32) {
         match self {
-            &Window::X(ref w) => w.set_inner_size(x, y),
+            &Window::X(_) => w.set_inner_size(x, y),
             &Window::Wayland(ref w) => w.set_inner_size(x, y)
+        }
+    }
+
+    #[inline]
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        match self {
+            &Window::X(ref w) => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_min_dimensions(dimensions)
+        }
+    }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        match self {
+            &Window::X(ref w) => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_max_dimensions(dimensions)
         }
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -189,7 +189,7 @@ impl Window {
     #[inline]
     pub fn set_inner_size(&self, x: u32, y: u32) {
         match self {
-            &Window::X(_) => w.set_inner_size(x, y),
+            &Window::X(ref w) => w.set_inner_size(x, y),
             &Window::Wayland(ref w) => w.set_inner_size(x, y)
         }
     }
@@ -197,7 +197,7 @@ impl Window {
     #[inline]
     pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
         match self {
-            &Window::X(ref w) => unimplemented!(),
+            &Window::X(ref w) => w.set_min_dimensions(dimensions),
             &Window::Wayland(ref w) => w.set_min_dimensions(dimensions)
         }
     }
@@ -205,7 +205,7 @@ impl Window {
     #[inline]
     pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
         match self {
-            &Window::X(ref w) => unimplemented!(),
+            &Window::X(ref w) => w.set_max_dimensions(dimensions),
             &Window::Wayland(ref w) => w.set_max_dimensions(dimensions)
         }
     }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -137,6 +137,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        self.frame.lock().unwrap().set_min_size(dimensions.map(|(w, h)| (w as i32, h as i32)));
+    }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        self.frame.lock().unwrap().set_max_size(dimensions.map(|(w, h)| (w as i32, h as i32)));
+    }
+
+    #[inline]
     pub fn set_cursor(&self, _cursor: MouseCursor) {
         // TODO
     }
@@ -190,11 +200,11 @@ impl Window {
         // TODO: not yet possible on wayland
         Err(())
     }
-    
+
     pub fn get_display(&self) -> &wl_display::WlDisplay {
         &*self.display
     }
-    
+
     pub fn get_surface(&self) -> &wl_surface::WlSurface {
         &self.surface
     }

--- a/src/platform/linux/x11/util.rs
+++ b/src/platform/linux/x11/util.rs
@@ -1,10 +1,53 @@
 use std::mem;
 use std::ptr;
 use std::sync::Arc;
+use std::ops::{Deref, DerefMut};
 use std::os::raw::{c_char, c_double, c_int, c_long, c_short, c_uchar, c_uint, c_ulong};
 
 use super::{ffi, XConnection, XError};
 use events::ModifiersState;
+
+pub struct XSmartPointer<'a, T> {
+    xconn: &'a Arc<XConnection>,
+    pub ptr: *mut T,
+}
+
+impl<'a, T> XSmartPointer<'a, T> {
+    // You're responsible for only passing things to this that should be XFree'd.
+    // Returns None if ptr is null.
+    pub fn new(xconn: &'a Arc<XConnection>, ptr: *mut T) -> Option<Self> {
+        if !ptr.is_null() {
+            Some(XSmartPointer {
+                xconn,
+                ptr,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T> Deref for XSmartPointer<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<'a, T> DerefMut for XSmartPointer<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.ptr }
+    }
+}
+
+impl<'a, T> Drop for XSmartPointer<'a, T> {
+    fn drop(&mut self) {
+        unsafe {
+            (self.xconn.xlib.XFree)(self.ptr as *mut _);
+        }
+    }
+}
 
 pub unsafe fn get_atom(xconn: &Arc<XConnection>, name: &[u8]) -> Result<ffi::Atom, XError> {
     let atom_name: *const c_char = name.as_ptr() as _;

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -19,7 +19,7 @@ use window::MonitorId as RootMonitorId;
 
 use platform::x11::monitor::get_available_monitors;
 
-use super::{ffi, util, XConnection, WindowId, EventsLoop};
+use super::{ffi, util, XConnection, XError, WindowId, EventsLoop};
 
 // TODO: remove me
 fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const libc::c_char) -> T {
@@ -230,23 +230,33 @@ impl Window2 {
             }
 
             // set size hints
-            let mut size_hints: ffi::XSizeHints = unsafe { mem::zeroed() };
-            size_hints.flags = ffi::PSize;
-            size_hints.width = dimensions.0 as i32;
-            size_hints.height = dimensions.1 as i32;
-            if let Some(dimensions) = window_attrs.min_dimensions {
-                size_hints.flags |= ffi::PMinSize;
-                size_hints.min_width = dimensions.0 as i32;
-                size_hints.min_height = dimensions.1 as i32;
-            }
-            if let Some(dimensions) = window_attrs.max_dimensions {
-                size_hints.flags |= ffi::PMaxSize;
-                size_hints.max_width = dimensions.0 as i32;
-                size_hints.max_height = dimensions.1 as i32;
-            }
-            unsafe {
-                (display.xlib.XSetNormalHints)(display.display, x_window.window, &mut size_hints);
-                display.check_errors().expect("Failed to call XSetNormalHints");
+            {
+                let mut size_hints = {
+                    let size_hints = unsafe { (display.xlib.XAllocSizeHints)() };
+                    util::XSmartPointer::new(&display, size_hints)
+                        .expect("XAllocSizeHints returned null; out of memory")
+                };
+                (*size_hints).flags = ffi::PSize;
+                (*size_hints).width = dimensions.0 as c_int;
+                (*size_hints).height = dimensions.1 as c_int;
+                if let Some(dimensions) = window_attrs.min_dimensions {
+                    (*size_hints).flags |= ffi::PMinSize;
+                    (*size_hints).min_width = dimensions.0 as c_int;
+                    (*size_hints).min_height = dimensions.1 as c_int;
+                }
+                if let Some(dimensions) = window_attrs.max_dimensions {
+                    (*size_hints).flags |= ffi::PMaxSize;
+                    (*size_hints).max_width = dimensions.0 as c_int;
+                    (*size_hints).max_height = dimensions.1 as c_int;
+                }
+                unsafe {
+                    (display.xlib.XSetWMNormalHints)(
+                        display.display,
+                        x_window.window,
+                        size_hints.ptr,
+                    );
+                }
+                display.check_errors().expect("Failed to call XSetWMNormalHints");
             }
 
             // Opt into handling window close
@@ -603,30 +613,65 @@ impl Window2 {
         self.x.display.check_errors().expect("Failed to call XResizeWindow");
     }
 
+    unsafe fn update_normal_hints<F>(&self, callback: F) -> Result<(), XError>
+        where F: FnOnce(*mut ffi::XSizeHints) -> ()
+    {
+        let xconn = &self.x.display;
+
+        let size_hints = {
+            let size_hints = (xconn.xlib.XAllocSizeHints)();
+            util::XSmartPointer::new(&xconn, size_hints)
+                .expect("XAllocSizeHints returned null; out of memory")
+        };
+
+        let mut flags: c_long = mem::uninitialized();
+
+        (xconn.xlib.XGetWMNormalHints)(
+            xconn.display,
+            self.x.window,
+            size_hints.ptr,
+            &mut flags,
+        );
+        xconn.check_errors()?;
+
+        callback(size_hints.ptr);
+
+        (xconn.xlib.XSetWMNormalHints)(
+            xconn.display,
+            self.x.window,
+            size_hints.ptr,
+        );
+        xconn.check_errors()?;
+
+        Ok(())
+    }
+
     pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        // set size hints
-        let mut size_hints: ffi::XSizeHints = unsafe { mem::zeroed() };
-        size_hints.flags |= ffi::PMinSize;
-        let (width, height) = dimensions.map(|(w, h)| (w as i32, h as i32)).unwrap_or((0, 0));
-        size_hints.min_width = width;
-        size_hints.min_height = height;
         unsafe {
-            (self.x.display.xlib.XSetNormalHints)(self.x.display.display, self.x.window, &mut size_hints);
-            self.x.display.check_errors().expect("Failed to call XSetNormalHints");
-        }
+            self.update_normal_hints(|size_hints| {
+                if let Some((width, height)) = dimensions {
+                    (*size_hints).flags |= ffi::PMinSize;
+                    (*size_hints).min_width = width as c_int;
+                    (*size_hints).min_height = height as c_int;
+                } else {
+                    (*size_hints).flags &= !ffi::PMinSize;
+                }
+            })
+        }.expect("Failed to call XSetWMNormalHints");
     }
 
     pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        // set size hints
-        let mut size_hints: ffi::XSizeHints = unsafe { mem::zeroed() };
-        size_hints.flags |= ffi::PMaxSize;
-        let (width, height) = dimensions.map(|(w, h)| (w as i32, h as i32)).unwrap_or((i32::max_value(), i32::max_value()));
-        size_hints.min_width = width;
-        size_hints.min_height = height;
         unsafe {
-            (self.x.display.xlib.XSetNormalHints)(self.x.display.display, self.x.window, &mut size_hints);
-            self.x.display.check_errors().expect("Failed to call XSetNormalHints");
-        }
+            self.update_normal_hints(|size_hints| {
+                if let Some((width, height)) = dimensions {
+                    (*size_hints).flags |= ffi::PMaxSize;
+                    (*size_hints).max_width = width as c_int;
+                    (*size_hints).max_height = height as c_int;
+                } else {
+                    (*size_hints).flags &= !ffi::PMaxSize;
+                }
+            })
+        }.expect("Failed to call XSetWMNormalHints");
     }
 
     #[inline]

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -603,6 +603,32 @@ impl Window2 {
         self.x.display.check_errors().expect("Failed to call XResizeWindow");
     }
 
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        // set size hints
+        let mut size_hints: ffi::XSizeHints = unsafe { mem::zeroed() };
+        size_hints.flags |= ffi::PMinSize;
+        let (width, height) = dimensions.map(|(w, h)| (w as i32, h as i32)).unwrap_or((0, 0));
+        size_hints.min_width = width;
+        size_hints.min_height = height;
+        unsafe {
+            (self.x.display.xlib.XSetNormalHints)(self.x.display.display, self.x.window, &mut size_hints);
+            self.x.display.check_errors().expect("Failed to call XSetNormalHints");
+        }
+    }
+
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        // set size hints
+        let mut size_hints: ffi::XSizeHints = unsafe { mem::zeroed() };
+        size_hints.flags |= ffi::PMaxSize;
+        let (width, height) = dimensions.map(|(w, h)| (w as i32, h as i32)).unwrap_or((i32::max_value(), i32::max_value()));
+        size_hints.min_width = width;
+        size_hints.min_height = height;
+        unsafe {
+            (self.x.display.xlib.XSetNormalHints)(self.x.display.display, self.x.window, &mut size_hints);
+            self.x.display.check_errors().expect("Failed to call XSetNormalHints");
+        }
+    }
+
     #[inline]
     pub fn get_xlib_display(&self) -> *mut c_void {
         self.x.display.display as _

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -549,6 +549,20 @@ impl Window2 {
         }
     }
 
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        unsafe {
+            let (width, height) = dimensions.unwrap_or((0, 0));
+            nswindow_set_min_dimensions(self.window.0, width.into(), height.into());
+        }
+    }
+
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        unsafe {
+            let (width, height) = dimensions.unwrap_or((!0, !0));
+            nswindow_set_max_dimensions(self.window.0, width.into(), height.into());
+        }
+    }
+
     #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
         unimplemented!()

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -384,7 +384,17 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
     // creating the real window this time, by using the functions in `extra_functions`
     let real_window = {
         let (width, height) = if fullscreen || window.dimensions.is_some() {
-            (Some(rect.right - rect.left), Some(rect.bottom - rect.top))
+            let min_dimensions = window.min_dimensions
+                .map(|d| (d.0 as raw::c_int, d.1 as raw::c_int))
+                .unwrap_or((0, 0));
+            let max_dimensions = window.max_dimensions
+                .map(|d| (d.0 as raw::c_int, d.1 as raw::c_int))
+                .unwrap_or((raw::c_int::max_value(), raw::c_int::max_value()));
+
+            (
+                Some((rect.right - rect.left).min(max_dimensions.0).max(min_dimensions.0)),
+                Some((rect.bottom - rect.top).min(max_dimensions.1).max(min_dimensions.1))
+            )
         } else {
             (None, None)
         };

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -153,6 +153,20 @@ impl Window {
         }
     }
 
+    /// See the docs in the crate root file.
+    #[inline]
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        let mut window_state = self.window_state.lock().unwrap();
+        window_state.attributes.min_dimensions = dimensions;
+    }
+
+    /// See the docs in the crate root file.
+    #[inline]
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        let mut window_state = self.window_state.lock().unwrap();
+        window_state.attributes.max_dimensions = dimensions;
+    }
+
     // TODO: remove
     pub fn platform_display(&self) -> *mut ::libc::c_void {
         panic!()        // Deprecated function ; we don't care anymore

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -158,6 +158,11 @@ impl Window {
     pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
         let mut window_state = self.window_state.lock().unwrap();
         window_state.attributes.min_dimensions = dimensions;
+
+        // Make windows re-check the window size bounds.
+        if let Some(inner_size) = self.get_inner_size() {
+            self.set_inner_size(inner_size.0, inner_size.1);
+        }
     }
 
     /// See the docs in the crate root file.
@@ -165,6 +170,11 @@ impl Window {
     pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
         let mut window_state = self.window_state.lock().unwrap();
         window_state.attributes.max_dimensions = dimensions;
+
+        // Make windows re-check the window size bounds.
+        if let Some(inner_size) = self.get_inner_size() {
+            self.set_inner_size(inner_size.0, inner_size.1);
+        }
     }
 
     // TODO: remove

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -161,7 +161,18 @@ impl Window {
 
         // Make windows re-check the window size bounds.
         if let Some(inner_size) = self.get_inner_size() {
-            self.set_inner_size(inner_size.0, inner_size.1);
+            unsafe {
+                let mut rect = RECT { top: 0, left: 0, bottom: inner_size.1 as LONG, right: inner_size.0 as LONG };
+                let dw_style = winuser::GetWindowLongA(self.window.0, winuser::GWL_STYLE) as DWORD;
+                let b_menu = !winuser::GetMenu(self.window.0).is_null() as BOOL;
+                let dw_style_ex = winuser::GetWindowLongA(self.window.0, winuser::GWL_EXSTYLE) as DWORD;
+                winuser::AdjustWindowRectEx(&mut rect, dw_style, b_menu, dw_style_ex);
+                let outer_x = (rect.right - rect.left).abs() as raw::c_int;
+                let outer_y = (rect.top - rect.bottom).abs() as raw::c_int;
+
+                winuser::SetWindowPos(self.window.0, ptr::null_mut(), 0, 0, outer_x, outer_y,
+                    winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER | winuser::SWP_NOREPOSITION | winuser::SWP_NOMOVE);
+            }
         }
     }
 
@@ -173,7 +184,18 @@ impl Window {
 
         // Make windows re-check the window size bounds.
         if let Some(inner_size) = self.get_inner_size() {
-            self.set_inner_size(inner_size.0, inner_size.1);
+            unsafe {
+                let mut rect = RECT { top: 0, left: 0, bottom: inner_size.1 as LONG, right: inner_size.0 as LONG };
+                let dw_style = winuser::GetWindowLongA(self.window.0, winuser::GWL_STYLE) as DWORD;
+                let b_menu = !winuser::GetMenu(self.window.0).is_null() as BOOL;
+                let dw_style_ex = winuser::GetWindowLongA(self.window.0, winuser::GWL_EXSTYLE) as DWORD;
+                winuser::AdjustWindowRectEx(&mut rect, dw_style, b_menu, dw_style_ex);
+                let outer_x = (rect.right - rect.left).abs() as raw::c_int;
+                let outer_y = (rect.top - rect.bottom).abs() as raw::c_int;
+
+                winuser::SetWindowPos(self.window.0, ptr::null_mut(), 0, 0, outer_x, outer_y,
+                    winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER | winuser::SWP_NOREPOSITION | winuser::SWP_NOMOVE);
+            }
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -255,11 +255,17 @@ impl Window {
         self.window.set_inner_size(x, y)
     }
 
+    /// Sets a minimum dimension size for the window.
+    ///
+    /// Width and height are in pixels.
     #[inline]
     pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
         self.window.set_min_dimensions(dimensions)
     }
 
+    /// Sets a maximum dimension size for the window.
+    ///
+    /// Width and height are in pixels.
     #[inline]
     pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
         self.window.set_max_dimensions(dimensions)

--- a/src/window.rs
+++ b/src/window.rs
@@ -255,6 +255,16 @@ impl Window {
         self.window.set_inner_size(x, y)
     }
 
+    #[inline]
+    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        self.window.set_min_dimensions(dimensions)
+    }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+        self.window.set_max_dimensions(dimensions)
+    }
+
     /// DEPRECATED. Gets the native platform specific display for this window.
     /// This is typically only required when integrating with
     /// other libraries that need this information.


### PR DESCRIPTION
Adds the ability to change the minimum and maximum sizes of a window, even after it's been created, with `set_min_dimensions` and `set_max_dimensions` functions on the Window struct.

I've only tested this on Windows, and I'm *pretty sure* the OSX and Linux code compiles, but it's much harder for me to test them personally than it is to test the Windows code. I'll probably be able to test the Linux code in the next couple of days but I don't think I can test the OSX code personally.