### PR TITLE
[macOS] Fix crashes due to the stabilization of the `!` (never) type

### DIFF
--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -278,7 +278,7 @@ impl Drop for Window2 {
         let nswindow = *self.window;
         if nswindow != nil {
             unsafe {
-                msg_send![nswindow, close];
+                let () = msg_send![nswindow, close];
             }
         }
     }
@@ -346,7 +346,7 @@ impl Window2 {
 
             use cocoa::foundation::NSArray;
             // register for drag and drop operations.
-            msg_send![(*window as id),
+            let () = msg_send![(*window as id),
                 registerForDraggedTypes:NSArray::arrayWithObject(nil, appkit::NSFilenamesPboardType)];
         }
 


### PR DESCRIPTION
Due to the recent changes in the Rust compiler, unconstrained type variables are now deduced to `!` instead of `()`. There are some occurrences where `msg_send!` is used without constraining its return
type (relying on the assumption that they would be deduced to be `()`). As a result, the macOS port of winit stopped working.

- [Summary issue - stabilization of `!`](https://github.com/rust-lang/rust/issues/48950)
- [Promote `!` to a type.](https://github.com/rust-lang/rfcs/pull/1216)

See the new type deduction behavior [in action](https://play.rust-lang.org/?gist=318b5429d39fc215654b6b38b2979406&version=nightly).

This PR fixes the issue (#426) by adding explicit return types to such uses of `msg_send!`.