### PR TITLE
macOS: Fix Window::get_current_monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Cargo.lock
 target/
+rls/
 *~
 #*#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On X11, `Window::hidpi_factor` returns values from XRandR rather than the inaccurate values previously queried from the core protocol.
 - On X11, the primary monitor is detected correctly even when using versions of XRandR less than 1.5.
 - `MonitorId` now implements `Debug`.
+- Implemented `MonitorId::get_position` on macOS.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On X11, the primary monitor is detected correctly even when using versions of XRandR less than 1.5.
 - `MonitorId` now implements `Debug`.
 - Implemented `MonitorId::get_position` on macOS.
+- On macOS, `Window::get_current_monitor` now returns accurate values.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ objc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
-cocoa = "0.14"
-core-foundation = "0.5"
-core-graphics = "0.13"
+cocoa = "0.15"
+core-foundation = "0.6"
+core-graphics = "0.14"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/src/platform/macos/monitor.rs
+++ b/src/platform/macos/monitor.rs
@@ -1,7 +1,7 @@
 use cocoa::appkit::NSScreen;
 use cocoa::base::{id, nil};
 use cocoa::foundation::{NSString, NSUInteger};
-use core_graphics::display::{CGDirectDisplayID, CGDisplay};
+use core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
 use std::collections::VecDeque;
 use std::fmt;
 use super::EventsLoop;
@@ -40,7 +40,7 @@ impl fmt::Debug for MonitorId {
             name: Option<String>,
             native_identifier: u32,
             dimensions: (u32, u32),
-            position: &'static str,
+            position: (i32, i32),
             hidpi_factor: f32,
         }
 
@@ -48,7 +48,7 @@ impl fmt::Debug for MonitorId {
             name: self.get_name(),
             native_identifier: self.get_native_identifier(),
             dimensions: self.get_dimensions(),
-            position: "WARNING: `MonitorId::get_position` is unimplemented on macOS!",
+            position: self.get_position(),
             hidpi_factor: self.get_hidpi_factor(),
         };
 
@@ -81,7 +81,8 @@ impl MonitorId {
 
     #[inline]
     pub fn get_position(&self) -> (i32, i32) {
-        unimplemented!()
+        let bounds = unsafe { CGDisplayBounds(self.get_native_identifier()) };
+        (bounds.origin.x as i32, bounds.origin.y as i32)
     }
 
     pub fn get_hidpi_factor(&self) -> f32 {

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -326,7 +326,7 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                state.win_attribs.borrow_mut().fullscreen = Some(get_current_monitor());
+                state.win_attribs.borrow_mut().fullscreen = Some(get_current_monitor(*state.window));
 
                 state.handle_with_fullscreen = false;
             }
@@ -499,18 +499,13 @@ pub struct Window2 {
 unsafe impl Send for Window2 {}
 unsafe impl Sync for Window2 {}
 
-/// Helpper funciton to convert NSScreen::mainScreen to MonitorId
-unsafe fn get_current_monitor() -> RootMonitorId {
-    let screen = NSScreen::mainScreen(nil);
+unsafe fn get_current_monitor(window: id) -> RootMonitorId {
+    let screen: id = msg_send![window, screen];
     let desc = NSScreen::deviceDescription(screen);
     let key = IdRef::new(NSString::alloc(nil).init_str("NSScreenNumber"));
-
     let value = NSDictionary::valueForKey_(desc, *key);
     let display_id = msg_send![value, unsignedIntegerValue];
-
-    RootMonitorId {
-        inner: EventsLoop::make_monitor_from_display(display_id),
-    }
+    RootMonitorId { inner: EventsLoop::make_monitor_from_display(display_id) }
 }
 
 impl Drop for Window2 {
@@ -638,7 +633,7 @@ impl Window2 {
         // Set fullscreen mode after we setup everything
         if let Some(ref monitor) = win_attribs.fullscreen {
             unsafe {
-                if monitor.inner != get_current_monitor().inner {
+                if monitor.inner != get_current_monitor(*window.window).inner {
                     unimplemented!();
                 }
             }
@@ -1088,7 +1083,7 @@ impl Window2 {
     #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
         unsafe {
-            self::get_current_monitor()
+            self::get_current_monitor(*self.window)
         }
     }
 }


### PR DESCRIPTION
This partially addresses #473, in case I haven't been putting out enough macOS PRs.