### PR TITLE
Add Copy/Paste keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Added `Copy`, `Paste` and `Cut` `VirtualKeyCode`s on Linux and Windows
 - Fix `.with_decorations(false)` in macOS
 - On Mac, `NSWindow` and supporting objects might be alive long after they were `closed` which resulted in apps consuming more heap then needed. Mainly it was affecting multi window applications. Not expecting any user visible change of behaviour after the fix.
 - Fix regression of Window platform extensions for macOS where `NSFullSizeContentViewWindowMask` was not being correctly applied to `.fullsize_content_view`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Added `Copy`, `Paste` and `Cut` `VirtualKeyCode`s on Linux and Windows
+- Added `Copy` VirtualKeyCode on Windows and Linux, additinally added `Paste` and `Cut` on Linux
 - Fix `.with_decorations(false)` in macOS
 - On Mac, `NSWindow` and supporting objects might be alive long after they were `closed` which resulted in apps consuming more heap then needed. Mainly it was affecting multi window applications. Not expecting any user visible change of behaviour after the fix.
 - Fix regression of Window platform extensions for macOS where `NSFullSizeContentViewWindowMask` was not being correctly applied to `.fullsize_content_view`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Added `Copy` VirtualKeyCode on Windows and Linux, additinally added `Paste` and `Cut` on Linux
+- Created the `Copy`, `Paste` and `Cut` `VirtualKeyCode`s and added support for them on X11 and Wayland
 - Fix `.with_decorations(false)` in macOS
 - On Mac, `NSWindow` and supporting objects might be alive long after they were `closed` which resulted in apps consuming more heap then needed. Mainly it was affecting multi window applications. Not expecting any user visible change of behaviour after the fix.
 - Fix regression of Window platform extensions for macOS where `NSFullSizeContentViewWindowMask` was not being correctly applied to `.fullsize_content_view`.

--- a/src/events.rs
+++ b/src/events.rs
@@ -433,6 +433,7 @@ pub enum VirtualKeyCode {
     Yen,
     Copy,
     Paste,
+    Cut,
 }
 
 /// Represents the current state of the keyboard modifiers

--- a/src/events.rs
+++ b/src/events.rs
@@ -431,6 +431,8 @@ pub enum VirtualKeyCode {
     WebSearch,
     WebStop,
     Yen,
+    Copy,
+    Paste,
 }
 
 /// Represents the current state of the keyboard modifiers

--- a/src/platform/linux/wayland/keyboard.rs
+++ b/src/platform/linux/wayland/keyboard.rs
@@ -290,10 +290,10 @@ fn keysym_to_vkey(keysym: u32) -> Option<VirtualKeyCode> {
         // => Some(VirtualKeyCode::WebSearch),
         // => Some(VirtualKeyCode::WebStop),
         // => Some(VirtualKeyCode::Yen),
-        // fallback
         keysyms::XKB_KEY_XF86Copy => Some(VirtualKeyCode::Copy),
         keysyms::XKB_KEY_XF86Paste => Some(VirtualKeyCode::Paste),
         keysyms::XKB_KEY_CUT => Some(VirtualKeyCode::Cut),
+        // fallback
         _ => None
     }
 }

--- a/src/platform/linux/wayland/keyboard.rs
+++ b/src/platform/linux/wayland/keyboard.rs
@@ -293,6 +293,7 @@ fn keysym_to_vkey(keysym: u32) -> Option<VirtualKeyCode> {
         // fallback
         keysyms::XKB_KEY_XF86Copy => Some(VirtualKeyCode::Copy),
         keysyms::XKB_KEY_XF86Paste => Some(VirtualKeyCode::Paste),
+        keysyms::XKB_KEY_CUT => Some(VirtualKeyCode::Cut),
         _ => None
     }
 }

--- a/src/platform/linux/wayland/keyboard.rs
+++ b/src/platform/linux/wayland/keyboard.rs
@@ -292,7 +292,7 @@ fn keysym_to_vkey(keysym: u32) -> Option<VirtualKeyCode> {
         // => Some(VirtualKeyCode::Yen),
         keysyms::XKB_KEY_XF86Copy => Some(VirtualKeyCode::Copy),
         keysyms::XKB_KEY_XF86Paste => Some(VirtualKeyCode::Paste),
-        keysyms::XKB_KEY_CUT => Some(VirtualKeyCode::Cut),
+        keysyms::XKB_KEY_XF86Cut => Some(VirtualKeyCode::Cut),
         // fallback
         _ => None
     }

--- a/src/platform/linux/wayland/keyboard.rs
+++ b/src/platform/linux/wayland/keyboard.rs
@@ -291,6 +291,8 @@ fn keysym_to_vkey(keysym: u32) -> Option<VirtualKeyCode> {
         // => Some(VirtualKeyCode::WebStop),
         // => Some(VirtualKeyCode::Yen),
         // fallback
+        keysyms::XKB_KEY_XF86Copy => Some(VirtualKeyCode::Copy),
+        keysyms::XKB_KEY_XF86Paste => Some(VirtualKeyCode::Paste),
         _ => None
     }
 }

