### PR TITLE
Fix macOS window sizes to follow convention with changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On X11, input method creation first tries to use the value from the user's `XMODIFIERS` environment variable, so application developers should no longer need to manually call `XSetLocaleModifiers`. If that fails, fallbacks are tried, which should prevent input method initialization from ever outright failing.
 - Fixed thread safety issues with input methods on X11.
 - Add support for `Touch` for win32 backend.
+- Fixed `Window::get_inner_size` and friends to return the size in pixels instead of points when using HIDPI displays on OSX.
 
 # Version 0.11.3 (2018-03-28)
 
@@ -14,7 +15,6 @@
   `with_title_hidden`, `with_titlebar_buttons_hidden`,
   `with_fullsize_content_view`.
 - Mapped X11 numpad keycodes (arrows, Home, End, PageUp, PageDown, Insert and Delete) to corresponding virtual keycodes
-- Fixed `Window::get_inner_size` and friends to return the size in pixels instead of points when using HIDPI displays on OSX.
 
 # Version 0.11.2 (2018-03-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   `with_title_hidden`, `with_titlebar_buttons_hidden`,
   `with_fullsize_content_view`.
 - Mapped X11 numpad keycodes (arrows, Home, End, PageUp, PageDown, Insert and Delete) to corresponding virtual keycodes
+- Fixed `Window::get_inner_size` and friends to return the size in pixels instead of points when using HIDPI displays on OSX.
 
 # Version 0.11.2 (2018-03-06)
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -560,22 +560,25 @@ impl Window2 {
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         unsafe {
             let view_frame = NSView::frame(*self.view);
-            Some((view_frame.size.width as u32, view_frame.size.height as u32))
+            let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
+            Some(((view_frame.size.width*factor) as u32, (view_frame.size.height*factor) as u32))
         }
     }
 
     #[inline]
     pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
         unsafe {
             let window_frame = NSWindow::frame(*self.window);
-            Some((window_frame.size.width as u32, window_frame.size.height as u32))
+            Some(((window_frame.size.width*factor) as u32, (window_frame.size.height*factor) as u32))
         }
     }
 
     #[inline]
     pub fn set_inner_size(&self, width: u32, height: u32) {
+        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
         unsafe {
-            NSWindow::setContentSize_(*self.window, NSSize::new(width as f64, height as f64));
+            NSWindow::setContentSize_(*self.window, NSSize::new((width as f64)/factor, (height as f64)/factor));
         }
     }
 


### PR DESCRIPTION
Just #359 rebased onto master with a changelog entry.

Hopefully this can get merged soon.

Closes #359.
Closes #399.