### PR TITLE
X11: Fix get_current_monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On X11, `Window::get_current_monitor` now reliably returns the correct monitor.
 - On X11, `Window::hidpi_factor` returns values from XRandR rather than the inaccurate values previously queried from the core protocol.
 - On X11, the primary monitor is detected correctly even when using versions of XRandR less than 1.5.
+- `MonitorId` now implements `Debug`.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - `Icon::to_cardinals` is no longer public, since it was never supposed to be.
 - Wayland: improve diagnostics if initialization fails
 - Fix some system event key doesn't work when focused, do not block keyevent forward to system on macOS
+- On X11, `Window::get_current_monitor` now reliably returns the correct monitor.
+- On X11, `Window::hidpi_factor` returns values from XRandR rather than the inaccurate values previously queried from the core protocol.
+- On X11, the primary monitor is detected correctly even when using versions of XRandR less than 1.5.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -164,7 +164,7 @@ pub struct Window {
     native_window: *const c_void,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorId;
 
 mod ffi;

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -24,7 +24,7 @@ pub struct DeviceId;
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorId;
 
 impl MonitorId {

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -96,7 +96,7 @@ use self::ffi::{
 
 static mut jmpbuf: [c_int;27] = [0;27];
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorId;
 
 pub struct Window {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -69,7 +69,7 @@ pub enum DeviceId {
     Wayland(wayland::DeviceId)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum MonitorId {
     X(x11::MonitorId),
     Wayland(wayland::MonitorId),

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -340,6 +340,8 @@ unsafe extern "C" fn x_error_callback(
             minor_code: (*event).minor_code,
         };
 
+        eprintln!("[winit X11 error] {:#?}", error);
+
         *xconn.latest_error.lock() = Some(error);
     }
     // Fun fact: this return value is completely ignored.

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::fmt;
 use std::sync::{Arc, Mutex, Weak};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -424,6 +425,29 @@ impl Clone for MonitorId {
             proxy: self.proxy.clone(),
             mgr: self.mgr.clone(),
         }
+    }
+}
+
+impl fmt::Debug for MonitorId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[derive(Debug)]
+        struct MonitorId {
+            name: Option<String>,
+            native_identifier: u32,
+            dimensions: (u32, u32),
+            position: (i32, i32),
+            hidpi_factor: f32,
+        }
+
+        let monitor_id_proxy = MonitorId {
+            name: self.get_name(),
+            native_identifier: self.get_native_identifier(),
+            dimensions: self.get_dimensions(),
+            position: self.get_position(),
+            hidpi_factor: self.get_hidpi_factor(),
+        };
+
+        monitor_id_proxy.fmt(f)
     }
 }
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -9,7 +9,12 @@ mod dnd;
 mod ime;
 mod util;
 
-pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
+pub use self::monitor::{
+    MonitorId,
+    get_available_monitors,
+    get_monitor_for_window,
+    get_primary_monitor,
+};
 pub use self::window::{Window2, XWindow};
 pub use self::xdisplay::{XConnection, XNotSupported, XError};
 
@@ -46,6 +51,7 @@ pub struct EventsLoop {
     ime_receiver: ImeReceiver,
     ime_sender: ImeSender,
     ime: RefCell<Ime>,
+    randr_event_offset: c_int,
     windows: Arc<Mutex<HashMap<WindowId, WindowData>>>,
     // Please don't laugh at this type signature
     shared_state: RefCell<HashMap<WindowId, Weak<Mutex<window::SharedState>>>>,
@@ -67,6 +73,8 @@ pub struct EventsLoopProxy {
 
 impl EventsLoop {
     pub fn new(display: Arc<XConnection>) -> EventsLoop {
+        let root = unsafe { (display.xlib.XDefaultRootWindow)(display.display) };
+
         let wm_delete_window = unsafe { util::get_atom(&display, b"WM_DELETE_WINDOW\0") }
             .expect("Failed to call XInternAtom (WM_DELETE_WINDOW)");
 
@@ -84,6 +92,9 @@ impl EventsLoop {
             }
             result.expect("Failed to set input method destruction callback")
         });
+
+        let randr_event_offset = monitor::select_input(&display, root)
+            .expect("Failed to query XRandR extension");
 
         let xi2ext = unsafe {
             let mut result = XExtension {
@@ -119,7 +130,6 @@ impl EventsLoop {
             }
         }
 
-        let root = unsafe { (display.xlib.XDefaultRootWindow)(display.display) };
         util::update_cached_wm_info(&display, root);
 
         let wakeup_dummy_window = unsafe {
@@ -146,6 +156,7 @@ impl EventsLoop {
             ime_receiver,
             ime_sender,
             ime,
+            randr_event_offset,
             windows: Arc::new(Mutex::new(HashMap::new())),
             shared_state: RefCell::new(HashMap::new()),
             devices: RefCell::new(HashMap::new()),
@@ -1037,7 +1048,12 @@ impl EventsLoop {
                     _ => {}
                 }
             },
-            _ => (),
+            _ => {
+                if event_type == self.randr_event_offset {
+                    // In the future, it would be quite easy to emit monitor hotplug events.
+                    monitor::invalidate_cached_monitor_list();
+                }
+            },
         }
 
         match self.ime_receiver.try_recv() {

--- a/src/platform/linux/x11/util/geometry.rs
+++ b/src/platform/linux/x11/util/geometry.rs
@@ -1,4 +1,39 @@
+use std::cmp;
+
 use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rect {
+    left: i64,
+    right: i64,
+    top: i64,
+    bottom: i64,
+}
+
+impl Rect {
+    pub fn new((x, y): (i32, i32), (width, height): (u32, u32)) -> Self {
+        let (x, y) = (x as i64, y as i64);
+        let (width, height) = (width as i64, height as i64);
+        Rect {
+            left: x,
+            right: x + width,
+            top: y,
+            bottom: y + height,
+        }
+    }
+
+    pub fn get_overlapping_area(&self, other: &Self) -> i64 {
+        let x_overlap = cmp::max(
+            0,
+            cmp::min(self.right, other.right) - cmp::max(self.left, other.left),
+        );
+        let y_overlap = cmp::max(
+            0,
+            cmp::min(self.bottom, other.bottom) - cmp::max(self.top, other.top),
+        );
+        x_overlap * y_overlap
+    }
+}
 
 #[derive(Debug)]
 pub struct TranslatedCoords {

--- a/src/platform/linux/x11/util/mod.rs
+++ b/src/platform/linux/x11/util/mod.rs
@@ -6,6 +6,7 @@ mod geometry;
 mod hint;
 mod icon;
 mod input;
+mod randr;
 mod window_property;
 mod wm;
 
@@ -14,6 +15,7 @@ pub use self::geometry::*;
 pub use self::hint::*;
 pub use self::icon::*;
 pub use self::input::*;
+pub use self::randr::*;
 pub use self::window_property::*;
 pub use self::wm::*;
 

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -1,0 +1,84 @@
+use std::slice;
+
+use super::*;
+use super::ffi::{
+    RROutput,
+    XRRCrtcInfo,
+    XRRMonitorInfo,
+    XRRScreenResources,
+};
+
+pub enum MonitorRepr {
+    Monitor(*mut XRRMonitorInfo),
+    Crtc(*mut XRRCrtcInfo),
+}
+
+impl MonitorRepr {
+    pub unsafe fn get_output(&self) -> RROutput {
+        match *self {
+            // Same member names, but different locations within the struct...
+            MonitorRepr::Monitor(monitor) => *((*monitor).outputs.offset(0)),
+            MonitorRepr::Crtc(crtc) => *((*crtc).outputs.offset(0)),
+        }
+    }
+
+    pub unsafe fn get_dimensions(&self) -> (u32, u32) {
+        match *self {
+            MonitorRepr::Monitor(monitor) => ((*monitor).width as u32, (*monitor).height as u32),
+            MonitorRepr::Crtc(crtc) => ((*crtc).width as u32, (*crtc).height as u32),
+        }
+    }
+
+    pub unsafe fn get_position(&self) -> (i32, i32) {
+        match *self {
+            MonitorRepr::Monitor(monitor) => ((*monitor).x as i32, (*monitor).y as i32),
+            MonitorRepr::Crtc(crtc) => ((*crtc).x as i32, (*crtc).y as i32),
+        }
+    }
+}
+
+impl From<*mut XRRMonitorInfo> for MonitorRepr {
+    fn from(monitor: *mut XRRMonitorInfo) -> Self {
+        MonitorRepr::Monitor(monitor)
+    }
+}
+
+impl From<*mut XRRCrtcInfo> for MonitorRepr {
+    fn from(crtc: *mut XRRCrtcInfo) -> Self {
+        MonitorRepr::Crtc(crtc)
+    }
+}
+
+pub fn calc_dpi_factor(
+    (width_px, height_px): (u32, u32),
+    (width_mm, height_mm): (u64, u64),
+) -> f64 {
+    let ppmm = (
+        (width_px as f64 * height_px as f64) / (width_mm as f64 * height_mm as f64)
+    ).sqrt();
+    // Quantize 1/12 step size
+    ((ppmm * (12.0 * 25.4 / 96.0)).round() / 12.0).max(1.0)
+}
+
+pub unsafe fn get_output_info(
+    xconn: &Arc<XConnection>,
+    resources: *mut XRRScreenResources,
+    repr: &MonitorRepr,
+) -> (String, f32) {
+    let output_info = (xconn.xrandr.XRRGetOutputInfo)(
+        xconn.display,
+        resources,
+        repr.get_output(),
+    );
+    let name_slice = slice::from_raw_parts(
+        (*output_info).name as *mut u8,
+        (*output_info).nameLen as usize,
+    );
+    let name = String::from_utf8_lossy(name_slice).into();
+    let hidpi_factor = calc_dpi_factor(
+        repr.get_dimensions(),
+        ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
+    ) as f32;
+    (xconn.xrandr.XRRFreeOutputInfo)(output_info);
+    (name, hidpi_factor)
+}

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -3,6 +3,7 @@ use cocoa::base::{id, nil};
 use cocoa::foundation::{NSString, NSUInteger};
 use core_graphics::display::{CGDirectDisplayID, CGDisplay};
 use std::collections::VecDeque;
+use std::fmt;
 use super::EventsLoop;
 use super::window::IdRef;
 
@@ -29,6 +30,29 @@ impl EventsLoop {
     pub fn make_monitor_from_display(id: CGDirectDisplayID) -> MonitorId {
         let id = MonitorId(id);
         id
+    }
+}
+
+impl fmt::Debug for MonitorId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[derive(Debug)]
+        struct MonitorId {
+            name: Option<String>,
+            native_identifier: u32,
+            dimensions: (u32, u32),
+            position: &'static str,
+            hidpi_factor: f32,
+        }
+
+        let monitor_id_proxy = MonitorId {
+            name: self.get_name(),
+            native_identifier: self.get_native_identifier(),
+            dimensions: self.get_dimensions(),
+            position: "WARNING: `MonitorId::get_position` is unimplemented on macOS!",
+            hidpi_factor: self.get_hidpi_factor(),
+        };
+
+        monitor_id_proxy.fmt(f)
     }
 }
 

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -9,7 +9,7 @@ use std::{mem, ptr};
 use super::{EventsLoop, util};
 
 /// Win32 implementation of the main `MonitorId` object.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorId {
     /// The system name of the adapter.
     adapter_name: [wchar_t; 32],
@@ -39,7 +39,7 @@ pub struct MonitorId {
 // For more info see:
 // https://github.com/retep998/winapi-rs/issues/360
 // https://github.com/retep998/winapi-rs/issues/396
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct HMonitor(HMONITOR);
 
 unsafe impl Send for HMonitor {}

--- a/src/window.rs
+++ b/src/window.rs
@@ -409,7 +409,7 @@ impl Iterator for AvailableMonitorsIter {
 }
 
 /// Identifier for a monitor.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MonitorId {
     pub(crate) inner: platform::MonitorId
 }


### PR DESCRIPTION
Fixes #64 

This also adds an `eprintln!` to the X11 error handler. Since many X11 errors occur asynchronously, this should make debugging a bit easier. I still plan on adding proper logging in future work, but for now, this serves as a convenient preview for the panic that will happen soon afterwards.

Another notable change is that the monitor list is cached now. `XRRGetScreenResources` is [supposedly very slow](https://people.gnome.org/~ssp/randr/TODO), and XRandR can notify us when we need to invalidate the cached list. Previously, Alacritty would query and reconstruct the monitor list 3 times, but now it only needs to once, so hooray for minor startup time improvements. (This will be more important when full HiDPI support for X11 lands, since detecting DPI changes involves checking which monitor a window is on whenever it moves.)

The rest of this is just some refactoring to reduce code duplication between the XRandR 1.5 and <1.5 paths.