### PR TITLE
X11: Improve hint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Added the `Window::set_ime_spot(x: i32, y: i32)` method, which is implemented on X11 and macOS.
 - **Breaking**: `os::unix::WindowExt::send_xim_spot(x: i16, y: i16)` no longer exists. Switch to the new `Window::set_ime_spot(x: i32, y: i32)`, which has equivalent functionality.
 - Fixed detection of `Pause` and `Scroll` keys on Windows.
+- On X11, `WindowBuilderExt` now has `with_class`, `with_override_redirect`, and `with_x11_window_type` to allow for more control over window creation. `WindowExt` additionally has `set_urgent`.
+- More hints are set by default on X11, including `_NET_WM_PID` and `WM_CLIENT_MACHINE`. Note that prior to this, the `WM_CLASS` hint was automatically set to whatever value was passed to `with_title`. It's now set to the executable name to better conform to expectations and the specification; if this is undesirable, you must explicitly use `WindowBuilderExt::with_class`.
 
 # Version 0.14.0 (2018-05-09)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!  - Calling `Window::new(&events_loop)`.
 //!  - Calling `let builder = WindowBuilder::new()` then `builder.build(&events_loop)`.
 //!
-//! The first way is the simpliest way and will give you default values for everything.
+//! The first way is the simplest way and will give you default values for everything.
 //!
 //! The second way allows you to customize the way your window will look and behave by modifying
 //! the fields of the `WindowBuilder` object before you create the window.

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -44,6 +44,9 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub screen_id: Option<i32>,
     pub resize_increments: Option<(u32, u32)>,
     pub base_size: Option<(u32, u32)>,
+    pub class: Option<(String, String)>,
+    pub override_redirect: bool,
+    pub x11_window_type: x11::util::WindowType,
 }
 
 lazy_static!(

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -7,7 +7,7 @@ mod window;
 mod xdisplay;
 mod dnd;
 mod ime;
-mod util;
+pub mod util;
 
 pub use self::monitor::{
     MonitorId,

--- a/src/platform/linux/x11/util/hint.rs
+++ b/src/platform/linux/x11/util/hint.rs
@@ -18,3 +18,51 @@ impl From<bool> for StateOperation {
         }
     }
 }
+
+/// X window type. Maps directly to
+/// [`_NET_WM_WINDOW_TYPE`](https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html).
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WindowType {
+    /// A desktop feature. This can include a single window containing desktop icons with the same dimensions as the
+    /// screen, allowing the desktop environment to have full control of the desktop, without the need for proxying
+    /// root window clicks.
+    Desktop,
+    /// A dock or panel feature. Typically a Window Manager would keep such windows on top of all other windows.
+    Dock,
+    /// Toolbar windows. "Torn off" from the main application.
+    Toolbar,
+    /// Pinnable menu windows. "Torn off" from the main application.
+    Menu,
+    /// A small persistent utility window, such as a palette or toolbox.
+    Utility,
+    /// The window is a splash screen displayed as an application is starting up.
+    Splash,
+    /// This is a dialog window.
+    Dialog,
+    /// This is a normal, top-level window.
+    Normal,
+}
+
+impl Default for WindowType {
+    fn default() -> Self {
+        WindowType::Normal
+    }
+}
+
+impl WindowType {
+    pub(crate) fn as_atom(&self, xconn: &Arc<XConnection>) -> ffi::Atom {
+        use self::WindowType::*;
+        let atom_name: &[u8] = match self {
+            Desktop => b"_NET_WM_WINDOW_TYPE_DESKTOP\0",
+            Dock => b"_NET_WM_WINDOW_TYPE_DOCK\0",
+            Toolbar => b"_NET_WM_WINDOW_TYPE_TOOLBAR\0",
+            Menu => b"_NET_WM_WINDOW_TYPE_MENU\0",
+            Utility => b"_NET_WM_WINDOW_TYPE_UTILITY\0",
+            Splash => b"_NET_WM_WINDOW_TYPE_SPLASH\0",
+            Dialog => b"_NET_WM_WINDOW_TYPE_DIALOG\0",
+            Normal => b"_NET_WM_WINDOW_TYPE_NORMAL\0",
+        };
+        unsafe { get_atom(xconn, atom_name) }
+            .expect("Failed to get atom for `WindowType`")
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -376,7 +376,7 @@ impl Window {
         self.window.set_window_icon(window_icon)
     }
 
-    //// Sets location of IME candidate box in client area coordinates relative to the top left.
+    /// Sets location of IME candidate box in client area coordinates relative to the top left.
     #[inline]
     pub fn set_ime_spot(&self, x: i32, y: i32) {
         self.window.set_ime_spot(x, y)


### PR DESCRIPTION
Fixes #257

After this, Alacritty also won't have to directly make calls to Xlib anymore. The hints needed there seemed reasonable to provide out of the box, i.e. setting a hint that contains the PID. There's also a behavior change included here, in that `WM_CLASS` is no longer based on the window title. It was a semantically incorrect and rather surprising thing to do in the first place; now it defaults to the executable name (which the spec specifies as a fallback) and you can explicitly set `WM_CLASS` using `WindowBuilderExt::with_class`.