### PR TITLE
fix(mac_platform): forward keyevent to system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `Icon::to_cardinals` is no longer public, since it was never supposed to be.
 - Wayland: improve diagnostics if initialization fails
+- Fix some system event key doesn't work when focused, do not block keyevent forward to system on macOS
 
 # Version 0.14.0 (2018-05-09)
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -294,10 +294,7 @@ impl EventsLoop {
 
         // FIXME: Document this. Why do we do this? Seems like it passes on events to window/app.
         // If we don't do this, window does not become main for some reason.
-        match event_type {
-            appkit::NSKeyDown => (),
-            _ => appkit::NSApp().sendEvent_(ns_event),
-        }
+        appkit::NSApp().sendEvent_(ns_event);
 
         let windows = self.shared.windows.lock().unwrap();
         let maybe_window = windows.iter()

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -415,13 +415,13 @@ impl WindowDelegate {
             // callbacks for drag and drop events
             decl.add_method(sel!(draggingEntered:),
                 dragging_entered as extern fn(&Object, Sel, id) -> BOOL);
-           decl.add_method(sel!(prepareForDragOperation:),
+            decl.add_method(sel!(prepareForDragOperation:),
                 prepare_for_drag_operation as extern fn(&Object, Sel, id));
-           decl.add_method(sel!(performDragOperation:),
+            decl.add_method(sel!(performDragOperation:),
                 perform_drag_operation as extern fn(&Object, Sel, id) -> BOOL);
-           decl.add_method(sel!(concludeDragOperation:),
+            decl.add_method(sel!(concludeDragOperation:),
                 conclude_drag_operation as extern fn(&Object, Sel, id));
-           decl.add_method(sel!(draggingExited:),
+            decl.add_method(sel!(draggingExited:),
                 dragging_exited as extern fn(&Object, Sel, id));
 
             // callbacks for fullscreen events
@@ -686,10 +686,13 @@ impl Window2 {
         static INIT: std::sync::Once = std::sync::ONCE_INIT;
 
         INIT.call_once(|| unsafe {
+            extern fn on_key_down(_this: &Object, _sel: Sel, _id: id) {}
+
             let window_superclass = Class::get("NSWindow").unwrap();
             let mut decl = ClassDecl::new("WinitWindow", window_superclass).unwrap();
             decl.add_method(sel!(canBecomeMainWindow), yes as extern fn(&Object, Sel) -> BOOL);
             decl.add_method(sel!(canBecomeKeyWindow), yes as extern fn(&Object, Sel) -> BOOL);
+            decl.add_method(sel!(keyDown:), on_key_down as extern fn(&Object, Sel, id));
             WINDOW2_CLASS = decl.register();
         });
 


### PR DESCRIPTION
- closes https://github.com/tomaka/winit/issues/496

This PR intend to fix #496 - reason system doesn't switch input method is winit doesn't forward NSKeyDown to system specifically, so only application aware of it.

Still, it is bit unsure about historical reason why keydown event was prevented from first time. Creating PR to discuss if there's better / viable approach than this.