### PR TITLE
Send Awakened event on Android when event loop is woken up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Impl `Hash`, `PartialEq`, and `Eq` for `events::ModifiersState`.
 - Implement `MonitorId::get_hidpi_factor` for MacOS.
 - Added method `os::macos::MonitorIdExt::get_nsscreen() -> *mut c_void` that gets a `NSScreen` object matching the monitor ID.
+- Send `Awakened` event on Android when event loop is woken up.
 
 # Version 0.11.1 (2018-02-19)
 

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -106,6 +106,9 @@ impl EventsLoop {
                         event: WindowEvent::Refresh,
                     })
                 }
+                android_glue::Event::Wake => {
+                    Some(Event::Awakened)
+                }
                 _ => {
                     None
                 }


### PR DESCRIPTION
This is necessary, otherwise the event loop callback is never called because no WindowEvent is available.