### PR TITLE
Discard mouse down after Cocoa window resize

### DIFF
--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -87,6 +87,9 @@ impl WindowDelegate {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
                 emit_resize_event(state);
+                if let Some(shared) = state.shared.upgrade() {
+                    shared.discard_next_event();
+                }
             }
         }
 


### PR DESCRIPTION
We are sending the mouse down event after the window resize has
completed, because Cocoa uses a modal event loop to implement window
resize. This leads to a mouse down without a matching mouse up.

This fixes #463.