### PR TITLE
x11: Don't panic when using dead keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Added subclass to macos windows so they can be made resizable even with no decorations.
+- Dead keys now work properly on X11, no longer resulting in a panic.
 
 # Version 0.11.3 (2018-03-28)
 


### PR DESCRIPTION
Fixes #366 

I was originally planning to fix this by rewriting keyboard handling to use XInput2+XKB+libxkbcommon, and I do indeed have a fully functional implementation of that. However, I never managed to figure out how to handle IME, and I could seldom find the motivation to try to conquer yet another dimension of X11 eroticism. That only got worse when I discovered older libxkbcommon versions, which are still in use, [don't support compose sequences](https://github.com/francesca64/xkbcommon-dl/issues/1). As a result, this fairly important issue has gone unresolved for much longer than I ever intended.

This PR fixes the issue using a bold new solution: a single `if` that checks if the keycode is non-zero. A `KeyPress` with a keycode of 0 is received at the end of compose sequences and pre-edit sequences, which has our desired UTF8 string associated with it. The panic was simply the result of trying to send a `KeyboardInput` event for this input, which involved trying to calculate a scancode for this nonexistent key. So, now we just don't try to send a `KeyboardInput` event in that case, and just like that, everything works.

I should note that the behavior of the X11 backend isn't consistent with [the expectations laid out in #343](https://github.com/tomaka/winit/issues/343#issuecomment-342106540). While I was able to easily achieve that behavior using XInput2, vanilla X11 seems less cooperative. For individual keys pressed during a compose/pre-edit sequence, X11 only generates `KeyRelease` events, so the user receives `KeyboardInput` events for key releases with no corresponding press events. In the case of compose, the `ReceivedCharacter` is sent to the user before the `KeyboardInput` for the release of the final key in the sequence. For pre-editing, a `KeyboardInput` for the release of the return key is sent after the `ReceivedCharacter`.