### PR TITLE
wayland: improve diagnostic of failed init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - `Icon::to_cardinals` is no longer public, since it was never supposed to be.
+- Wayland: improve diagnostics if initialization fails
 
 # Version 0.14.0 (2018-05-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
-wayland-client = { version = "0.20.4", features = [ "dlopen", "egl", "cursor"] }
+wayland-client = { version = "0.20.6", features = [ "dlopen", "egl", "cursor"] }
 smithay-client-toolkit = "0.2.1"
 x11-dl = "2.17.5"
 parking_lot = "0.5"

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -6,6 +6,8 @@ use std::ffi::CStr;
 use std::os::raw::*;
 use std::sync::Arc;
 
+use sctk::reexports::client::ConnectError;
+
 // `std::os::raw::c_void` and `libc::c_void` are NOT interchangeable!
 use libc;
 
@@ -395,10 +397,9 @@ r#"Failed to initialize any backend!
         panic!(err_string);
     }
 
-    pub fn new_wayland() -> Result<EventsLoop, ()> {
+    pub fn new_wayland() -> Result<EventsLoop, ConnectError> {
         wayland::EventsLoop::new()
             .map(EventsLoop::Wayland)
-            .ok_or(())
     }
 
     pub fn new_x11() -> Result<EventsLoop, XNotSupported> {

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -10,7 +10,7 @@ use super::window::WindowStore;
 
 use sctk::Environment;
 use sctk::output::OutputMgr;
-use sctk::reexports::client::{Display, EventQueue, GlobalEvent, Proxy};
+use sctk::reexports::client::{Display, EventQueue, GlobalEvent, Proxy, ConnectError};
 use sctk::reexports::client::commons::Implementation;
 use sctk::reexports::client::protocol::{wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat,
                                         wl_touch};
@@ -100,11 +100,8 @@ impl EventsLoopProxy {
 }
 
 impl EventsLoop {
-    pub fn new() -> Option<EventsLoop> {
-        let (display, mut event_queue) = match Display::connect_to_env() {
-            Ok(ret) => ret,
-            Err(_) => return None,
-        };
+    pub fn new() -> Result<EventsLoop, ConnectError> {
+        let (display, mut event_queue) = Display::connect_to_env()?;
 
         let sink = Arc::new(Mutex::new(EventsLoopSink::new()));
         let store = Arc::new(Mutex::new(WindowStore::new()));
@@ -120,7 +117,7 @@ impl EventsLoop {
             },
         ).unwrap();
 
-        Some(EventsLoop {
+        Ok(EventsLoop {
             display: Arc::new(display),
             evq: RefCell::new(event_queue),
             sink: sink,


### PR DESCRIPTION
Slightly improve the diagnostics in case where winit failed to initialize the wayland backend to differentiate between the cases where winit could not find the wayland libs vs. could not find a listening compositor.