### PR TITLE
[macOS] implement HiDPIFactorChanged event on relevant events:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Implement `WindowEvent::HiDPIFactorChanged` for macOS
+
 # Version 0.11.3 (2018-03-28)
 
 - Added `set_min_dimensions` and `set_max_dimensions` methods to `Window`, and implemented on Windows, X11, Wayland, and OSX.

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -95,6 +95,17 @@ impl WindowDelegate {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
                 emit_resize_event(state);
+                let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
+                emit_event(state, WindowEvent::HiDPIFactorChanged(scale_factor));
+            }
+        }
+
+        extern fn window_did_change_backing_properties(this: &Object, _:Sel, _:id) {
+            unsafe {
+                let state: *mut c_void = *this.get_ivar("winitState");
+                let state = &mut *(state as *mut DelegateState);
+                let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
+                emit_event(state, WindowEvent::HiDPIFactorChanged(scale_factor));
             }
         }
 
@@ -198,7 +209,8 @@ impl WindowDelegate {
                 window_did_resize as extern fn(&Object, Sel, id));
             decl.add_method(sel!(windowDidChangeScreen:),
                 window_did_change_screen as extern fn(&Object, Sel, id));
-
+            decl.add_method(sel!(windowDidChangeBackingProperties:),
+                window_did_change_backing_properties as extern fn(&Object, Sel, id));
             decl.add_method(sel!(windowDidBecomeKey:),
                 window_did_become_key as extern fn(&Object, Sel, id));
             decl.add_method(sel!(windowDidResignKey:),


### PR DESCRIPTION
* moving window to another screen
* changing resolution of screen

implement #105 for macos
fixes #441 (using `windowDidChangeBackingProperties` instead of `viewDidChangeBackingProperties`)