### PR TITLE
[macOS] Register the Cocoa main thread at an earlier point

### DIFF
--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -163,6 +163,13 @@ impl UserCallback {
 impl EventsLoop {
 
     pub fn new() -> Self {
+        // Mark this thread as the main thread of the Cocoa event system.
+        //
+        // This must be done before any worker threads get a chance to call it
+        // (e.g., via `EventsLoopProxy::wakeup()`), causing a wrong thread to be
+        // marked as the main thread.
+        unsafe { appkit::NSApp(); }
+
         EventsLoop {
             shared: Arc::new(Shared::new()),
             modifiers: Modifiers::new(),


### PR DESCRIPTION
Solves the issues caused by calling `EventsLoopProxy::wakeup()` too early from a worker thread.

A global singleton instance of `NSApplication` is created when `[NSApplication sharedApplication]` is called for the first time. When this happens, the calling thread is registered as the main thread. This means that the main thread in a Cocoa application is determined when the application calls it for the first time.

`EventsLoopProxy::wakeup` calls it internally. As a result, if you call `EventsLoopProxy::wakeup` very early, a wrong thread will be registered as the main thread, causing the application to misbehave. The framework detects such situations and generates the following log output:

    2018-04-10 13:34:43.495 ${ApplicationName}[90843:3858828] !!! BUG: The current event queue and the main event queue are not the same. Events will not be handled correctly. This is probably because _TSGetMainThread was called for the first time off the main thread.
    2018-04-10 13:34:43.499 ${ApplicationName}[90843:3858828] pid(90843)/euid(501) is calling TIS/TSM in non-main thread environment, ERROR : This is NOT allowed. Please call TIS/TSM in main thread!!!
    2018-04-10 13:34:43.513 ${ApplicationName}[90843:3858828] pid(90843)/euid(501) is calling TIS/TSM in non-main thread environment, ERROR : This is NOT allowed. Please call TIS/TSM in main thread!!!

<img width="1100" alt="screen shot 2018-04-10 at 14 02 28" src="https://user-images.githubusercontent.com/5253988/38539205-0eba587c-3cd2-11e8-9c41-611dbc50bc50.png">

This PR fixes this issue by calling `[NSApplication sharedApplication]` from `EventsLoop::new()`.
