### PR TITLE
323 windowbuilder ext macos

### DIFF
--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -67,12 +67,14 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 ///
 ///  - `with_titlebar_transparent`
 ///  - `with_title_hidden`
+///  - `with_titlebar_hidden`
 ///  - `with_fullsize_content_view`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
     fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
+    fn with_titlebar_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
 }
 
@@ -95,6 +97,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> WindowBuilder {
         self.platform_specific.titlebar_transparent = titlebar_transparent;
+        self
+    }
+
+    /// Hides the window titlebar
+    #[inline]
+    fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
+        self.platform_specific.titlebar_hidden = titlebar_hidden;
         self
     }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -64,6 +64,7 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
+    fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -78,6 +79,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> WindowBuilder {
         self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self
+    }
+
+    /// Hides the window title
+    #[inline]
+    fn with_title_hidden(mut self, title_hidden: bool) -> WindowBuilder {
+        self.platform_specific.title_hidden = title_hidden;
         self
     }
 }

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -68,6 +68,7 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 ///  - `with_titlebar_transparent`
 ///  - `with_title_hidden`
 ///  - `with_titlebar_hidden`
+///  - `with_titlebar_buttons_hidden`
 ///  - `with_fullsize_content_view`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
@@ -75,6 +76,7 @@ pub trait WindowBuilderExt {
     fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
     fn with_titlebar_hidden(self, titlebar_hidden: bool) -> WindowBuilder;
+    fn with_titlebar_buttons_hidden(self, titlebar_buttons_hidden: bool) -> WindowBuilder;
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
 }
 
@@ -104,6 +106,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> WindowBuilder {
         self.platform_specific.titlebar_hidden = titlebar_hidden;
+        self
+    }
+
+    /// Hides the window titlebar buttons
+    #[inline]
+    fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> WindowBuilder {
+        self.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
         self
     }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -61,9 +61,16 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to MacOS.
+///
+/// **Note:** Properties dealing with the titlebar will be overwritten by the `with_decorations` method
+/// on the base `WindowBuilder`:
+///
+///  - `with_titlebar_transparent`
+///  - `with_title_hidden`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
+    fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
 }
 
