### PR TITLE
Correct privacy for Icon::to_cardinals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `Icon::to_cardinals` is no longer public, since it was never supposed to be.
+
 # Version 0.14.0 (2018-05-09)
 
 - Created the `Copy`, `Paste` and `Cut` `VirtualKeyCode`s and added support for them on X11 and Wayland

--- a/src/platform/linux/x11/util/icon.rs
+++ b/src/platform/linux/x11/util/icon.rs
@@ -17,7 +17,7 @@ impl Pixel {
 }
 
 impl Icon {
-    pub fn to_cardinals(&self) -> Vec<Cardinal> {
+    pub(crate) fn to_cardinals(&self) -> Vec<Cardinal> {
         assert_eq!(self.rgba.len() % PIXEL_SIZE, 0);
         let pixel_count = self.rgba.len() / PIXEL_SIZE;
         assert_eq!(pixel_count, (self.width * self.height) as usize);


### PR DESCRIPTION
Number of goofs spotted in 0.14.0 so far: 1