### PR TITLE
x11: Always receive Awakened event in run_forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Corrected `get_position` on Windows to be relative to the screen rather than to the taskbar.
 - Corrected `Moved` event on Windows to use position values equivalent to those returned by `get_position`. It previously supplied client area positions instead of window positions, and would additionally interpret negative values as being very large (around `u16::MAX`).
 - Implemented `Moved` event on macOS.
+- Corrected `run_forever` on X11 to stop discarding `Awakened` events.
 
 # Version 0.13.1 (2018-04-26)
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -190,8 +190,6 @@ impl EventsLoop {
     pub fn run_forever<F>(&mut self, mut callback: F)
         where F: FnMut(Event) -> ControlFlow
     {
-        self.pending_wakeup.store(false, atomic::Ordering::Relaxed);
-
         let mut xev = unsafe { mem::uninitialized() };
 
         loop {


### PR DESCRIPTION
Do not reset the pending_wakeup boolean at the start of run_forever so
that each call to EventsLoopProxy::wakeup results in an Awakened event.

Fixes #462