@@ -79,6 +86,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> WindowBuilder {
         self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self
+    }
+
+    /// Makes the titlebar transparent and allows the content to appear behind it
+    #[inline]
+    fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> WindowBuilder {
+        self.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -67,11 +67,13 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 ///
 ///  - `with_titlebar_transparent`
 ///  - `with_title_hidden`
+///  - `with_fullsize_content_view`
 pub trait WindowBuilderExt {
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> WindowBuilder;
     fn with_titlebar_transparent(self, titlebar_transparent: bool) -> WindowBuilder;
     fn with_title_hidden(self, title_hidden: bool) -> WindowBuilder;
+    fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -100,6 +102,13 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> WindowBuilder {
         self.platform_specific.title_hidden = title_hidden;
+        self
+    }
+
+    /// Makes the window content appear behind the titlebar
+    #[inline]
+    fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> WindowBuilder {
+        self.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -255,6 +255,7 @@ impl Drop for WindowDelegate {
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub activation_policy: ActivationPolicy,
     pub movable_by_window_background: bool,
+    pub title_hidden: bool,
 }
 
 pub struct Window2 {
@@ -404,7 +405,8 @@ impl Window2 {
 
             let masks = if screen.is_some() {
                 // Fullscreen window
-                NSWindowStyleMask::NSBorderlessWindowMask | NSWindowStyleMask::NSResizableWindowMask |
+                NSWindowStyleMask::NSBorderlessWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
             } else if attrs.decorations {
                 // Window2 with a titlebar
@@ -412,7 +414,8 @@ impl Window2 {
                     NSWindowStyleMask::NSResizableWindowMask | NSWindowStyleMask::NSTitledWindowMask
             } else {
                 // Window2 without a titlebar
-                NSWindowStyleMask::NSClosableWindowMask | NSWindowStyleMask::NSMiniaturizableWindowMask |
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
             };
@@ -429,13 +432,16 @@ impl Window2 {
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
 
+                if pl_attrs.title_hidden {
+                    window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
+                }
+                if pl_attrs.movable_by_window_background {
+                    window.setMovableByWindowBackground_(YES);
+                }
+
                 if !attrs.decorations {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                     window.setTitlebarAppearsTransparent_(YES);
-                }
-
-                if pl_attrs.movable_by_window_background {
-                    window.setMovableByWindowBackground_(YES);
                 }
 
                 if screen.is_some() {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -257,6 +257,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub movable_by_window_background: bool,
     pub titlebar_transparent: bool,
     pub title_hidden: bool,
+    pub fullsize_content_view: bool,
 }
 
 pub struct Window2 {
@@ -421,13 +422,19 @@ impl Window2 {
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
-            } else {
-                // Window2 with a transparent titlebar
+            } else if pl_attrs.fullsize_content_view {
+                // Window2 with a transparent titlebar and fullsize content view
                 NSWindowStyleMask::NSClosableWindowMask |
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
+            } else {
+                // Window2 with a transparent titlebar and regular content view
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask
             };
 
             let window = IdRef::new(NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -257,6 +257,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub movable_by_window_background: bool,
     pub titlebar_transparent: bool,
     pub title_hidden: bool,
+    pub titlebar_hidden: bool,
     pub fullsize_content_view: bool,
 }
 
@@ -416,6 +417,9 @@ impl Window2 {
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
+            } else if pl_attrs.titlebar_hidden {
+                NSWindowStyleMask::NSBorderlessWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask
             } else if !pl_attrs.titlebar_transparent {
                 // Window2 with a titlebar
                 NSWindowStyleMask::NSClosableWindowMask |

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -255,6 +255,7 @@ impl Drop for WindowDelegate {
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub activation_policy: ActivationPolicy,
     pub movable_by_window_background: bool,
+    pub titlebar_transparent: bool,
     pub title_hidden: bool,
 }
 
@@ -408,15 +409,24 @@ impl Window2 {
                 NSWindowStyleMask::NSBorderlessWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
                     NSWindowStyleMask::NSTitledWindowMask
-            } else if attrs.decorations {
-                // Window2 with a titlebar
-                NSWindowStyleMask::NSClosableWindowMask | NSWindowStyleMask::NSMiniaturizableWindowMask |
-                    NSWindowStyleMask::NSResizableWindowMask | NSWindowStyleMask::NSTitledWindowMask
-            } else {
+            } else if !attrs.decorations {
                 // Window2 without a titlebar
                 NSWindowStyleMask::NSClosableWindowMask |
                     NSWindowStyleMask::NSMiniaturizableWindowMask |
                     NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSFullSizeContentViewWindowMask
+            } else if !pl_attrs.titlebar_transparent {
+                // Window2 with a titlebar
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask
+            } else {
+                // Window2 with a transparent titlebar
+                NSWindowStyleMask::NSClosableWindowMask |
+                    NSWindowStyleMask::NSMiniaturizableWindowMask |
+                    NSWindowStyleMask::NSResizableWindowMask |
+                    NSWindowStyleMask::NSTitledWindowMask |
                     NSWindowStyleMask::NSFullSizeContentViewWindowMask
             };
 
@@ -432,6 +442,9 @@ impl Window2 {
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
 
+                if pl_attrs.titlebar_transparent {
+                    window.setTitlebarAppearsTransparent_(YES);
+                }
                 if pl_attrs.title_hidden {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
                 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -13,7 +13,7 @@ use objc::declare::ClassDecl;
 use cocoa;
 use cocoa::base::{id, nil};
 use cocoa::foundation::{NSPoint, NSRect, NSSize, NSString};
-use cocoa::appkit::{self, NSApplication, NSColor, NSView, NSWindow, NSWindowStyleMask};
+use cocoa::appkit::{self, NSApplication, NSColor, NSView, NSWindow, NSWindowStyleMask, NSWindowButton};
 
 use core_graphics::display::CGDisplay;
 
@@ -258,6 +258,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub titlebar_transparent: bool,
     pub title_hidden: bool,
     pub titlebar_hidden: bool,
+    pub titlebar_buttons_hidden: bool,
     pub fullsize_content_view: bool,
 }
 
@@ -458,6 +459,16 @@ impl Window2 {
                 }
                 if pl_attrs.title_hidden {
                     window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
+                }
+                if pl_attrs.titlebar_buttons_hidden {
+                    let button = window.standardWindowButton_(NSWindowButton::NSWindowFullScreenButton);
+                    msg_send![button, setHidden:YES];
+                    let button = window.standardWindowButton_(NSWindowButton::NSWindowMiniaturizeButton);
+                    msg_send![button, setHidden:YES];
+                    let button = window.standardWindowButton_(NSWindowButton::NSWindowCloseButton);
+                    msg_send![button, setHidden:YES];
+                    let button = window.standardWindowButton_(NSWindowButton::NSWindowZoomButton);
+                    msg_send![button, setHidden:YES];
                 }
                 if pl_attrs.movable_by_window_background {
                     window.setMovableByWindowBackground_(YES);


### PR DESCRIPTION
fixes #323 

This is #389, rebased from current master, with a couple of extra commits to add `titlebar_hidden` and `titlebar_buttons_hidden`. I didn't get any response from @robertgzr on this so I decided to just open a new one. #389 was approved, not sure why it didn't get merged, so I'm hoping to get this merged soon.

NB: `titlebar_hidden` depends on #408 to be resizable.