### PR TITLE
Windows: Implement DeviceEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Corrected `get_position` on Windows to be relative to the screen rather than to the taskbar.
 - Corrected `Moved` event on Windows to use position values equivalent to those returned by `get_position`. It previously supplied client area positions instead of window positions, and would additionally interpret negative values as being very large (around `u16::MAX`).
+- On Windows, implemented all variants of `DeviceEvent` other than `Text`. Mouse `DeviceEvent`s are now received even if the window isn't in the foreground.
+- `DeviceId` on Windows is no longer a unit struct, and now contains a `u32`. For `WindowEvent`s, this will always be 0, but on `DeviceEvent`s it will be the handle to that device. `DeviceIdExt::get_persistent_identifier` can be used to acquire a unique identifier for that device that persists across replugs/reboots/etc.
 
 # Version 0.13.1 (2018-04-26)
 

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -3,6 +3,7 @@
 use std::os::raw::c_void;
 use libc;
 use MonitorId;
+use DeviceId;
 use Window;
 use WindowBuilder;
 use winapi::shared::windef::HWND;
@@ -54,5 +55,20 @@ impl MonitorIdExt for MonitorId {
     #[inline]
     fn hmonitor(&self) -> *mut c_void {
         self.inner.get_hmonitor() as *mut _
+    }
+}
+
+/// Additional methods on `DeviceId` that are specific to Windows.
+pub trait DeviceIdExt {
+    /// Returns an identifier that persistently refers to this specific device.
+    ///
+    /// Will return `None` if the device is no longer available.
+    fn get_persistent_identifier(&self) -> Option<String>;
+}
+
+impl DeviceIdExt for DeviceId {
+    #[inline]
+    fn get_persistent_identifier(&self) -> Option<String> {
+        self.0.get_persistent_identifier()
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -18,10 +18,25 @@ unsafe impl Sync for PlatformSpecificWindowBuilderAttributes {}
 // TODO: document what this means
 pub type Cursor = *const winapi::ctypes::wchar_t;
 
-// Constant device ID, to be removed when this backend is updated to report real device IDs.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId;
-const DEVICE_ID: ::DeviceId = ::DeviceId(DeviceId);
+pub struct DeviceId(u32);
+
+impl DeviceId {
+    pub fn get_persistent_identifier(&self) -> Option<String> {
+        if self.0 != 0 {
+            raw_input::get_raw_input_device_name(self.0 as _)
+        } else {
+            None
+        }
+    }
+}
+
+// Constant device ID, to be removed when this backend is updated to report real device IDs.
+const DEVICE_ID: ::DeviceId = ::DeviceId(DeviceId(0));
+
+fn wrap_device_id(id: u32) -> ::DeviceId {
+    ::DeviceId(DeviceId(id))
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(HWND);
@@ -31,4 +46,6 @@ unsafe impl Sync for WindowId {}
 mod event;
 mod events_loop;
 mod monitor;
+mod raw_input;
+mod util;
 mod window;

--- a/src/platform/windows/raw_input.rs
+++ b/src/platform/windows/raw_input.rs
@@ -1,0 +1,235 @@
+use std::mem::{self, size_of};
+use std::ptr;
+
+use winapi::ctypes::wchar_t;
+use winapi::shared::minwindef::{UINT, USHORT, TRUE};
+use winapi::shared::hidusage::{
+    HID_USAGE_PAGE_GENERIC,
+    HID_USAGE_GENERIC_MOUSE,
+    HID_USAGE_GENERIC_KEYBOARD,
+};
+use winapi::shared::windef::HWND;
+use winapi::um::winnt::HANDLE;
+use winapi::um::winuser::{
+    self,
+    RAWINPUTDEVICELIST,
+    RID_DEVICE_INFO,
+    RID_DEVICE_INFO_MOUSE,
+    RID_DEVICE_INFO_KEYBOARD,
+    RID_DEVICE_INFO_HID,
+    RIM_TYPEMOUSE,
+    RIM_TYPEKEYBOARD,
+    RIM_TYPEHID,
+    RIDI_DEVICEINFO,
+    RIDI_DEVICENAME,
+    RAWINPUTDEVICE,
+    RIDEV_DEVNOTIFY,
+    RIDEV_INPUTSINK,
+    HRAWINPUT,
+    RAWINPUT,
+    RAWINPUTHEADER,
+    RID_INPUT,
+};
+
+use platform::platform::util;
+use events::ElementState;
+
+#[allow(dead_code)]
+pub fn get_raw_input_device_list() -> Option<Vec<RAWINPUTDEVICELIST>> {
+    let list_size = size_of::<RAWINPUTDEVICELIST>() as UINT;
+
+    let mut num_devices = 0;
+    let status = unsafe { winuser::GetRawInputDeviceList(
+        ptr::null_mut(),
+        &mut num_devices,
+        list_size,
+    ) };
+
+    if status == UINT::max_value() {
+        return None;
+    }
+
+    let mut buffer = Vec::with_capacity(num_devices as _);
+
+    let num_stored = unsafe { winuser::GetRawInputDeviceList(
+        buffer.as_ptr() as _,
+        &mut num_devices,
+        list_size,
+    ) };
+
+    if num_stored == UINT::max_value() {
+        return None;
+    }
+
+    debug_assert_eq!(num_devices, num_stored);
+
+    unsafe { buffer.set_len(num_devices as _) };
+
+    Some(buffer)
+}
+
+#[allow(dead_code)]
+pub enum RawDeviceInfo {
+    Mouse(RID_DEVICE_INFO_MOUSE),
+    Keyboard(RID_DEVICE_INFO_KEYBOARD),
+    Hid(RID_DEVICE_INFO_HID),
+}
+
+impl From<RID_DEVICE_INFO> for RawDeviceInfo {
+    fn from(info: RID_DEVICE_INFO) -> Self {
+        unsafe {
+            match info.dwType {
+                RIM_TYPEMOUSE => RawDeviceInfo::Mouse(*info.u.mouse()),
+                RIM_TYPEKEYBOARD => RawDeviceInfo::Keyboard(*info.u.keyboard()),
+                RIM_TYPEHID => RawDeviceInfo::Hid(*info.u.hid()),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn get_raw_input_device_info(handle: HANDLE) -> Option<RawDeviceInfo> {
+    let mut info: RID_DEVICE_INFO = unsafe { mem::uninitialized() };
+    let info_size = size_of::<RID_DEVICE_INFO>() as UINT;
+
+    info.cbSize = info_size;
+
+    let mut minimum_size = 0;
+    let status = unsafe { winuser::GetRawInputDeviceInfoW(
+        handle,
+        RIDI_DEVICEINFO,
+        &mut info as *mut _ as _,
+        &mut minimum_size,
+    ) };
+
+    if status == UINT::max_value() || status == 0 {
+        return None;
+    }
+
+    debug_assert_eq!(info_size, status);
+
+    Some(info.into())
+}
+
+pub fn get_raw_input_device_name(handle: HANDLE) -> Option<String> {
+    let mut minimum_size = 0;
+    let status = unsafe { winuser::GetRawInputDeviceInfoW(
+        handle,
+        RIDI_DEVICENAME,
+        ptr::null_mut(),
+        &mut minimum_size,
+    ) };
+
+    if status != 0 {
+        return None;
+    }
+
+    let mut name: Vec<wchar_t> = Vec::with_capacity(minimum_size as _);
+
+    let status = unsafe { winuser::GetRawInputDeviceInfoW(
+        handle,
+        RIDI_DEVICENAME,
+        name.as_ptr() as _,
+        &mut minimum_size,
+    ) };
+
+    if status == UINT::max_value() || status == 0 {
+        return None;
+    }
+
+    debug_assert_eq!(minimum_size, status);
+
+    unsafe { name.set_len(minimum_size as _) };
+
+    Some(util::wchar_to_string(&name))
+}
+
+pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {
+    let device_size = size_of::<RAWINPUTDEVICE>() as UINT;
+
+    let success = unsafe { winuser::RegisterRawInputDevices(
+        devices.as_ptr() as _,
+        devices.len() as _,
+        device_size,
+    ) };
+
+    success == TRUE
+}
+
+pub fn register_all_mice_and_keyboards_for_raw_input(window_handle: HWND) -> bool {
+    // RIDEV_DEVNOTIFY: receive hotplug events
+    // RIDEV_INPUTSINK: receive events even if we're not in the foreground
+    let flags = RIDEV_DEVNOTIFY | RIDEV_INPUTSINK;
+
+    let devices: [RAWINPUTDEVICE; 2] = [
+        RAWINPUTDEVICE {
+            usUsagePage: HID_USAGE_PAGE_GENERIC,
+            usUsage: HID_USAGE_GENERIC_MOUSE,
+            dwFlags: flags,
+            hwndTarget: window_handle,
+        },
+        RAWINPUTDEVICE {
+            usUsagePage: HID_USAGE_PAGE_GENERIC,
+            usUsage: HID_USAGE_GENERIC_KEYBOARD,
+            dwFlags: flags,
+            hwndTarget: window_handle,
+        },
+    ];
+
+    register_raw_input_devices(&devices)
+}
+
+pub fn get_raw_input_data(handle: HRAWINPUT) -> Option<RAWINPUT> {
+    let mut data: RAWINPUT = unsafe { mem::uninitialized() };
+    let mut data_size = size_of::<RAWINPUT>() as UINT;
+    let header_size = size_of::<RAWINPUTHEADER>() as UINT;
+
+    let status = unsafe { winuser::GetRawInputData(
+        handle,
+        RID_INPUT,
+        &mut data as *mut _  as _,
+        &mut data_size,
+        header_size,
+    ) };
+
+    if status == UINT::max_value() || status == 0 {
+        return None;
+    }
+
+    Some(data)
+}
+
+
+fn button_flags_to_element_state(button_flags: USHORT, down_flag: USHORT, up_flag: USHORT)
+    -> Option<ElementState>
+{
+    // We assume the same button won't be simultaneously pressed and released.
+    if util::has_flag(button_flags, down_flag) {
+        Some(ElementState::Pressed)
+    } else if util::has_flag(button_flags, up_flag) {
+        Some(ElementState::Released)
+    } else {
+        None
+    }
+}
+
+pub fn get_raw_mouse_button_state(button_flags: USHORT) -> [Option<ElementState>; 3] {
+    [
+        button_flags_to_element_state(
+            button_flags,
+            winuser::RI_MOUSE_LEFT_BUTTON_DOWN,
+            winuser::RI_MOUSE_LEFT_BUTTON_UP,
+        ),
+        button_flags_to_element_state(
+            button_flags,
+            winuser::RI_MOUSE_MIDDLE_BUTTON_DOWN,
+            winuser::RI_MOUSE_MIDDLE_BUTTON_UP,
+        ),
+        button_flags_to_element_state(
+            button_flags,
+            winuser::RI_MOUSE_RIGHT_BUTTON_DOWN,
+            winuser::RI_MOUSE_RIGHT_BUTTON_UP,
+        ),
+    ]
+}

--- a/src/platform/windows/util.rs
+++ b/src/platform/windows/util.rs
@@ -1,0 +1,16 @@
+use std::ops::BitAnd;
+
+use winapi::ctypes::wchar_t;
+
+pub fn has_flag<T>(bitset: T, flag: T) -> bool
+where T:
+    Copy + PartialEq + BitAnd<T, Output = T>
+{
+    bitset & flag == flag
+}
+
+pub fn wchar_to_string(wchar: &[wchar_t]) -> String {
+    String::from_utf16_lossy(wchar)
+        .trim_right_matches(0 as char)
+        .to_string()
+}

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -14,6 +14,7 @@ use std::cell::Cell;
 use platform::platform::events_loop::{self, DESTROY_MSG_ID};
 use platform::platform::EventsLoop;
 use platform::platform::PlatformSpecificWindowBuilderAttributes;
+use platform::platform::raw_input::register_all_mice_and_keyboards_for_raw_input;
 use platform::platform::WindowId;
 
 use CreationError;
@@ -24,7 +25,6 @@ use MonitorId as RootMonitorId;
 
 use winapi::shared::minwindef::{UINT, DWORD, BOOL};
 use winapi::shared::windef::{HWND, HDC, RECT, POINT};
-use winapi::shared::hidusage;
 use winapi::um::{winuser, dwmapi, libloaderapi, processthreadsapi};
 use winapi::um::winnt::{LPCWSTR, LONG, HRESULT};
 use winapi::um::combaseapi;
@@ -727,16 +727,8 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
         WindowWrapper(handle, hdc)
     };
 
-    // Set up raw mouse input
-    {
-        let mut rid: winuser::RAWINPUTDEVICE = mem::uninitialized();
-        rid.usUsagePage = hidusage::HID_USAGE_PAGE_GENERIC;
-        rid.usUsage = hidusage::HID_USAGE_GENERIC_MOUSE;
-        rid.dwFlags = 0;
-        rid.hwndTarget = real_window.0;
-
-        winuser::RegisterRawInputDevices(&rid, 1, mem::size_of::<winuser::RAWINPUTDEVICE>() as u32);
-    }
+    // Set up raw input
+    register_all_mice_and_keyboards_for_raw_input(real_window.0);
 
     // Register for touch events if applicable
     {


### PR DESCRIPTION
Fixes #467

All variants other than `Text` have been implemented. While `Text` can be implemented using `ToUnicode`, that doesn't play nice with dead keys, IME, etc.

Most of the mouse `DeviceEvent`s were already implemented, but due to the flags that were used when registering for raw input events, they only worked when the window was in the foreground.

This is also a step forward for #338, as `DeviceId`s are no longer useless on Windows. On `DeviceEvent`s, the `DeviceId` contains that device's handle. While that handle could ostensibly be used by developers to query device information, my actual reason for choosing it is because it's simply a very easy way to handle this. As a fun bonus, this enabled me to create this method:
```rust
DevideIdExt::get_persistent_identifier() -> Option<String>
```
Using this gives you a unique identifier for the device that persists across replugs/reboots/etc., so it's ideal for something like device-specific configuration.

There's a notable caveat to the new `DeviceId`s, which is that the value will always be 0 for a `WindowEvent`. There doesn't seem to be any straightforward way around this limitation.

I was concerned that multi-window applications would receive *n* copies of every `DeviceEvent`, but Windows only sends them to one window per application.

Lastly, there's a chance that these additions will cause antivirus/etc. software to detect winit applications as keyloggers. I don't know how likely that is to actually happen to people, but if it does become an issue, the raw input code is neatly sequestered and would be easy to make optional during compilation.