### PR TITLE
x11: Windows are Sync again

### DIFF
--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -1004,7 +1004,7 @@ pub struct Window {
     pub window: Arc<Window2>,
     display: Weak<XConnection>,
     windows: Weak<Mutex<HashMap<WindowId, WindowData>>>,
-    ime_sender: ImeSender,
+    ime_sender: Mutex<ImeSender>,
 }
 
 impl ::std::ops::Deref for Window {
@@ -1038,7 +1038,7 @@ impl Window {
             window: win,
             windows: Arc::downgrade(&x_events_loop.windows),
             display: Arc::downgrade(&x_events_loop.display),
-            ime_sender: x_events_loop.ime_sender.clone(),
+            ime_sender: Mutex::new(x_events_loop.ime_sender.clone()),
         })
     }
 
@@ -1049,7 +1049,10 @@ impl Window {
 
     #[inline]
     pub fn send_xim_spot(&self, x: i16, y: i16) {
-        let _ = self.ime_sender.send((self.window.id().0, x, y));
+        let _ = self.ime_sender
+            .lock()
+            .unwrap()
+            .send((self.window.id().0, x, y));
     }
 }
 

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -1,0 +1,9 @@
+extern crate winit;
+
+fn needs_sync<T:Sync>() {}
+
+#[test]
+fn window_sync() {
+    // ensures that `winit::Window` implements `Sync`
+    needs_sync::<winit::Window>();
+}


### PR DESCRIPTION
Fixes #472

This also adds a test ensuring that `Window` is `Sync`. 