--- a/src/platform/linux/x11/events.rs
+++ b/src/platform/linux/x11/events.rs
@@ -1000,6 +1000,8 @@ pub fn keysym_to_element(keysym: libc::c_uint) -> Option<VirtualKeyCode> {
         //ffi::XK_Hebrew_switch => events::VirtualKeyCode::Hebrew_switch,
         ffi::XF86XK_Back => VirtualKeyCode::NavigateBackward,
         ffi::XF86XK_Forward => VirtualKeyCode::NavigateForward,
+        ffi::XF86XK_Copy => VirtualKeyCode::Copy,
+        ffi::XF86XK_Paste => VirtualKeyCode::Paste,
         _ => return None
     })
 }

--- a/src/platform/linux/x11/events.rs
+++ b/src/platform/linux/x11/events.rs
@@ -1002,6 +1002,7 @@ pub fn keysym_to_element(keysym: libc::c_uint) -> Option<VirtualKeyCode> {
         ffi::XF86XK_Forward => VirtualKeyCode::NavigateForward,
         ffi::XF86XK_Copy => VirtualKeyCode::Copy,
         ffi::XF86XK_Paste => VirtualKeyCode::Paste,
+        ffi::XF86XK_Cut => VirtualKeyCode::Cut,
         _ => return None
     })
 }

--- a/src/platform/windows/event.rs
+++ b/src/platform/windows/event.rs
@@ -201,9 +201,7 @@ pub fn vkey_to_winit_vkey(vkey: c_int) -> Option<VirtualKeyCode> {
         winuser::VK_NONAME => Some(VirtualKeyCode::Noname),
         winuser::VK_PA1 => Some(VirtualKeyCode::Pa1),
         winuser::VK_OEM_CLEAR => Some(VirtualKeyCode::Oem_clear),*/
-        winuser::APPCOMMAND_COPY => Some(VirtualKeyCode::Copy),
-        winuser::APPCOMMAND_PASTE => Some(VirtualKeyCode::Paste),
-        winuser::APPCOMMAND_CUT => Some(VirtualKeyCode::Cut),
+        winuser::VK_OEM_COPY => Some(VirtualKeyCode::Copy),
         _ => None
     }
 }

--- a/src/platform/windows/event.rs
+++ b/src/platform/windows/event.rs
@@ -201,6 +201,8 @@ pub fn vkey_to_winit_vkey(vkey: c_int) -> Option<VirtualKeyCode> {
         winuser::VK_NONAME => Some(VirtualKeyCode::Noname),
         winuser::VK_PA1 => Some(VirtualKeyCode::Pa1),
         winuser::VK_OEM_CLEAR => Some(VirtualKeyCode::Oem_clear),*/
+        winuser::WM_COPY => Some(VirtualKeyCode::Copy),
+        winuser::WM_PASTE => Some(VirtualKeyCode::Paste),
         _ => None
     }
 }

--- a/src/platform/windows/event.rs
+++ b/src/platform/windows/event.rs
@@ -201,8 +201,9 @@ pub fn vkey_to_winit_vkey(vkey: c_int) -> Option<VirtualKeyCode> {
         winuser::VK_NONAME => Some(VirtualKeyCode::Noname),
         winuser::VK_PA1 => Some(VirtualKeyCode::Pa1),
         winuser::VK_OEM_CLEAR => Some(VirtualKeyCode::Oem_clear),*/
-        winuser::WM_COPY => Some(VirtualKeyCode::Copy),
-        winuser::WM_PASTE => Some(VirtualKeyCode::Paste),
+        winuser::APPCOMMAND_COPY => Some(VirtualKeyCode::Copy),
+        winuser::APPCOMMAND_PASTE => Some(VirtualKeyCode::Paste),
+        winuser::APPCOMMAND_CUT => Some(VirtualKeyCode::Cut),
         _ => None
     }
 }

--- a/src/platform/windows/event.rs
+++ b/src/platform/windows/event.rs
@@ -201,7 +201,6 @@ pub fn vkey_to_winit_vkey(vkey: c_int) -> Option<VirtualKeyCode> {
         winuser::VK_NONAME => Some(VirtualKeyCode::Noname),
         winuser::VK_PA1 => Some(VirtualKeyCode::Pa1),
         winuser::VK_OEM_CLEAR => Some(VirtualKeyCode::Oem_clear),*/
-        winuser::VK_OEM_COPY => Some(VirtualKeyCode::Copy),
         _ => None
     }
 }


### PR DESCRIPTION
This is only a tiny update which introduces the `Copy` and `Paste` keys
which are present on X11/Wayland/Windows. I'm not sure if this exists on
MacOS too, but I'm not able to test that and it doesn't have names but
just matches on the hex key values.

The "Copy" element is a reserved keyword in Rust but shouldn't cause any
conflicts in this scenario, this behavior falls in line with
https://docs.rs/winit/0.13.1/winit/enum.MouseCursor.html#variant.Copy,
but it would be possible to rename it. However `Copy` seems like the
most intuitive choice.

I'd be willing to add a few other keys too, however I wanted to keep this minimal
to what I actually want and need. I'm not quite sure why the current selection of
keys is the way it is, so I'm keeping this PR to the bare minimum of what I would
like to see introduced.