### PR TITLE
Add support for `WM_CREATE` and `WM_COMMAND` messages on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Added `WindowBuilder::with_window_icon` and `Window::set_window_icon`, finally making it possible to set the window icon on Windows and X11. The `icon_loading` feature can be enabled to allow for icons to be easily loaded; see example program `window_icon.rs` for usage.
 - Windows additionally has `WindowBuilderExt::with_taskbar_icon` and `WindowExt::set_taskbar_icon`.
 - On Windows, fix panic when trying to call `set_fullscreen(None)` on a window that has not been fullscreened prior.
+- Added `WindowBuilder::with_create_callback` on Windows, allowing to add custom application menus (see the `menu_bar_win32` example)
+- Added the `WindowEvent::Command` to catch custom Win32 messages (see the `menu_bar_win32` for a usage example)
+- Publicly exported the `winapi` crate, so that other crates can depend on the exact version of `winapi` that `winit` is using (to prevent version conflicts between different versions of `winapi` for external libraries)
 
 # Version 0.13.1 (2018-04-26)
 

--- a/examples/menu_bar_win32.rs
+++ b/examples/menu_bar_win32.rs
@@ -1,0 +1,104 @@
+extern crate winit;
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    println!("This example only works on Windows!");
+}
+
+#[cfg(target_os = "windows")]
+const ID_FILE_NEW: u16         = 9001;
+#[cfg(target_os = "windows")]
+const ID_QUIT_APPLICATION: u16 = 9002;
+
+#[cfg(target_os = "windows")]
+fn main() {
+    use winit::os::windows::WindowBuilderExt;
+    let mut events_loop = winit::EventsLoop::new();
+
+    let _window = winit::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_create_callback(win32_create_callback)
+        .build(&events_loop)
+        .unwrap();
+
+    events_loop.run_forever(|event| {
+        match event {
+            winit::Event::WindowEvent { event,  .. } => {
+                match event {
+                    winit::WindowEvent::CloseRequested => winit::ControlFlow::Break,
+                    winit::WindowEvent::Command(command) => {
+                        match command {
+                            ID_FILE_NEW => {
+                                println!("New File button clicked!");
+                                winit::ControlFlow::Continue
+                            },
+                            ID_QUIT_APPLICATION => {
+                                println!("Quit Application button clicked!");
+                                winit::ControlFlow::Break
+                            },
+                            _ => winit::ControlFlow::Continue,
+                        }
+                    },
+                    _ => winit::ControlFlow::Continue,
+                }
+            },
+            _ => winit::ControlFlow::Continue,
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn win32_create_callback(hwnd: winit::winapi::shared::windef::HWND) {
+
+    // Encode a Rust `&str` as a Vec<u16> compatible with the Win32 API
+    fn str_to_wide_vec_u16(input: &str) -> Vec<u16> {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStrExt;
+        let mut s: Vec<u16> = OsString::from(input).as_os_str().encode_wide().into_iter().collect();
+        s.push(0);
+        s
+    }
+
+    use winit::winapi::um::winuser::{SetMenu, CreateMenu, AppendMenuW, DestroyMenu, MF_STRING, MF_POPUP};
+
+    let menu_bar = unsafe { CreateMenu() };
+    if menu_bar.is_null() {
+        println!("CreateMenu failed!");
+        return;
+    }
+
+    let popup_menu_1 = unsafe { CreateMenu() };
+    if popup_menu_1.is_null() {
+        println!("CreateMenu failed!");
+        unsafe { DestroyMenu(menu_bar) };
+        return;
+    }
+
+    let application_top_level_menu_str = str_to_wide_vec_u16("&Application");
+    let file_new_str = str_to_wide_vec_u16("New &File");
+    let quit_application_str = str_to_wide_vec_u16("&Quit");
+
+    // In order to keep this example simple, we don't check for errors here...
+
+    // Append the "New File" to the popup menu
+    unsafe { AppendMenuW(popup_menu_1, MF_STRING, ID_FILE_NEW as usize, file_new_str.as_ptr()) };
+
+    // Append the "Quit" to the popup menu
+    unsafe { AppendMenuW(popup_menu_1, MF_STRING, ID_QUIT_APPLICATION as usize, quit_application_str.as_ptr()) };
+
+    // Append the popup menu to the menu bar under the text "Application"
+    unsafe { AppendMenuW(menu_bar, MF_POPUP, popup_menu_1 as usize, application_top_level_menu_str.as_ptr()) };
+
+    // Add the menu bar to the window
+    if unsafe { SetMenu(hwnd, menu_bar) } == 0 { // <- window locks up here
+        println!("SetMenu failed!");
+        unsafe { DestroyMenu(popup_menu_1) };
+        unsafe { DestroyMenu(menu_bar) };
+        return;
+    }
+
+    // You can store the resources in your structure here if you want to
+    // (ex. for pushing new items to the menu).
+    unsafe { DestroyMenu(popup_menu_1) };
+    unsafe { DestroyMenu(menu_bar) };
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -104,6 +104,16 @@ pub enum WindowEvent {
     /// * A user changes the desktop scaling value (e.g. in Control Panel on Windows).
     /// * A user moves the application window to a display with a different DPI.
     HiDPIFactorChanged(f32),
+
+    /// Custom command (currently only emitted on Windows). Win32 allows the user to
+    /// register custom command IDs for app menus, context menus and so on
+    /// (see the `WM_COMMAND` message in the Windows API). This event allows
+    /// you to, for example, react to when a user has clicked an item in an application menu.
+    ///
+    /// The ID contained in the `Command` has to be registered by the user of the library,
+    /// usually by using the `WindowBuilder::with_create_callback` function.
+    /// For an example of how to use it, see the `menu_bar_win32` example.
+    Command(u16)
 }
 
 /// Represents raw hardware events that are not associated with any particular window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ extern crate image;
 
 #[cfg(target_os = "windows")]
 #[macro_use]
-extern crate winapi;
+pub extern crate winapi;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[macro_use]
 extern crate objc;

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -1009,6 +1009,15 @@ pub unsafe extern "system" fn callback(window: HWND, msg: UINT,
             0
         },
 
+        winuser::WM_COMMAND => {
+            use events::WindowEvent::Command;
+            send_event(Event::WindowEvent {
+                window_id: SuperWindowId(WindowId(window)),
+                event: Command(LOWORD(wparam as u32))
+            });
+            0
+        },
+
         _ => {
             if msg == *DESTROY_MSG_ID {
                 winuser::DestroyWindow(window);

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -11,6 +11,9 @@ pub use self::window::Window;
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub parent: Option<HWND>,
     pub taskbar_icon: Option<::Icon>,
+    /// Allows the user to register a callback that is called when the
+    /// WM_CREATE is emitted, allows to register application menus and context menus.
+    pub wm_create_callback: Option<fn(HWND) -> ()>,
 }
 
 unsafe impl Send for PlatformSpecificWindowBuilderAttributes {}


### PR DESCRIPTION
This PR allows to register a custom callback (only on Windows) that can be used to set up application menus / native Win32 menu bars. The reason why it has to be a callback and can't be just a `WindowEvent` is because the Win32 API isn't thread-safe. If you call the callback from a different thread than the one on which the window was created, Windows will freeze your application on the `SetMenu` call.

Regular Win32 programming guides want you to register your application menus directly in the `winuser::WM_CREATE` message. Since we can't expose this directly to the user of this library, the only place to call the callback is directly after the window has been created.

In the callback, it is usual to set up custom IDs for getting a message back when the user has clicked an item. To return this ID to the user of the library, I've added a `WindowEvent::Command`. Currently this event is available on all platforms, but only gets emitted on Windows. It is debatable if we should put this behind a `cfg` flag, I've decided not to do that because it makes the event handling code a bit cleaner.

Also note that I've exported the `winapi` crate. This is done so that libraries can say `use winit::winapi` instead of having to match their version of winapi to whatever version `winit` is using. This leads to less version conflicts, when, for example `winit` uses `winapi 0.3`, but I want to use `winapi 0.4` in my crate. This isn't critical, but it's nicer to re-export it. It's not critical though and could be removed from the PR.