### PR TITLE
Release winit 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.13.1 (2018-04-26)
+
+- Ensure necessary `x11-dl` version is used.
+
 # Version 0.13.0 (2018-04-25)
 
 - Implement `WindowBuilder::with_maximized`, `Window::set_fullscreen`, `Window::set_maximized` and `Window::set_decorations` for MacOS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]


### PR DESCRIPTION
0.13.0 requires existing users to run `cargo update` to build on Linux (#484). 0.13.1 doesn't.