### PR TITLE
Add set_suspend_callback method for Android

### DIFF
--- a/src/os/android.rs
+++ b/src/os/android.rs
@@ -1,8 +1,21 @@
 #![cfg(any(target_os = "android"))]
 
 use std::os::raw::c_void;
+use EventsLoop;
 use Window;
 use WindowBuilder;
+
+/// Additional methods on `EventsLoop` that are specific to Android.
+pub trait EventsLoopExt {
+    /// Makes it possible for glutin to register a callback when a suspend event happens on Android
+    fn set_suspend_callback(&self, cb: Option<Box<Fn(bool) -> ()>>);
+}
+
+impl EventsLoopExt for EventsLoop {
+    fn set_suspend_callback(&self, cb: Option<Box<Fn(bool) -> ()>>) {
+        self.events_loop.set_suspend_callback(cb);
+    }
+}
 
 /// Additional methods on `Window` that are specific to Android.
 pub trait WindowExt {


### PR DESCRIPTION
Makes it possible for glutin to register a callback when a suspend event happens on Android.

We need it to unfork Glutin on Servo. See https://github.com/tomaka/glutin/pull/868 for more details: