### PR TITLE
Add methods to get the position of a window's client area, relative to the desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Overhauled X11 window geometry calculations. `get_position` and `set_position` are more universally accurate across different window managers, and `get_outer_size` actually works now.
+- Corrected `get_position` on macOS to return outer frame position, not content area position.
 
 # Version 0.12.0 (2018-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Overhauled X11 window geometry calculations. `get_position` and `set_position` are more universally accurate across different window managers, and `get_outer_size` actually works now.
 - Corrected `get_position` on macOS to return outer frame position, not content area position.
 - Corrected `set_position` on macOS to set outer frame position, not content area position.
+- Added `get_inner_position` method to `Window`, which gets the position of the window's client area. This is implemented on all applicable platforms (all desktop platforms other than Wayland, where this isn't possible).
 
 # Version 0.12.0 (2018-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Overhauled X11 window geometry calculations. `get_position` and `set_position` are more universally accurate across different window managers, and `get_outer_size` actually works now.
 - Corrected `get_position` on macOS to return outer frame position, not content area position.
+- Corrected `set_position` on macOS to set outer frame position, not content area position.
 
 # Version 0.12.0 (2018-04-06)
 

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -244,6 +244,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        None
+    }
+
+    #[inline]
     pub fn set_position(&self, _x: i32, _y: i32) {
     }
 

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -418,6 +418,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        Some((0, 0))
+    }
+
+    #[inline]
     pub fn set_position(&self, _: i32, _: i32) {
     }
 

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -289,6 +289,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        None
+    }
+
+    #[inline]
     pub fn set_position(&self, _x: i32, _y: i32) {
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -163,6 +163,14 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        match self {
+            &Window::X(ref m) => m.get_inner_position(),
+            &Window::Wayland(ref m) => m.get_inner_position(),
+        }
+    }
+
+    #[inline]
     pub fn set_position(&self, x: i32, y: i32) {
         match self {
             &Window::X(ref w) => w.set_position(x, y),

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -114,6 +114,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        // Not possible with wayland
+        None
+    }
+
+    #[inline]
     pub fn set_position(&self, _x: i32, _y: i32) {
         // Not possible with wayland
     }

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -919,6 +919,11 @@ impl Window2 {
         self.get_geometry().map(|geo| geo.get_position())
     }
 
+    #[inline]
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        self.get_geometry().map(|geo| geo.get_inner_position())
+    }
+
     pub fn set_position(&self, mut x: i32, mut y: i32) {
         if let Some(ref wm_name) = self.wm_name {
             // There are a few WMs that set client area position rather than window position, so

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -526,8 +526,9 @@ impl Window2 {
         unsafe { NSWindow::orderOut_(*self.window, nil); }
     }
 
-    // Translate bottom-left origin coordinates into top-left origin coordinates for
-    // consistency with other platform
+    // For consistency with other platforms, this will...
+    // 1. translate the bottom-left window corner into the top-left window corner
+    // 2. translate the coordinate from a bottom-left origin coordinate system to a top-left one
     fn bottom_left_to_top_left(rect: NSRect) -> i32 {
         (CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height)) as _
     }
@@ -554,26 +555,17 @@ impl Window2 {
     }
 
     pub fn set_position(&self, x: i32, y: i32) {
-        unsafe {
-            let frame = NSWindow::frame(*self.view);
-
-            // NOTE: `setFrameOrigin` might not give desirable results when
-            // setting window, as it treats bottom left as origin.
-            // `setFrameTopLeftPoint` treats top left as origin (duh), but
-            // does not equal the value returned by `get_window_position`
-            // (there is a difference by 22 for me on yosemite)
-
-            // TODO: consider extrapolating the calculations for the y axis to
-            // a private method
-            let dummy = NSRect::new(NSPoint::new(
+        let dummy = NSRect::new(
+            NSPoint::new(
                 x as f64,
-                CGDisplay::main().pixels_high() as f64 - (frame.size.height + y as f64)),
-                NSSize::new(0f64, 0f64),
-            );
-            let conv = NSWindow::frameRectForContentRect_(*self.window, dummy);
-
-            // NSWindow::setFrameTopLeftPoint_(*self.window, conv.origin);
-            NSWindow::setFrameOrigin_(*self.window, conv.origin);
+                // While it's true that we're setting the top-left position, it still needs to be
+                // in a bottom-left coordinate system.
+                CGDisplay::main().pixels_high() as f64 - y as f64,
+            ),
+            NSSize::new(0f64, 0f64),
+        );
+        unsafe {
+            NSWindow::setFrameTopLeftPoint_(*self.window, dummy.origin);
         }
     }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -536,6 +536,10 @@ impl Window2 {
         }
     }
 
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        unimplemented!()
+    }
+
     pub fn set_position(&self, x: i32, y: i32) {
         unsafe {
             let frame = NSWindow::frame(*self.view);

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -537,7 +537,12 @@ impl Window2 {
     }
 
     pub fn get_inner_position(&self) -> Option<(i32, i32)> {
-        unimplemented!()
+        unsafe {
+            let inner_size = self.get_inner_size().unwrap();
+            let window_rect = NSRect::new(NSPoint::new(0., 0.), NSSize::new(inner_size.0 as f64, inner_size.1 as f64));
+            let screen_rect = self.window.convertRectToScreen_(window_rect);
+            Some((screen_rect.origin.x as i32, (CGDisplay::main().pixels_high() as f64 - (screen_rect.origin.y + screen_rect.size.height)) as i32))
+        }
     }
 
     pub fn set_position(&self, x: i32, y: i32) {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -96,6 +96,17 @@ impl Window {
         Some((rect.left as i32, rect.top as i32))
     }
 
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        use std::mem;
+
+        let mut position: POINT = unsafe{ mem::zeroed() };
+        if unsafe{ winuser::ClientToScreen(self.window.0, &mut position) } == 0 {
+            return None;
+        }
+
+        Some((position.x, position.y))
+    }
+
     /// See the docs in the crate root file.
     pub fn set_position(&self, x: i32, y: i32) {
         unsafe {

--- a/src/window.rs
+++ b/src/window.rs
@@ -181,6 +181,10 @@ impl Window {
         self.window.get_position()
     }
 
+    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+        self.window.get_inner_position()
+    }
+
     /// Modifies the position of the window.
     ///
     /// See `get_position` for more information about the coordinates.

--- a/src/window.rs
+++ b/src/window.rs
@@ -181,6 +181,11 @@ impl Window {
         self.window.get_position()
     }
 
+    /// Returns the position of the top-left hand corner of the window's client area relative to the
+    /// top-left hand corner of the desktop.
+    ///
+    /// The same conditions that apply to `get_position` apply to this method.
+    #[inline]
     pub fn get_inner_position(&self) -> Option<(i32, i32)> {
         self.window.get_inner_position()
     }


### PR DESCRIPTION
This differs from the current `get_position`, in that the current method gets the window's top-left position, including window decorations. This adds a `get_inner_position` method, which gets the client area's top-left position, not including decorations, relative to the desktop.