### PR TITLE
macOS: Fix re-enabling decorations after the window is built without them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Cargo.lock
 target/
+rls/
 *~
 #*#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On X11, `Window::hidpi_factor` returns values from XRandR rather than the inaccurate values previously queried from the core protocol.
 - On X11, the primary monitor is detected correctly even when using versions of XRandR less than 1.5.
 - `MonitorId` now implements `Debug`.
+- Fixed bug on macOS where using `with_decorations(false)` would cause `set_decorations(true)` to produce a transparent titlebar with no title.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -573,23 +573,22 @@ impl Window2 {
 
         let app = match Window2::create_app(pl_attribs.activation_policy) {
             Some(app) => app,
-            None      => {
+            None => {
                 let _: () = unsafe { msg_send![autoreleasepool, drain] };
                 return Err(OsError(format!("Couldn't create NSApplication")));
             },
         };
 
-        let window = match Window2::create_window(&win_attribs, &pl_attribs)
-        {
-            Some(window) => window,
-            None         => {
+        let window = match Window2::create_window(&win_attribs, &pl_attribs) {
+            Some(res) => res,
+            None => {
                 let _: () = unsafe { msg_send![autoreleasepool, drain] };
                 return Err(OsError(format!("Couldn't create NSWindow")));
             },
         };
         let view = match Window2::create_view(*window) {
             Some(view) => view,
-            None       => {
+            None => {
                 let _: () = unsafe { msg_send![autoreleasepool, drain] };
                 return Err(OsError(format!("Couldn't create NSView")));
             },
@@ -776,11 +775,6 @@ impl Window2 {
                 }
                 if pl_attrs.movable_by_window_background {
                     window.setMovableByWindowBackground_(YES);
-                }
-
-                if !attrs.decorations {
-                    window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
-                    window.setTitlebarAppearsTransparent_(YES);
                 }
 
                 window.center();


### PR DESCRIPTION
Fixes #517

These properties are changed *only* when using `with_decorations(false)`, and *not* when calling `set_decorations(false)`: 
https://github.com/tomaka/winit/blob/d86f53a02c0b17f76551c6b8917ecafe4f1f5164/src/platform/macos/window.rs#L781-L784

Changing those properties back to the default when calling `set_decorations(true)` solves the problem. @sodiumjoe do you know why those calls are used for `with_decorations(false)`? It seems to work fine without them, especially considering they're never used when disabling decorations after the fact.