### PR TITLE
Windows: Fix panic when calling set_fullscreen(None)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Rework of the wayland backend, migrating it to use [Smithay's Client Toolkit](https://github.com/Smithay/client-toolkit).
 - Added `WindowBuilder::with_window_icon` and `Window::set_window_icon`, finally making it possible to set the window icon on Windows and X11. The `icon_loading` feature can be enabled to allow for icons to be easily loaded; see example program `window_icon.rs` for usage.
 - Windows additionally has `WindowBuilderExt::with_taskbar_icon` and `WindowExt::set_taskbar_icon`.
+- Fix panic when trying to call `set_fullscreen(None)` on a window that has not been fullscreened prior.
 
 # Version 0.13.1 (2018-04-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Rework of the wayland backend, migrating it to use [Smithay's Client Toolkit](https://github.com/Smithay/client-toolkit).
 - Added `WindowBuilder::with_window_icon` and `Window::set_window_icon`, finally making it possible to set the window icon on Windows and X11. The `icon_loading` feature can be enabled to allow for icons to be easily loaded; see example program `window_icon.rs` for usage.
 - Windows additionally has `WindowBuilderExt::with_taskbar_icon` and `WindowExt::set_taskbar_icon`.
-- Fix panic when trying to call `set_fullscreen(None)` on a window that has not been fullscreened prior.
+- On Windows, fix panic when trying to call `set_fullscreen(None)` on a window that has not been fullscreened prior.
 
 # Version 0.13.1 (2018-04-26)
 

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -425,6 +425,13 @@ impl Window {
 
     unsafe fn restore_saved_window(&self) {
         let window_state = self.window_state.lock().unwrap();
+
+        // 'saved_window_info' can be None if the window has never been
+        // in fullscreen mode before this method gets called.
+        if window_state.saved_window_info.is_none() {
+            return;
+        }
+
         // Reset original window style and size.  The multiple window size/moves
         // here are ugly, but if SetWindowPos() doesn't redraw, the taskbar won't be
         // repainted.  Better-looking methods welcome.


### PR DESCRIPTION
Fixes #501 

This circumvents a panic when one calls set_fullscreen(None) on a window that has never been in fullscreen mode prior to calling that method.