### PR TITLE
 Implement set_maximized, get_current_monitor, set_fullscreen and set_decorations for MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Implement `WindowBuilder::with_maximized`, `Window::set_fullscreen`, `Window::set_maximized` and `Window::set_decorations` for MacOS.
 - Implement `WindowBuilder::with_maximized`, `Window::set_fullscreen`, `Window::set_maximized` and `Window::set_decorations` for Windows.
 - On Windows, `WindowBuilder::with_dimensions` no longer changing monitor display resolution.
 - Overhauled X11 window geometry calculations. `get_position` and `set_position` are more universally accurate across different window managers, and `get_outer_size` actually works now.

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -51,7 +51,7 @@ fn main() {
                     ..
                 } => match (virtual_code, state) {
                     (winit::VirtualKeyCode::Escape, _) => return ControlFlow::Break,
-                    (winit::VirtualKeyCode::F11, winit::ElementState::Pressed) => {
+                    (winit::VirtualKeyCode::F, winit::ElementState::Pressed) => {
                         is_fullscreen = !is_fullscreen;
                         if !is_fullscreen {
                             window.set_fullscreen(None);

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -25,6 +25,11 @@ impl EventsLoop {
         let id = MonitorId(CGDisplay::main().id);
         id
     }
+
+    pub fn make_monitor_from_display(id: CGDirectDisplayID) -> MonitorId {
+        let id = MonitorId(id);
+        id
+    }
 }
 
 impl MonitorId {

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 use super::EventsLoop;
 use super::window::IdRef;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MonitorId(CGDirectDisplayID);
 
 impl EventsLoop {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -347,8 +347,7 @@ impl WindowDelegate {
                         withObject:nil
                         afterDelay: 0.5                        
                     ];
-                }
-                else {
+                } else {
                     state.restore_state_from_fullscreen();
                 }
             }
@@ -574,7 +573,7 @@ impl Window2 {
         }
 
         // Make key have to be after set fullscreen
-        // to prevent normal zie window brefly appears
+        // to prevent normal size window brefly appears
         unsafe {
             if win_attribs.visible {
                 window.window.makeKeyAndOrderFront_(nil);

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -55,7 +55,7 @@ impl DelegateState {
 
             let is_zoomed: BOOL = msg_send![*self.window, isZoomed];
 
-            // Roll the the style
+            // Roll back temp styles
             if !win_attribs.decorations {
                 self.window.setStyleMask_(NSWindowStyleMask::NSBorderlessWindowMask);
             } 
@@ -302,8 +302,8 @@ impl WindowDelegate {
         /// Invoked when fail to enter fullscreen
         ///
         /// When this window launch from a fullscreen app (e.g. launch from VS Code
-        /// terminal), it creates a new virtual destkop and d an transition
-        /// animation. This animation takes one second and cannot be disable without
+        /// terminal), it creates a new virtual destkop and a transition animation. 
+        /// This animation takes one second and cannot be disable without
         /// elevated privileges. In this animation time, all toggleFullscreen events
         /// will be failed. In this implementation, we will try again by using
         /// performSelector:withObject:afterDelay: until window_did_enter_fullscreen.
@@ -427,6 +427,7 @@ pub struct Window2 {
 unsafe impl Send for Window2 {}
 unsafe impl Sync for Window2 {}
 
+/// Helpper funciton to convert NSScreen::mainScreen to MonitorId
 unsafe fn get_current_monitor() -> RootMonitorId {
     let screen = NSScreen::mainScreen(nil);
     let desc = NSScreen::deviceDescription(screen);


### PR DESCRIPTION
This PR implemented following functions in MacOS:
- `Window::get_current_monitor`
- `Window::set_fullscreen`
- `Window::set_maximized`
- `Window::set_decorations`
- `WindowBuilder::with_maximized`

And the maximized and fullscreen behaviors are following safari's conventions. (See https://github.com/tomaka/winit/issues/460).

This PR should f-ixed #300, #72, #66, #129, and Part of #252
