### PR TITLE
Windows: Implement Refresh event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Overhauled X11 window geometry calculations. `get_position` and `set_position` are more universally accurate across different window managers, and `get_outer_size` actually works now.
 - Fixed SIGSEGV/SIGILL crashes on macOS caused by stabilization of the `!` (never) type.
+- Implemented `Refresh` event on Windows.
 
 # Version 0.12.0 (2018-04-06)
 

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -367,6 +367,15 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             1
         },
 
+        winuser::WM_PAINT => {
+            use events::WindowEvent::Refresh;
+            send_event(Event::WindowEvent {
+                window_id: SuperWindowId(WindowId(window)),
+                event: Refresh,
+            });
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
+        },
+
         winuser::WM_SIZE => {
             use events::WindowEvent::Resized;
             let w = LOWORD(lparam as DWORD) as u32;


### PR DESCRIPTION
Fixes #180 

This is based on [the snippet](https://github.com/tomaka/winit/issues/180#issuecomment-302977662) provided by @LPGhatguy, with one key difference: rather than returning 0, we pass the event along to the default handler. The reason for this is made clear in [the docs](https://msdn.microsoft.com/en-us/library/windows/desktop/dd145137(v=vs.85).aspx):

> If an application processes a `WM_PAINT` message but does not call `BeginPaint` or otherwise clear the update region, the application continues to receive `WM_PAINT` messages as long as the region is not empty. In all cases, an application must clear the update region before returning from the `WM_PAINT` message.

Using the original snippet, event processing slows down massively and my laptop fan gets quite loud. With this, `Refresh` appears to have the same behavior on Windows as on X11.