### PR TITLE
Remove child thread from win32 event loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ features = [
     "libloaderapi",
     "windowsx",
     "hidusage",
+    "commctrl"
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -224,7 +224,7 @@ pub unsafe extern "system" fn callback(
                 window_id: SuperWindowId(WindowId(window)),
                 event: Closed
             });
-            winuser::DefWindowProcW(window, msg, wparam, lparam)
+            commctrl::DefSubclassProc(window, msg, wparam, lparam)
         },
         winuser::WM_DESTROY => {
             Box::from_raw(subclass_input);
@@ -364,7 +364,7 @@ pub unsafe extern "system" fn callback(
             use events::ElementState::Pressed;
             use events::VirtualKeyCode;
             if msg == winuser::WM_SYSKEYDOWN && wparam as i32 == winuser::VK_F4 {
-                winuser::DefWindowProcW(window, msg, wparam, lparam)
+                commctrl::DefSubclassProc(window, msg, wparam, lparam)
             } else {
                 let (scancode, vkey) = event::vkeycode_to_element(wparam, lparam);
                 subclass_input.event_queue.borrow_mut().push_back(Event::WindowEvent {
@@ -561,7 +561,7 @@ pub unsafe extern "system" fn callback(
 
                 0
             } else {
-                winuser::DefWindowProcW(window, msg, wparam, lparam)
+                commctrl::DefSubclassProc(window, msg, wparam, lparam)
             }
         },
 
@@ -612,7 +612,7 @@ pub unsafe extern "system" fn callback(
             };
 
             if call_def_window_proc {
-                winuser::DefWindowProcW(window, msg, wparam, lparam)
+                commctrl::DefSubclassProc(window, msg, wparam, lparam)
             } else {
                 0
             }
@@ -665,7 +665,7 @@ pub unsafe extern "system" fn callback(
         },
 
         _ => {
-            winuser::DefWindowProcW(window, msg, wparam, lparam)
+            commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
     }
 }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -371,8 +371,12 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
 
     // building a RECT object with coordinates
     let mut rect = RECT {
-        left: 0, right: window.dimensions.unwrap_or((1024, 768)).0 as LONG,
-        top: 0, bottom: window.dimensions.unwrap_or((1024, 768)).1 as LONG,
+        left: 0, right: window.dimensions.unwrap_or((1024, 768)).0
+            .max(window.min_dimensions.map(|m| m.0).unwrap_or(0))
+            .min(window.max_dimensions.map(|m| m.0).unwrap_or(u32::max_value())) as LONG,
+        top: 0, bottom: window.dimensions.unwrap_or((1024, 768)).1
+            .max(window.min_dimensions.map(|m| m.1).unwrap_or(0))
+            .min(window.max_dimensions.map(|m| m.1).unwrap_or(u32::max_value())) as LONG,
     };
 
     // switching to fullscreen if necessary


### PR DESCRIPTION
This PR removes child thread creation from the win32 event loop, which has the side effect of getting rid of all the hacks present beforehand to get inter-thread communication working properly. It also updates the window callback to use win32's subclassing API to pass winit's data to windows, rather than going through thread-local storage.

At first glance, this closes #415, #391, and #94, though further testing is required and it may close other issues I'm not seeing.

OUTSTANDING ISSUES:
* [ ] How do we handle Windows' modal loops (e.g. on resizing, moving)? Currently, the users' event handling code is paused, which is bad (not to mention inconsistent with other platforms).
* [ ] `EventsLoop` handles events from ALL windows on a thread, not just windows created within the loop.