### PR TITLE
X11: util design improvements

### DIFF
--- a/src/platform/linux/x11/dnd.rs
+++ b/src/platform/linux/x11/dnd.rs
@@ -40,7 +40,7 @@ impl DndAtoms {
             b"text/uri-list\0".as_ptr() as *mut c_char,
             b"None\0".as_ptr() as *mut c_char,
         ];
-        let atoms = unsafe { util::get_atoms(xconn, &names) }?;
+        let atoms = unsafe { xconn.get_atoms(&names) }?;
         Ok(DndAtoms {
             aware: atoms[0],
             enter: atoms[1],
@@ -127,13 +127,12 @@ impl Dnd {
             DndState::Accepted => (1, self.atoms.action_private as c_long),
             DndState::Rejected => (0, self.atoms.none as c_long),
         };
-        util::send_client_msg(
-            &self.xconn,
+        self.xconn.send_client_msg(
             target_window,
             target_window,
             self.atoms.status,
             None,
-            (this_window as c_long, accepted, 0, 0, action),
+            [this_window as c_long, accepted, 0, 0, action],
         ).flush()
     }
 
@@ -147,13 +146,12 @@ impl Dnd {
             DndState::Accepted => (1, self.atoms.action_private as c_long),
             DndState::Rejected => (0, self.atoms.none as c_long),
         };
-        util::send_client_msg(
-            &self.xconn,
+        self.xconn.send_client_msg(
             target_window,
             target_window,
             self.atoms.finished,
             None,
-            (this_window as c_long, accepted, action, 0, 0),
+            [this_window as c_long, accepted, action, 0, 0],
         ).flush()
     }
 
@@ -161,8 +159,7 @@ impl Dnd {
         &self,
         source_window: c_ulong,
     ) -> Result<Vec<ffi::Atom>, util::GetPropertyError> {
-        util::get_property(
-            &self.xconn,
+        self.xconn.get_property(
             source_window,
             self.atoms.type_list,
             ffi::XA_ATOM,
@@ -184,8 +181,7 @@ impl Dnd {
         &self,
         window: c_ulong,
     ) -> Result<Vec<c_uchar>, util::GetPropertyError> {
-        util::get_property(
-            &self.xconn,
+        self.xconn.get_property(
             window,
             self.atoms.selection,
             self.atoms.uri_list,

--- a/src/platform/linux/x11/ime/input_method.rs
+++ b/src/platform/linux/x11/ime/input_method.rs
@@ -85,13 +85,11 @@ enum GetXimServersError {
 // modifiers, since we don't want a user who's looking at logs to ask "am I supposed to set
 // XMODIFIERS to `@server=ibus`?!?"
 unsafe fn get_xim_servers(xconn: &Arc<XConnection>) -> Result<Vec<String>, GetXimServersError> {
-    let servers_atom = util::get_atom(&xconn, b"XIM_SERVERS\0")
-        .map_err(GetXimServersError::XError)?;
+    let servers_atom = xconn.get_atom_unchecked(b"XIM_SERVERS\0");
 
     let root = (xconn.xlib.XDefaultRootWindow)(xconn.display);
 
-    let mut atoms: Vec<ffi::Atom> = util::get_property(
-        &xconn,
+    let mut atoms: Vec<ffi::Atom> = xconn.get_property(
         root,
         servers_atom,
         ffi::XA_ATOM,

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -66,7 +66,7 @@ impl MonitorId {
         repr: util::MonitorRepr,
         primary: bool,
     ) -> Self {
-        let (name, hidpi_factor) = unsafe { util::get_output_info(xconn, resources, &repr) };
+        let (name, hidpi_factor) = unsafe { xconn.get_output_info(resources, &repr) };
         let (dimensions, position) = unsafe { (repr.get_dimensions(), repr.get_position()) };
         let rect = util::Rect::new(position, dimensions);
         MonitorId {

--- a/src/platform/linux/x11/util/client_msg.rs
+++ b/src/platform/linux/x11/util/client_msg.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+pub type ClientMsgPayload = [c_long; 5];
+
+impl XConnection {
+    pub fn send_event<T: Into<ffi::XEvent>>(
+        &self,
+        target_window: c_ulong,
+        event_mask: Option<c_long>,
+        event: T,
+    ) -> Flusher {
+        let event_mask = event_mask.unwrap_or(ffi::NoEventMask);
+        unsafe {
+            (self.xlib.XSendEvent)(
+                self.display,
+                target_window,
+                ffi::False,
+                event_mask,
+                &mut event.into(),
+            );
+        }
+        Flusher::new(self)
+    }
+
+    pub fn send_client_msg(
+        &self,
+        window: c_ulong,        // The window this is "about"; not necessarily this window
+        target_window: c_ulong, // The window we're sending to
+        message_type: ffi::Atom,
+        event_mask: Option<c_long>,
+        data: ClientMsgPayload,
+    ) -> Flusher {
+        let mut event: ffi::XClientMessageEvent = unsafe { mem::uninitialized() };
+        event.type_ = ffi::ClientMessage;
+        event.display = self.display;
+        event.window = window;
+        event.message_type = message_type;
+        event.format = c_long::FORMAT as c_int;
+        event.data = unsafe { mem::transmute(data) };
+        self.send_event(target_window, event_mask, event)
+    }
+
+    // Prepare yourself for the ultimate in unsafety!
+    // You should favor `send_client_msg` whenever possible, but some protocols (i.e. startup notification) require you
+    // to send more than one message worth of data.
+    pub fn send_client_msg_multi<T: Formattable>(
+        &self,
+        window: c_ulong,        // The window this is "about"; not necessarily this window
+        target_window: c_ulong, // The window we're sending to
+        message_type: ffi::Atom,
+        event_mask: Option<c_long>,
+        data: &[T],
+    ) -> Flusher {
+        let format = T::FORMAT;
+        let size_of_t = mem::size_of::<T>();
+        debug_assert_eq!(size_of_t, format.get_actual_size());
+        let mut event: ffi::XClientMessageEvent = unsafe { mem::uninitialized() };
+        event.type_ = ffi::ClientMessage;
+        event.display = self.display;
+        event.window = window;
+        event.message_type = message_type;
+        event.format = format as c_int;
+
+        let t_per_payload = format.get_payload_size() / size_of_t;
+        assert!(t_per_payload > 0);
+        let payload_count = data.len() / t_per_payload;
+        let payload_remainder = data.len() % t_per_payload;
+        let payload_ptr = data.as_ptr() as *const ClientMsgPayload;
+
+        let mut payload_index = 0;
+        while payload_index < payload_count {
+            let payload = unsafe { payload_ptr.offset(payload_index as isize) };
+            payload_index += 1;
+            event.data = unsafe { mem::transmute(*payload) };
+            self.send_event(target_window, event_mask, &event).queue();
+        }
+
+        if payload_remainder > 0 {
+            let mut payload: ClientMsgPayload = [0; 5];
+            let t_payload = payload.as_mut_ptr() as *mut T;
+            let invalid_payload = unsafe { payload_ptr.offset(payload_index as isize) };
+            let invalid_t_payload = invalid_payload as *const T;
+            let mut t_index = 0;
+            while t_index < payload_remainder {
+                let valid_t = unsafe { invalid_t_payload.offset(t_index as isize) };
+                unsafe { (*t_payload.offset(t_index as isize)) = (*valid_t).clone() };
+                t_index += 1;
+            }
+            event.data = unsafe { mem::transmute(payload) };
+            self.send_event(target_window, event_mask, &event).queue();
+        }
+
+        Flusher::new(self)
+    }
+}

--- a/src/platform/linux/x11/util/format.rs
+++ b/src/platform/linux/x11/util/format.rs
@@ -1,0 +1,58 @@
+use std::fmt::Debug;
+use std::mem;
+use std::os::raw::*;
+
+// This isn't actually the number of the bits in the format.
+// X11 does a match on this value to determine which type to call sizeof on.
+// Thus, we use 32 for c_long, since 32 maps to c_long which maps to 64.
+// ...if that sounds confusing, then you know why this enum is here.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Format {
+    Char = 8,
+    Short = 16,
+    Long = 32,
+}
+
+impl Format {
+    pub fn from_format(format: usize) -> Option<Self> {
+        match format {
+            8 => Some(Format::Char),
+            16 => Some(Format::Short),
+            32 => Some(Format::Long),
+            _ => None,
+        }
+    }
+
+    pub fn is_same_size_as<T>(&self) -> bool {
+        mem::size_of::<T>() == self.get_actual_size()
+    }
+
+    pub fn get_actual_size(&self) -> usize {
+        match self {
+            &Format::Char => mem::size_of::<c_char>(),
+            &Format::Short => mem::size_of::<c_short>(),
+            &Format::Long => mem::size_of::<c_long>(),
+        }
+    }
+
+    pub fn get_payload_size(&self) -> usize {
+        match self {
+            // Due to the wonders of X11, half the space goes unused if you're not using longs (on 64-bit).
+            &Format::Char => mem::size_of::<c_char>() * 20,
+            &Format::Short => mem::size_of::<c_short>() * 10,
+            &Format::Long => mem::size_of::<c_long>() * 5,
+        }
+    }
+}
+
+pub trait Formattable: Debug + Clone + Copy + PartialEq + PartialOrd {
+    const FORMAT: Format;
+}
+
+// You might be surprised by the absence of c_int, but not as surprised as X11 would be by the presence of it.
+impl Formattable for c_char { const FORMAT: Format = Format::Char; }
+impl Formattable for c_uchar { const FORMAT: Format = Format::Char; }
+impl Formattable for c_short { const FORMAT: Format = Format::Short; }
+impl Formattable for c_ushort { const FORMAT: Format = Format::Short; }
+impl Formattable for c_long { const FORMAT: Format = Format::Long; }
+impl Formattable for c_ulong { const FORMAT: Format = Format::Long; }

--- a/src/platform/linux/x11/util/geometry.rs
+++ b/src/platform/linux/x11/util/geometry.rs
@@ -42,30 +42,6 @@ pub struct TranslatedCoords {
     pub child: ffi::Window,
 }
 
-// This is adequate for get_inner_position
-pub unsafe fn translate_coords(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-    root: ffi::Window,
-) -> Result<TranslatedCoords, XError> {
-    let mut translated_coords: TranslatedCoords = mem::uninitialized();
-
-    (xconn.xlib.XTranslateCoordinates)(
-        xconn.display,
-        window,
-        root,
-        0,
-        0,
-        &mut translated_coords.x_rel_root,
-        &mut translated_coords.y_rel_root,
-        &mut translated_coords.child,
-    );
-
-    //println!("XTranslateCoordinates coords:{:?}", translated_coords);
-
-    xconn.check_errors().map(|_| translated_coords)
-}
-
 #[derive(Debug)]
 pub struct Geometry {
     pub root: ffi::Window,
@@ -86,30 +62,6 @@ pub struct Geometry {
     pub depth: c_uint,
 }
 
-// This is adequate for get_inner_size
-pub unsafe fn get_geometry(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-) -> Result<Geometry, XError> {
-    let mut geometry: Geometry = mem::uninitialized();
-
-    let _status = (xconn.xlib.XGetGeometry)(
-        xconn.display,
-        window,
-        &mut geometry.root,
-        &mut geometry.x_rel_parent,
-        &mut geometry.y_rel_parent,
-        &mut geometry.width,
-        &mut geometry.height,
-        &mut geometry.border,
-        &mut geometry.depth,
-    );
-
-    //println!("XGetGeometry geo:{:?}", geometry);
-
-    xconn.check_errors().map(|_| geometry)
-}
-
 #[derive(Debug, Clone)]
 pub struct FrameExtents {
     pub left: c_ulong,
@@ -126,109 +78,6 @@ impl FrameExtents {
     pub fn from_border(border: c_ulong) -> Self {
         Self::new(border, border, border, border)
     }
-}
-
-fn get_frame_extents(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-) -> Option<self::FrameExtents> {
-    let extents_atom = unsafe { self::get_atom(xconn, b"_NET_FRAME_EXTENTS\0") }
-        .expect("Failed to call XInternAtom (_NET_FRAME_EXTENTS)");
-
-    if !self::hint_is_supported(extents_atom) {
-        return None;
-    }
-
-    // Of the WMs tested, xmonad, i3, dwm, IceWM (1.3.x and earlier), and blackbox don't
-    // support this. As this is part of EWMH (Extended Window Manager Hints), it's likely to
-    // be unsupported by many smaller WMs.
-    let extents: Option<Vec<c_ulong>> = unsafe {
-        self::get_property(
-            xconn,
-            window,
-            extents_atom,
-            ffi::XA_CARDINAL,
-        )
-    }.ok();
-
-    extents.and_then(|extents| {
-        if extents.len() >= 4 {
-            Some(self::FrameExtents {
-                left: extents[0],
-                right: extents[1],
-                top: extents[2],
-                bottom: extents[3],
-            })
-        } else {
-            None
-        }
-    })
-}
-
-pub fn is_top_level(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-    root: ffi::Window,
-) -> Option<bool> {
-    let client_list_atom = unsafe { self::get_atom(xconn, b"_NET_CLIENT_LIST\0") }
-        .expect("Failed to call XInternAtom (_NET_CLIENT_LIST)");
-
-    if !self::hint_is_supported(client_list_atom) {
-        return None;
-    }
-
-    let client_list: Option<Vec<ffi::Window>> = unsafe {
-        self::get_property(
-            xconn,
-            root,
-            client_list_atom,
-            ffi::XA_WINDOW,
-        )
-    }.ok();
-
-    client_list.map(|client_list| client_list.contains(&window))
-}
-
-unsafe fn get_parent_window(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-) -> Result<ffi::Window, XError> {
-    let mut root: ffi::Window = mem::uninitialized();
-    let mut parent: ffi::Window = mem::uninitialized();
-    let mut children: *mut ffi::Window = ptr::null_mut();
-    let mut nchildren: c_uint = mem::uninitialized();
-
-    let _status = (xconn.xlib.XQueryTree)(
-        xconn.display,
-        window,
-        &mut root,
-        &mut parent,
-        &mut children,
-        &mut nchildren,
-    );
-
-    // The list of children isn't used
-    if children != ptr::null_mut() {
-        (xconn.xlib.XFree)(children as *mut _);
-    }
-
-    xconn.check_errors().map(|_| parent)
-}
-
-fn climb_hierarchy(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-    root: ffi::Window,
-) -> Result<ffi::Window, XError> {
-    let mut outer_window = window;
-    loop {
-        let candidate = unsafe { get_parent_window(xconn, outer_window) }?;
-        if candidate == root {
-            break;
-        }
-        outer_window = candidate;
-    }
-    Ok(outer_window)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -266,120 +115,237 @@ impl FrameExtentsHeuristic {
     }
 }
 
-pub fn get_frame_extents_heuristic(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-    root: ffi::Window,
-) -> FrameExtentsHeuristic {
-    use self::FrameExtentsHeuristicPath::*;
+impl XConnection {
+    // This is adequate for get_inner_position
+    pub fn translate_coords(&self, window: ffi::Window, root: ffi::Window) -> Result<TranslatedCoords, XError> {
+        let mut translated_coords: TranslatedCoords = unsafe { mem::uninitialized() };
+        unsafe {
+            (self.xlib.XTranslateCoordinates)(
+                self.display,
+                window,
+                root,
+                0,
+                0,
+                &mut translated_coords.x_rel_root,
+                &mut translated_coords.y_rel_root,
+                &mut translated_coords.child,
+            );
+        }
+        //println!("XTranslateCoordinates coords:{:?}", translated_coords);
+        self.check_errors().map(|_| translated_coords)
+    }
 
-    // Position relative to root window.
-    // With rare exceptions, this is the position of a nested window. Cases where the window
-    // isn't nested are outlined in the comments throghout this function, but in addition to
-    // that, fullscreen windows often aren't nested.
-    let (inner_y_rel_root, child) = {
-        let coords = unsafe { translate_coords(xconn, window, root) }
-            .expect("Failed to translate window coordinates");
-        (
-            coords.y_rel_root,
-            coords.child,
-        )
-    };
+    // This is adequate for get_inner_size
+    pub fn get_geometry(&self, window: ffi::Window) -> Result<Geometry, XError> {
+        let mut geometry: Geometry = unsafe { mem::uninitialized() };
+        let _status = unsafe {
+            (self.xlib.XGetGeometry)(
+                self.display,
+                window,
+                &mut geometry.root,
+                &mut geometry.x_rel_parent,
+                &mut geometry.y_rel_parent,
+                &mut geometry.width,
+                &mut geometry.height,
+                &mut geometry.border,
+                &mut geometry.depth,
+            )
+        };
+        //println!("XGetGeometry geo:{:?}", geometry);
+        self.check_errors().map(|_| geometry)
+    }
 
-    let (width, height, border) = {
-        let inner_geometry = unsafe { get_geometry(xconn, window) }
-            .expect("Failed to get inner window geometry");
-        (
-            inner_geometry.width,
-            inner_geometry.height,
-            inner_geometry.border,
-        )
-    };
+    fn get_frame_extents(&self, window: ffi::Window) -> Option<FrameExtents> {
+        let extents_atom = unsafe { self.get_atom_unchecked(b"_NET_FRAME_EXTENTS\0") };
 
-    // The first condition is only false for un-nested windows, but isn't always false for
-    // un-nested windows. Mutter/Muffin/Budgie and Marco present a mysterious discrepancy:
-    // when y is on the range [0, 2] and if the window has been unfocused since being
-    // undecorated (or was undecorated upon construction), the first condition is true,
-    // requiring us to rely on the second condition.
-    let nested = !(window == child || is_top_level(xconn, child, root) == Some(true));
-
-    // Hopefully the WM supports EWMH, allowing us to get exact info on the window frames.
-    if let Some(mut frame_extents) = get_frame_extents(xconn, window) {
-        // Mutter/Muffin/Budgie and Marco preserve their decorated frame extents when
-        // decorations are disabled, but since the window becomes un-nested, it's easy to
-        // catch.
-        if !nested {
-            frame_extents = FrameExtents::new(0, 0, 0, 0);
+        if !hint_is_supported(extents_atom) {
+            return None;
         }
 
-        // The difference between the nested window's position and the outermost window's
-        // position is equivalent to the frame size. In most scenarios, this is equivalent to
-        // manually climbing the hierarchy as is done in the case below. Here's a list of
-        // known discrepancies:
-        // * Mutter/Muffin/Budgie gives decorated windows a margin of 9px (only 7px on top) in
-        //   addition to a 1px semi-transparent border. The margin can be easily observed by
-        //   using a screenshot tool to get a screenshot of a selected window, and is
-        //   presumably used for drawing drop shadows. Getting window geometry information
-        //   via hierarchy-climbing results in this margin being included in both the
-        //   position and outer size, so a window positioned at (0, 0) would be reported as
-        //   having a position (-10, -8).
-        // * Compiz has a drop shadow margin just like Mutter/Muffin/Budgie, though it's 10px
-        //   on all sides, and there's no additional border.
-        // * Enlightenment otherwise gets a y position equivalent to inner_y_rel_root.
-        //   Without decorations, there's no difference. This is presumably related to
-        //   Enlightenment's fairly unique concept of window position; it interprets
-        //   positions given to XMoveWindow as a client area position rather than a position
-        //   of the overall window.
+        // Of the WMs tested, xmonad, i3, dwm, IceWM (1.3.x and earlier), and blackbox don't
+        // support this. As this is part of EWMH (Extended Window Manager Hints), it's likely to
+        // be unsupported by many smaller WMs.
+        let extents: Option<Vec<c_ulong>> = self.get_property(
+            window,
+            extents_atom,
+            ffi::XA_CARDINAL,
+        ).ok();
 
-        FrameExtentsHeuristic {
-            frame_extents,
-            heuristic_path: Supported,
+        extents.and_then(|extents| {
+            if extents.len() >= 4 {
+                Some(FrameExtents {
+                    left: extents[0],
+                    right: extents[1],
+                    top: extents[2],
+                    bottom: extents[3],
+                })
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn is_top_level(&self, window: ffi::Window, root: ffi::Window) -> Option<bool> {
+        let client_list_atom = unsafe { self.get_atom_unchecked(b"_NET_CLIENT_LIST\0") };
+
+        if !hint_is_supported(client_list_atom) {
+            return None;
         }
-    } else if nested {
-        // If the position value we have is for a nested window used as the client area, we'll
-        // just climb up the hierarchy and get the geometry of the outermost window we're
-        // nested in.
-        let outer_window = climb_hierarchy(xconn, window, root)
-            .expect("Failed to climb window hierarchy");
 
-        let (outer_y, outer_width, outer_height) = {
-            let outer_geometry = unsafe { get_geometry(xconn, outer_window) }
-                .expect("Failed to get outer window geometry");
+        let client_list: Option<Vec<ffi::Window>> = self.get_property(
+            root,
+            client_list_atom,
+            ffi::XA_WINDOW,
+        ).ok();
+
+        client_list.map(|client_list| client_list.contains(&window))
+    }
+
+    fn get_parent_window(&self, window: ffi::Window) -> Result<ffi::Window, XError> {
+        let parent = unsafe {
+            let mut root: ffi::Window = mem::uninitialized();
+            let mut parent: ffi::Window = mem::uninitialized();
+            let mut children: *mut ffi::Window = ptr::null_mut();
+            let mut nchildren: c_uint = mem::uninitialized();
+
+            // What's filled into `parent` if `window` is the root window?
+            let _status = (self.xlib.XQueryTree)(
+                self.display,
+                window,
+                &mut root,
+                &mut parent,
+                &mut children,
+                &mut nchildren,
+            );
+
+            // The list of children isn't used
+            if children != ptr::null_mut() {
+                (self.xlib.XFree)(children as *mut _);
+            }
+
+            parent
+        };
+        self.check_errors().map(|_| parent)
+    }
+
+    fn climb_hierarchy(&self, window: ffi::Window, root: ffi::Window) -> Result<ffi::Window, XError> {
+        let mut outer_window = window;
+        loop {
+            let candidate = self.get_parent_window(outer_window)?;
+            if candidate == root {
+                break;
+            }
+            outer_window = candidate;
+        }
+        Ok(outer_window)
+    }
+
+    pub fn get_frame_extents_heuristic(&self, window: ffi::Window, root: ffi::Window) -> FrameExtentsHeuristic {
+        use self::FrameExtentsHeuristicPath::*;
+
+        // Position relative to root window.
+        // With rare exceptions, this is the position of a nested window. Cases where the window
+        // isn't nested are outlined in the comments throghout this function, but in addition to
+        // that, fullscreen windows often aren't nested.
+        let (inner_y_rel_root, child) = {
+            let coords = self.translate_coords(window, root).expect("Failed to translate window coordinates");
             (
-                outer_geometry.y_rel_parent,
-                outer_geometry.width,
-                outer_geometry.height,
+                coords.y_rel_root,
+                coords.child,
             )
         };
 
-        // Since we have the geometry of the outermost window and the geometry of the client
-        // area, we can figure out what's in between.
-        let diff_x = outer_width.saturating_sub(width);
-        let diff_y = outer_height.saturating_sub(height);
-        let offset_y = inner_y_rel_root.saturating_sub(outer_y) as c_uint;
+        let (width, height, border) = {
+            let inner_geometry = self.get_geometry(window).expect("Failed to get inner window geometry");
+            (
+                inner_geometry.width,
+                inner_geometry.height,
+                inner_geometry.border,
+            )
+        };
 
-        let left = diff_x / 2;
-        let right = left;
-        let top = offset_y;
-        let bottom = diff_y.saturating_sub(offset_y);
+        // The first condition is only false for un-nested windows, but isn't always false for
+        // un-nested windows. Mutter/Muffin/Budgie and Marco present a mysterious discrepancy:
+        // when y is on the range [0, 2] and if the window has been unfocused since being
+        // undecorated (or was undecorated upon construction), the first condition is true,
+        // requiring us to rely on the second condition.
+        let nested = !(window == child || self.is_top_level(child, root) == Some(true));
 
-        let frame_extents = FrameExtents::new(
-            left.into(),
-            right.into(),
-            top.into(),
-            bottom.into(),
-        );
-        FrameExtentsHeuristic {
-            frame_extents,
-            heuristic_path: UnsupportedNested,
-        }
-    } else {
-        // This is the case for xmonad and dwm, AKA the only WMs tested that supplied a
-        // border value. This is convenient, since we can use it to get an accurate frame.
-        let frame_extents = FrameExtents::from_border(border.into());
-        FrameExtentsHeuristic {
-            frame_extents,
-            heuristic_path: UnsupportedBordered,
+        // Hopefully the WM supports EWMH, allowing us to get exact info on the window frames.
+        if let Some(mut frame_extents) = self.get_frame_extents(window) {
+            // Mutter/Muffin/Budgie and Marco preserve their decorated frame extents when
+            // decorations are disabled, but since the window becomes un-nested, it's easy to
+            // catch.
+            if !nested {
+                frame_extents = FrameExtents::new(0, 0, 0, 0);
+            }
+
+            // The difference between the nested window's position and the outermost window's
+            // position is equivalent to the frame size. In most scenarios, this is equivalent to
+            // manually climbing the hierarchy as is done in the case below. Here's a list of
+            // known discrepancies:
+            // * Mutter/Muffin/Budgie gives decorated windows a margin of 9px (only 7px on top) in
+            //   addition to a 1px semi-transparent border. The margin can be easily observed by
+            //   using a screenshot tool to get a screenshot of a selected window, and is
+            //   presumably used for drawing drop shadows. Getting window geometry information
+            //   via hierarchy-climbing results in this margin being included in both the
+            //   position and outer size, so a window positioned at (0, 0) would be reported as
+            //   having a position (-10, -8).
+            // * Compiz has a drop shadow margin just like Mutter/Muffin/Budgie, though it's 10px
+            //   on all sides, and there's no additional border.
+            // * Enlightenment otherwise gets a y position equivalent to inner_y_rel_root.
+            //   Without decorations, there's no difference. This is presumably related to
+            //   Enlightenment's fairly unique concept of window position; it interprets
+            //   positions given to XMoveWindow as a client area position rather than a position
+            //   of the overall window.
+
+            FrameExtentsHeuristic {
+                frame_extents,
+                heuristic_path: Supported,
+            }
+        } else if nested {
+            // If the position value we have is for a nested window used as the client area, we'll
+            // just climb up the hierarchy and get the geometry of the outermost window we're
+            // nested in.
+            let outer_window = self.climb_hierarchy(window, root).expect("Failed to climb window hierarchy");
+            let (outer_y, outer_width, outer_height) = {
+                let outer_geometry = self.get_geometry(outer_window).expect("Failed to get outer window geometry");
+                (
+                    outer_geometry.y_rel_parent,
+                    outer_geometry.width,
+                    outer_geometry.height,
+                )
+            };
+
+            // Since we have the geometry of the outermost window and the geometry of the client
+            // area, we can figure out what's in between.
+            let diff_x = outer_width.saturating_sub(width);
+            let diff_y = outer_height.saturating_sub(height);
+            let offset_y = inner_y_rel_root.saturating_sub(outer_y) as c_uint;
+
+            let left = diff_x / 2;
+            let right = left;
+            let top = offset_y;
+            let bottom = diff_y.saturating_sub(offset_y);
+
+            let frame_extents = FrameExtents::new(
+                left.into(),
+                right.into(),
+                top.into(),
+                bottom.into(),
+            );
+            FrameExtentsHeuristic {
+                frame_extents,
+                heuristic_path: UnsupportedNested,
+            }
+        } else {
+            // This is the case for xmonad and dwm, AKA the only WMs tested that supplied a
+            // border value. This is convenient, since we can use it to get an accurate frame.
+            let frame_extents = FrameExtents::from_border(border.into());
+            FrameExtentsHeuristic {
+                frame_extents,
+                heuristic_path: UnsupportedBordered,
+            }
         }
     }
 }

--- a/src/platform/linux/x11/util/input.rs
+++ b/src/platform/linux/x11/util/input.rs
@@ -1,44 +1,12 @@
+use std::str;
+
 use super::*;
 use events::ModifiersState;
 
-pub unsafe fn select_xinput_events(
-    xconn: &Arc<XConnection>,
-    window: c_ulong,
-    device_id: c_int,
-    mask: i32,
-) -> Flusher {
-    let mut event_mask = ffi::XIEventMask {
-        deviceid: device_id,
-        mask: &mask as *const _ as *mut c_uchar,
-        mask_len: mem::size_of_val(&mask) as c_int,
-    };
-    (xconn.xinput2.XISelectEvents)(
-        xconn.display,
-        window,
-        &mut event_mask as *mut ffi::XIEventMask,
-        1, // number of masks to read from pointer above
-    );
-    Flusher::new(xconn)
-}
-
-#[allow(dead_code)]
-pub unsafe fn select_xkb_events(
-    xconn: &Arc<XConnection>,
-    device_id: c_uint,
-    mask: c_ulong,
-) -> Option<Flusher> {
-    let status = (xconn.xlib.XkbSelectEvents)(
-        xconn.display,
-        device_id,
-        mask,
-        mask,
-    );
-    if status == ffi::True {
-        Some(Flusher::new(xconn))
-    } else {
-        None
-    }
-}
+// A base buffer size of 1kB uses a negligible amount of RAM while preventing us from having to
+// re-allocate (and make another round-trip) in the *vast* majority of cases.
+// To test if `lookup_utf8` works correctly, set this to 1.
+const TEXT_BUFFER_SIZE: usize = 1024;
 
 impl From<ffi::XIModifierState> for ModifiersState {
     fn from(mods: ffi::XIModifierState) -> Self {
@@ -53,17 +21,17 @@ impl From<ffi::XIModifierState> for ModifiersState {
 }
 
 pub struct PointerState<'a> {
-    xconn: &'a Arc<XConnection>,
-    _root: ffi::Window,
-    _child: ffi::Window,
-    _root_x: c_double,
-    _root_y: c_double,
-    _win_x: c_double,
-    _win_y: c_double,
-    _buttons: ffi::XIButtonState,
+    xconn: &'a XConnection,
+    root: ffi::Window,
+    child: ffi::Window,
+    root_x: c_double,
+    root_y: c_double,
+    win_x: c_double,
+    win_y: c_double,
+    buttons: ffi::XIButtonState,
     modifiers: ffi::XIModifierState,
-    _group: ffi::XIGroupState,
-    _relative_to_window: bool,
+    group: ffi::XIGroupState,
+    relative_to_window: bool,
 }
 
 impl<'a> PointerState<'a> {
@@ -74,114 +42,115 @@ impl<'a> PointerState<'a> {
 
 impl<'a> Drop for PointerState<'a> {
     fn drop(&mut self) {
-        unsafe {
-            // This is why you need to read the docs carefully...
-            (self.xconn.xlib.XFree)(self._buttons.mask as _);
+        if !self.buttons.mask.is_null() {
+            unsafe {
+                // This is why you need to read the docs carefully...
+                (self.xconn.xlib.XFree)(self.buttons.mask as _);
+            }
         }
     }
 }
 
-pub unsafe fn query_pointer(
-    xconn: &Arc<XConnection>,
-    window: ffi::Window,
-    device_id: c_int,
-) -> Result<PointerState, XError> {
-    let mut root_return = mem::uninitialized();
-    let mut child_return = mem::uninitialized();
-    let mut root_x_return = mem::uninitialized();
-    let mut root_y_return = mem::uninitialized();
-    let mut win_x_return = mem::uninitialized();
-    let mut win_y_return = mem::uninitialized();
-    let mut buttons_return = mem::uninitialized();
-    let mut modifiers_return = mem::uninitialized();
-    let mut group_return = mem::uninitialized();
+impl XConnection {
+    pub fn select_xinput_events(&self, window: c_ulong, device_id: c_int, mask: i32) -> Flusher {
+        let mut event_mask = ffi::XIEventMask {
+            deviceid: device_id,
+            mask: &mask as *const _ as *mut c_uchar,
+            mask_len: mem::size_of_val(&mask) as c_int,
+        };
+        unsafe {
+            (self.xinput2.XISelectEvents)(
+                self.display,
+                window,
+                &mut event_mask as *mut ffi::XIEventMask,
+                1, // number of masks to read from pointer above
+            );
+        }
+        Flusher::new(self)
+    }
 
-    let relative_to_window = (xconn.xinput2.XIQueryPointer)(
-        xconn.display,
-        device_id,
-        window,
-        &mut root_return,
-        &mut child_return,
-        &mut root_x_return,
-        &mut root_y_return,
-        &mut win_x_return,
-        &mut win_y_return,
-        &mut buttons_return,
-        &mut modifiers_return,
-        &mut group_return,
-    ) == ffi::True;
+    #[allow(dead_code)]
+    pub fn select_xkb_events(&self, device_id: c_uint, mask: c_ulong) -> Option<Flusher> {
+        let status = unsafe {
+            (self.xlib.XkbSelectEvents)(
+                self.display,
+                device_id,
+                mask,
+                mask,
+            )
+        };
+        if status == ffi::True {
+            Some(Flusher::new(self))
+        } else {
+            None
+        }
+    }
 
-    xconn.check_errors()?;
+    pub fn query_pointer(&self, window: ffi::Window, device_id: c_int) -> Result<PointerState, XError> {
+        unsafe {
+            let mut pointer_state: PointerState = mem::uninitialized();
+            pointer_state.xconn = self;
+            pointer_state.relative_to_window = (self.xinput2.XIQueryPointer)(
+                self.display,
+                device_id,
+                window,
+                &mut pointer_state.root,
+                &mut pointer_state.child,
+                &mut pointer_state.root_x,
+                &mut pointer_state.root_y,
+                &mut pointer_state.win_x,
+                &mut pointer_state.win_y,
+                &mut pointer_state.buttons,
+                &mut pointer_state.modifiers,
+                &mut pointer_state.group,
+            ) == ffi::True;
+            if let Err(err) = self.check_errors() {
+                // Running the destrutor would be bad news for us...
+                mem::forget(pointer_state);
+                Err(err)
+            } else {
+                Ok(pointer_state)
+            }
+        }
+    }
 
-    Ok(PointerState {
-        xconn,
-        _root: root_return,
-        _child: child_return,
-        _root_x: root_x_return,
-        _root_y: root_y_return,
-        _win_x: win_x_return,
-        _win_y: win_y_return,
-        _buttons: buttons_return,
-        modifiers: modifiers_return,
-        _group: group_return,
-        _relative_to_window: relative_to_window,
-    })
-}
+    fn lookup_utf8_inner(
+        &self,
+        ic: ffi::XIC,
+        key_event: &mut ffi::XKeyEvent,
+        buffer: &mut [u8],
+    ) -> (ffi::KeySym, ffi::Status, c_int) {
+        let mut keysym: ffi::KeySym = 0;
+        let mut status: ffi::Status = 0;
+        let count = unsafe {
+            (self.xlib.Xutf8LookupString)(
+                ic,
+                key_event,
+                buffer.as_mut_ptr() as *mut c_char,
+                buffer.len() as c_int,
+                &mut keysym,
+                &mut status,
+            )
+        };
+        (keysym, status, count)
+    }
 
-unsafe fn lookup_utf8_inner(
-    xconn: &Arc<XConnection>,
-    ic: ffi::XIC,
-    key_event: &mut ffi::XKeyEvent,
-    buffer: &mut [u8],
-) -> (ffi::KeySym, ffi::Status, c_int) {
-    let mut keysym: ffi::KeySym = 0;
-    let mut status: ffi::Status = 0;
-    let count = (xconn.xlib.Xutf8LookupString)(
-        ic,
-        key_event,
-        buffer.as_mut_ptr() as *mut c_char,
-        buffer.len() as c_int,
-        &mut keysym,
-        &mut status,
-    );
-    (keysym, status, count)
-}
-
-// A base buffer size of 1kB uses a negligible amount of RAM while preventing us from having to
-// re-allocate (and make another round-trip) in the *vast* majority of cases.
-// To test if lookup_utf8 works correctly, set this to 1.
-const TEXT_BUFFER_SIZE: usize = 1024;
-
-pub unsafe fn lookup_utf8(
-    xconn: &Arc<XConnection>,
-    ic: ffi::XIC,
-    key_event: &mut ffi::XKeyEvent,
-) -> String {
-    let mut buffer: [u8; TEXT_BUFFER_SIZE] = mem::uninitialized();
-    let (_, status, count) = lookup_utf8_inner(
-        xconn,
-        ic,
-        key_event,
-        &mut buffer,
-    );
-
-    // The buffer overflowed, so we'll make a new one on the heap.
-    if status == ffi::XBufferOverflow {
-        let mut buffer = Vec::with_capacity(count as usize);
-        buffer.set_len(count as usize);
-        let (_, _, new_count) = lookup_utf8_inner(
-            xconn,
-            ic,
-            key_event,
-            &mut buffer,
-        );
-        debug_assert_eq!(count, new_count);
-        str::from_utf8(&buffer[..count as usize])
-            .unwrap_or("")
-            .to_string()
-    } else {
-        str::from_utf8(&buffer[..count as usize])
-            .unwrap_or("")
-            .to_string()
+    pub fn lookup_utf8(&self, ic: ffi::XIC, key_event: &mut ffi::XKeyEvent) -> String {
+        let mut buffer: [u8; TEXT_BUFFER_SIZE] = unsafe { mem::uninitialized() };
+        let (_, status, count) = self.lookup_utf8_inner(ic, key_event, &mut buffer);
+        // The buffer overflowed, so we'll make a new one on the heap.
+        if status == ffi::XBufferOverflow {
+            let mut buffer = Vec::with_capacity(count as usize);
+            unsafe { buffer.set_len(count as usize) };
+            let (_, _, new_count) = self.lookup_utf8_inner(ic, key_event, &mut buffer);
+            debug_assert_eq!(count, new_count);
+            str::from_utf8(&buffer[..count as usize])
+                .unwrap_or("")
+                .to_string()
+        } else {
+            str::from_utf8(&buffer[..count as usize])
+                .unwrap_or("")
+                .to_string()
+        }
     }
 }

--- a/src/platform/linux/x11/util/memory.rs
+++ b/src/platform/linux/x11/util/memory.rs
@@ -1,0 +1,62 @@
+use std::ops::{Deref, DerefMut};
+
+use super::*;
+
+pub struct XSmartPointer<'a, T> {
+    xconn: &'a XConnection,
+    pub ptr: *mut T,
+}
+
+impl<'a, T> XSmartPointer<'a, T> {
+    // You're responsible for only passing things to this that should be XFree'd.
+    // Returns None if ptr is null.
+    pub fn new(xconn: &'a XConnection, ptr: *mut T) -> Option<Self> {
+        if !ptr.is_null() {
+            Some(XSmartPointer {
+                xconn,
+                ptr,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T> Deref for XSmartPointer<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<'a, T> DerefMut for XSmartPointer<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.ptr }
+    }
+}
+
+impl<'a, T> Drop for XSmartPointer<'a, T> {
+    fn drop(&mut self) {
+        unsafe {
+            (self.xconn.xlib.XFree)(self.ptr as *mut _);
+        }
+    }
+}
+
+impl XConnection {
+    pub fn alloc_class_hint(&self) -> XSmartPointer<ffi::XClassHint> {
+        XSmartPointer::new(self, unsafe { (self.xlib.XAllocClassHint)() })
+            .expect("`XAllocClassHint` returned null; out of memory")
+    }
+
+    pub fn alloc_size_hints(&self) -> XSmartPointer<ffi::XSizeHints> {
+        XSmartPointer::new(self, unsafe { (self.xlib.XAllocSizeHints)() })
+            .expect("`XAllocSizeHints` returned null; out of memory")
+    }
+
+    pub fn alloc_wm_hints(&self) -> XSmartPointer<ffi::XWMHints> {
+        XSmartPointer::new(self, unsafe { (self.xlib.XAllocWMHints)() })
+            .expect("`XAllocWMHints` returned null; out of memory")
+    }
+}

--- a/src/platform/linux/x11/util/mod.rs
+++ b/src/platform/linux/x11/util/mod.rs
@@ -2,180 +2,80 @@
 // *results may vary
 
 mod atom;
+mod client_msg;
+mod format;
 mod geometry;
 mod hint;
 mod icon;
 mod input;
+mod memory;
 mod randr;
 mod window_property;
 mod wm;
 
 pub use self::atom::*;
+pub use self::client_msg::*;
+pub use self::format::*;
 pub use self::geometry::*;
 pub use self::hint::*;
 pub use self::icon::*;
 pub use self::input::*;
+pub use self::memory::*;
 pub use self::randr::*;
 pub use self::window_property::*;
 pub use self::wm::*;
 
 use std::mem;
 use std::ptr;
-use std::str;
-use std::sync::Arc;
-use std::ops::{Deref, DerefMut};
 use std::os::raw::*;
 
 use super::{ffi, XConnection, XError};
 
-// This isn't actually the number of the bits in the format.
-// X11 does a match on this value to determine which type to call sizeof on.
-// Thus, we use 32 for c_long, since 32 maps to c_long which maps to 64.
-// ...if that sounds confusing, then you know why this enum is here.
-#[derive(Debug, Copy, Clone)]
-pub enum Format {
-    Char = 8,
-    Short = 16,
-    Long = 32,
-}
-
-impl Format {
-    pub fn from_format(format: usize) -> Option<Self> {
-        match format {
-            8 => Some(Format::Char),
-            16 => Some(Format::Short),
-            32 => Some(Format::Long),
-            _ => None,
-        }
-    }
-
-    pub fn is_same_size_as<T>(&self) -> bool {
-        mem::size_of::<T>() == self.get_actual_size()
-    }
-
-    pub fn get_actual_size(&self) -> usize {
-        match self {
-            &Format::Char => mem::size_of::<c_char>(),
-            &Format::Short => mem::size_of::<c_short>(),
-            &Format::Long => mem::size_of::<c_long>(),
-        }
-    }
-}
-
-pub struct XSmartPointer<'a, T> {
-    xconn: &'a Arc<XConnection>,
-    pub ptr: *mut T,
-}
-
-impl<'a, T> XSmartPointer<'a, T> {
-    // You're responsible for only passing things to this that should be XFree'd.
-    // Returns None if ptr is null.
-    pub fn new(xconn: &'a Arc<XConnection>, ptr: *mut T) -> Option<Self> {
-        if !ptr.is_null() {
-            Some(XSmartPointer {
-                xconn,
-                ptr,
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl<'a, T> Deref for XSmartPointer<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<'a, T> DerefMut for XSmartPointer<'a, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.ptr }
-    }
-}
-
-impl<'a, T> Drop for XSmartPointer<'a, T> {
-    fn drop(&mut self) {
-        unsafe {
-            (self.xconn.xlib.XFree)(self.ptr as *mut _);
-        }
-    }
-}
-
-// This is impoartant, so pay attention!
-// Xlib has an output buffer, and tries to hide the async nature of X from you.
-// This buffer contains the requests you make, and is flushed under various circumstances:
-// 1. XPending, XNextEvent, and XWindowEvent flush "as needed"
-// 2. XFlush explicitly flushes
-// 3. XSync flushes and blocks until all requests are responded to
-// 4. Calls that have a return dependent on a response (i.e. XGetWindowProperty) sync internally.
-//    When in doubt, check the X11 source; if a function calls _XReply, it flushes and waits.
-// All util functions that abstract an async function will return a Flusher.
-pub unsafe fn flush_requests(xconn: &Arc<XConnection>) -> Result<(), XError> {
-    (xconn.xlib.XFlush)(xconn.display);
-    //println!("XFlush");
-    // This isn't necessarily a useful time to check for errors (since our request hasn't
-    // necessarily been processed yet)
-    xconn.check_errors()
-}
-
-pub unsafe fn sync_with_server(xconn: &Arc<XConnection>) -> Result<(), XError> {
-    (xconn.xlib.XSync)(xconn.display, ffi::False);
-    //println!("XSync");
-    xconn.check_errors()
-}
-
 #[must_use = "This request was made asynchronously, and is still in the output buffer. You must explicitly choose to either `.flush()` (empty the output buffer, sending the request now) or `.queue()` (wait to send the request, allowing you to continue to add more requests without additional round-trips). For more information, see the documentation for `util::flush_requests`."]
 pub struct Flusher<'a> {
-    xconn: &'a Arc<XConnection>,
+    xconn: &'a XConnection,
 }
 
 impl<'a> Flusher<'a> {
-    pub fn new(xconn: &'a Arc<XConnection>) -> Self {
+    pub fn new(xconn: &'a XConnection) -> Self {
         Flusher { xconn }
     }
 
     // "I want this request sent now!"
     pub fn flush(self) -> Result<(), XError> {
-        unsafe { flush_requests(self.xconn) }
+        self.xconn.flush_requests()
+    }
+
+    // "I want the response now too!"
+    pub fn sync(self) -> Result<(), XError> {
+        self.xconn.sync_with_server()
     }
 
     // "I'm aware that this request hasn't been sent, and I'm okay with waiting."
     pub fn queue(self) {}
 }
 
-pub unsafe fn send_client_msg(
-    xconn: &Arc<XConnection>,
-    window: c_ulong,        // The window this is "about"; not necessarily this window
-    target_window: c_ulong, // The window we're sending to
-    message_type: ffi::Atom,
-    event_mask: Option<c_long>,
-    data: (c_long, c_long, c_long, c_long, c_long),
-) -> Flusher {
-    let mut event: ffi::XClientMessageEvent = mem::uninitialized();
-    event.type_ = ffi::ClientMessage;
-    event.display = xconn.display;
-    event.window = window;
-    event.message_type = message_type;
-    event.format = Format::Long as c_int;
-    event.data = ffi::ClientMessageData::new();
-    event.data.set_long(0, data.0);
-    event.data.set_long(1, data.1);
-    event.data.set_long(2, data.2);
-    event.data.set_long(3, data.3);
-    event.data.set_long(4, data.4);
+impl XConnection {
+    // This is impoartant, so pay attention!
+    // Xlib has an output buffer, and tries to hide the async nature of X from you.
+    // This buffer contains the requests you make, and is flushed under various circumstances:
+    // 1. `XPending`, `XNextEvent`, and `XWindowEvent` flush "as needed"
+    // 2. `XFlush` explicitly flushes
+    // 3. `XSync` flushes and blocks until all requests are responded to
+    // 4. Calls that have a return dependent on a response (i.e. `XGetWindowProperty`) sync internally.
+    //    When in doubt, check the X11 source; if a function calls `_XReply`, it flushes and waits.
+    // All util functions that abstract an async function will return a `Flusher`.
+    pub fn flush_requests(&self) -> Result<(), XError> {
+        unsafe { (self.xlib.XFlush)(self.display) };
+        //println!("XFlush");
+        // This isn't necessarily a useful time to check for errors (since our request hasn't
+        // necessarily been processed yet)
+        self.check_errors()
+    }
 
-    let event_mask = event_mask.unwrap_or(ffi::NoEventMask);
-
-    (xconn.xlib.XSendEvent)(
-        xconn.display,
-        target_window,
-        ffi::False,
-        event_mask,
-        &mut event.into(),
-    );
-
-    Flusher::new(xconn)
+    pub fn sync_with_server(&self) -> Result<(), XError> {
+        unsafe { (self.xlib.XSync)(self.display, ffi::False) };
+        //println!("XSync");
+        self.check_errors()
+    }
 }

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -60,25 +60,23 @@ pub fn calc_dpi_factor(
     ((ppmm * (12.0 * 25.4 / 96.0)).round() / 12.0).max(1.0)
 }
 
-pub unsafe fn get_output_info(
-    xconn: &Arc<XConnection>,
-    resources: *mut XRRScreenResources,
-    repr: &MonitorRepr,
-) -> (String, f32) {
-    let output_info = (xconn.xrandr.XRRGetOutputInfo)(
-        xconn.display,
-        resources,
-        repr.get_output(),
-    );
-    let name_slice = slice::from_raw_parts(
-        (*output_info).name as *mut u8,
-        (*output_info).nameLen as usize,
-    );
-    let name = String::from_utf8_lossy(name_slice).into();
-    let hidpi_factor = calc_dpi_factor(
-        repr.get_dimensions(),
-        ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
-    ) as f32;
-    (xconn.xrandr.XRRFreeOutputInfo)(output_info);
-    (name, hidpi_factor)
+impl XConnection {
+    pub unsafe fn get_output_info(&self, resources: *mut XRRScreenResources, repr: &MonitorRepr) -> (String, f32) {
+        let output_info = (self.xrandr.XRRGetOutputInfo)(
+            self.display,
+            resources,
+            repr.get_output(),
+        );
+        let name_slice = slice::from_raw_parts(
+            (*output_info).name as *mut u8,
+            (*output_info).nameLen as usize,
+        );
+        let name = String::from_utf8_lossy(name_slice).into();
+        let hidpi_factor = calc_dpi_factor(
+            repr.get_dimensions(),
+            ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
+        ) as f32;
+        (self.xrandr.XRRFreeOutputInfo)(output_info);
+        (name, hidpi_factor)
+    }
 }

--- a/src/platform/linux/x11/util/window_property.rs
+++ b/src/platform/linux/x11/util/window_property.rs
@@ -1,5 +1,4 @@
 use std;
-use std::fmt::Debug;
 
 use super::*;
 
@@ -25,139 +24,121 @@ impl GetPropertyError {
 }
 
 // Number of 32-bit chunks to retrieve per iteration of get_property's inner loop.
-// To test if get_property works correctly, set this to 1.
+// To test if `get_property` works correctly, set this to 1.
 const PROPERTY_BUFFER_SIZE: c_long = 1024; // 4k of RAM ought to be enough for anyone!
-
-pub unsafe fn get_property<T: Debug + Clone>(
-    xconn: &Arc<XConnection>,
-    window: c_ulong,
-    property: ffi::Atom,
-    property_type: ffi::Atom,
-) -> Result<Vec<T>, GetPropertyError> {
-    let mut data = Vec::new();
-    let mut offset = 0;
-
-    let mut done = false;
-    while !done {
-        let mut actual_type: ffi::Atom = mem::uninitialized();
-        let mut actual_format: c_int = mem::uninitialized();
-        let mut quantity_returned: c_ulong = mem::uninitialized();
-        let mut bytes_after: c_ulong = mem::uninitialized();
-        let mut buf: *mut c_uchar = ptr::null_mut();
-        (xconn.xlib.XGetWindowProperty)(
-            xconn.display,
-            window,
-            property,
-            // This offset is in terms of 32-bit chunks.
-            offset,
-            // This is the quanity of 32-bit chunks to receive at once.
-            PROPERTY_BUFFER_SIZE,
-            ffi::False,
-            property_type,
-            &mut actual_type,
-            &mut actual_format,
-            // This is the quantity of items we retrieved in our format, NOT of 32-bit chunks!
-            &mut quantity_returned,
-            // ...and this is a quantity of bytes. So, this function deals in 3 different units.
-            &mut bytes_after,
-            &mut buf,
-        );
-
-        if let Err(e) = xconn.check_errors() {
-            return Err(GetPropertyError::XError(e));
-        }
-
-        if actual_type != property_type {
-            return Err(GetPropertyError::TypeMismatch(actual_type));
-        }
-
-        let format_mismatch = Format::from_format(actual_format as _)
-            .map(|actual_format| !actual_format.is_same_size_as::<T>())
-            // This won't actually be reached; the XError condition above is triggered first.
-            .unwrap_or(true);
-
-        if format_mismatch {
-            return Err(GetPropertyError::FormatMismatch(actual_format));
-        }
-
-        if !buf.is_null() {
-            offset += PROPERTY_BUFFER_SIZE;
-            let new_data = std::slice::from_raw_parts(
-                buf as *mut T,
-                quantity_returned as usize,
-            );
-            /*println!(
-                "XGetWindowProperty prop:{:?} fmt:{:02} len:{:02} off:{:02} out:{:02}, buf:{:?}",
-                property,
-                mem::size_of::<T>() * 8,
-                data.len(),
-                offset,
-                quantity_returned,
-                new_data,
-            );*/
-            data.extend_from_slice(&new_data);
-            // Fun fact: XGetWindowProperty allocates one extra byte at the end.
-            (xconn.xlib.XFree)(buf as _); // Don't try to access new_data after this.
-        } else {
-            return Err(GetPropertyError::NothingAllocated);
-        }
-
-        done = bytes_after == 0;
-    }
-
-    Ok(data)
-}
 
 #[derive(Debug)]
 pub enum PropMode {
     Replace = ffi::PropModeReplace as isize,
-    _Prepend = ffi::PropModePrepend as isize,
-    _Append = ffi::PropModeAppend as isize,
+    Prepend = ffi::PropModePrepend as isize,
+    Append = ffi::PropModeAppend as isize,
 }
 
-#[derive(Debug, Clone)]
-pub struct InvalidFormat {
-    format_used: Format,
-    size_passed: usize,
-    size_expected: usize,
-}
+impl XConnection {
+    pub fn get_property<T: Formattable>(
+        &self,
+        window: c_ulong,
+        property: ffi::Atom,
+        property_type: ffi::Atom,
+    ) -> Result<Vec<T>, GetPropertyError> {
+        let mut data = Vec::new();
+        let mut offset = 0;
 
-pub unsafe fn change_property<'a, T: Debug>(
-    xconn: &'a Arc<XConnection>,
-    window: c_ulong,
-    property: ffi::Atom,
-    property_type: ffi::Atom,
-    format: Format,
-    mode: PropMode,
-    new_value: &[T],
-) -> Flusher<'a> {
-    if !format.is_same_size_as::<T>() {
-        panic!(format!(
-            "[winit developer error] Incorrect usage of `util::change_property`: {:#?}",
-            InvalidFormat {
-                format_used: format,
-                size_passed: mem::size_of::<T>() * 8,
-                size_expected: format.get_actual_size() * 8,
-            },
-        ));
+        let mut done = false;
+        while !done {
+            unsafe {
+                let mut actual_type: ffi::Atom = mem::uninitialized();
+                let mut actual_format: c_int = mem::uninitialized();
+                let mut quantity_returned: c_ulong = mem::uninitialized();
+                let mut bytes_after: c_ulong = mem::uninitialized();
+                let mut buf: *mut c_uchar = ptr::null_mut();
+                (self.xlib.XGetWindowProperty)(
+                    self.display,
+                    window,
+                    property,
+                    // This offset is in terms of 32-bit chunks.
+                    offset,
+                    // This is the quanity of 32-bit chunks to receive at once.
+                    PROPERTY_BUFFER_SIZE,
+                    ffi::False,
+                    property_type,
+                    &mut actual_type,
+                    &mut actual_format,
+                    // This is the quantity of items we retrieved in our format, NOT of 32-bit chunks!
+                    &mut quantity_returned,
+                    // ...and this is a quantity of bytes. So, this function deals in 3 different units.
+                    &mut bytes_after,
+                    &mut buf,
+                );
+
+                if let Err(e) = self.check_errors() {
+                    return Err(GetPropertyError::XError(e));
+                }
+
+                if actual_type != property_type {
+                    return Err(GetPropertyError::TypeMismatch(actual_type));
+                }
+
+                let format_mismatch = Format::from_format(actual_format as _) != Some(T::FORMAT);
+                if format_mismatch {
+                    return Err(GetPropertyError::FormatMismatch(actual_format));
+                }
+
+                if !buf.is_null() {
+                    offset += PROPERTY_BUFFER_SIZE;
+                    let new_data = std::slice::from_raw_parts(
+                        buf as *mut T,
+                        quantity_returned as usize,
+                    );
+                    /*println!(
+                        "XGetWindowProperty prop:{:?} fmt:{:02} len:{:02} off:{:02} out:{:02}, buf:{:?}",
+                        property,
+                        mem::size_of::<T>() * 8,
+                        data.len(),
+                        offset,
+                        quantity_returned,
+                        new_data,
+                    );*/
+                    data.extend_from_slice(&new_data);
+                    // Fun fact: XGetWindowProperty allocates one extra byte at the end.
+                    (self.xlib.XFree)(buf as _); // Don't try to access new_data after this.
+                } else {
+                    return Err(GetPropertyError::NothingAllocated);
+                }
+
+                done = bytes_after == 0;
+            }
+        }
+
+        Ok(data)
     }
 
-    (xconn.xlib.XChangeProperty)(
-        xconn.display,
-        window,
-        property,
-        property_type,
-        format as c_int,
-        mode as c_int,
-        new_value.as_ptr() as *const c_uchar,
-        new_value.len() as c_int,
-    );
-
-    /*println!(
-        "XChangeProperty prop:{:?} val:{:?}",
-        property,
-        new_value,
-    );*/
-
-    Flusher::new(xconn)
+    pub fn change_property<'a, T: Formattable>(
+        &'a self,
+        window: c_ulong,
+        property: ffi::Atom,
+        property_type: ffi::Atom,
+        mode: PropMode,
+        new_value: &[T],
+    ) -> Flusher<'a> {
+        debug_assert_eq!(mem::size_of::<T>(), T::FORMAT.get_actual_size());
+        unsafe {
+            (self.xlib.XChangeProperty)(
+                self.display,
+                window,
+                property,
+                property_type,
+                T::FORMAT as c_int,
+                mode as c_int,
+                new_value.as_ptr() as *const c_uchar,
+                new_value.len() as c_int,
+            );
+        }
+        /*println!(
+            "XChangeProperty prop:{:?} val:{:?}",
+            property,
+            new_value,
+        );*/
+        Flusher::new(self)
+    }
 }

--- a/src/platform/linux/x11/util/wm.rs
+++ b/src/platform/linux/x11/util/wm.rs
@@ -20,139 +20,122 @@ pub fn wm_name_is_one_of(names: &[&str]) -> bool {
     }
 }
 
-pub fn update_cached_wm_info(xconn: &Arc<XConnection>, root: ffi::Window) {
-    *SUPPORTED_HINTS.lock() = self::get_supported_hints(xconn, root);
-    *WM_NAME.lock() = self::get_wm_name(xconn, root);
-}
+impl XConnection {
+    pub fn update_cached_wm_info(&self, root: ffi::Window) {
+        *SUPPORTED_HINTS.lock() = self.get_supported_hints(root);
+        *WM_NAME.lock() = self.get_wm_name(root);
+    }
 
-fn get_supported_hints(xconn: &Arc<XConnection>, root: ffi::Window) -> Vec<ffi::Atom> {
-    let supported_atom = unsafe { self::get_atom(xconn, b"_NET_SUPPORTED\0") }
-        .expect("Failed to call XInternAtom (_NET_SUPPORTED)");
-    unsafe {
-        self::get_property(
-            xconn,
+    fn get_supported_hints(&self, root: ffi::Window) -> Vec<ffi::Atom> {
+        let supported_atom = unsafe { self.get_atom_unchecked(b"_NET_SUPPORTED\0") };
+        self.get_property(
             root,
             supported_atom,
             ffi::XA_ATOM,
-        )
-    }.unwrap_or_else(|_| Vec::with_capacity(0))
-}
+        ).unwrap_or_else(|_| Vec::with_capacity(0))
+    }
 
-fn get_wm_name(xconn: &Arc<XConnection>, root: ffi::Window) -> Option<String> {
-    let check_atom = unsafe { self::get_atom(xconn, b"_NET_SUPPORTING_WM_CHECK\0") }
-        .expect("Failed to call XInternAtom (_NET_SUPPORTING_WM_CHECK)");
-    let wm_name_atom = unsafe { self::get_atom(xconn, b"_NET_WM_NAME\0") }
-        .expect("Failed to call XInternAtom (_NET_WM_NAME)");
+    fn get_wm_name(&self, root: ffi::Window) -> Option<String> {
+        let check_atom = unsafe { self.get_atom_unchecked(b"_NET_SUPPORTING_WM_CHECK\0") };
+        let wm_name_atom = unsafe { self.get_atom_unchecked(b"_NET_WM_NAME\0") };
 
-    // Mutter/Muffin/Budgie doesn't have _NET_SUPPORTING_WM_CHECK in its _NET_SUPPORTED, despite
-    // it working and being supported. This has been reported upstream, but due to the
-    // inavailability of time machines, we'll just try to get _NET_SUPPORTING_WM_CHECK
-    // regardless of whether or not the WM claims to support it.
-    //
-    // Blackbox 0.70 also incorrectly reports not supporting this, though that appears to be fixed
-    // in 0.72.
-    /*if !supported_hints.contains(&check_atom) {
-        return None;
-    }*/
+        // Mutter/Muffin/Budgie doesn't have _NET_SUPPORTING_WM_CHECK in its _NET_SUPPORTED, despite
+        // it working and being supported. This has been reported upstream, but due to the
+        // inavailability of time machines, we'll just try to get _NET_SUPPORTING_WM_CHECK
+        // regardless of whether or not the WM claims to support it.
+        //
+        // Blackbox 0.70 also incorrectly reports not supporting this, though that appears to be fixed
+        // in 0.72.
+        /*if !supported_hints.contains(&check_atom) {
+            return None;
+        }*/
 
-    // IceWM (1.3.x and earlier) doesn't report supporting _NET_WM_NAME, but will nonetheless
-    // provide us with a value for it. Note that the unofficial 1.4 fork of IceWM works fine.
-    /*if !supported_hints.contains(&wm_name_atom) {
-        return None;
-    }*/
+        // IceWM (1.3.x and earlier) doesn't report supporting _NET_WM_NAME, but will nonetheless
+        // provide us with a value for it. Note that the unofficial 1.4 fork of IceWM works fine.
+        /*if !supported_hints.contains(&wm_name_atom) {
+            return None;
+        }*/
 
-    // Of the WMs tested, only xmonad and dwm fail to provide a WM name.
+        // Of the WMs tested, only xmonad and dwm fail to provide a WM name.
 
-    // Querying this property on the root window will give us the ID of a child window created by
-    // the WM.
-    let root_window_wm_check = {
-        let result = unsafe {
-            self::get_property(
-                xconn,
+        // Querying this property on the root window will give us the ID of a child window created by
+        // the WM.
+        let root_window_wm_check = {
+            let result = self.get_property(
                 root,
                 check_atom,
                 ffi::XA_WINDOW,
-            )
+            );
+
+            let wm_check = result
+                .ok()
+                .and_then(|wm_check| wm_check.get(0).cloned());
+
+            if let Some(wm_check) = wm_check {
+                wm_check
+            } else {
+                return None;
+            }
         };
 
-        let wm_check = result
-            .ok()
-            .and_then(|wm_check| wm_check.get(0).cloned());
-
-        if let Some(wm_check) = wm_check {
-            wm_check
-        } else {
-            return None;
-        }
-    };
-
-    // Querying the same property on the child window we were given, we should get this child
-    // window's ID again.
-    let child_window_wm_check = {
-        let result = unsafe {
-            self::get_property(
-                xconn,
+        // Querying the same property on the child window we were given, we should get this child
+        // window's ID again.
+        let child_window_wm_check = {
+            let result = self.get_property(
                 root_window_wm_check,
                 check_atom,
                 ffi::XA_WINDOW,
-            )
+            );
+
+            let wm_check = result
+                .ok()
+                .and_then(|wm_check| wm_check.get(0).cloned());
+
+            if let Some(wm_check) = wm_check {
+                wm_check
+            } else {
+                return None;
+            }
         };
 
-        let wm_check = result
-            .ok()
-            .and_then(|wm_check| wm_check.get(0).cloned());
-
-        if let Some(wm_check) = wm_check {
-            wm_check
-        } else {
+        // These values should be the same.
+        if root_window_wm_check != child_window_wm_check {
             return None;
         }
-    };
 
-    // These values should be the same.
-    if root_window_wm_check != child_window_wm_check {
-        return None;
-    }
+        // All of that work gives us a window ID that we can get the WM name from.
+        let wm_name = {
+            let utf8_string_atom = unsafe { self.get_atom_unchecked(b"UTF8_STRING\0") };
 
-    // All of that work gives us a window ID that we can get the WM name from.
-    let wm_name = {
-        let utf8_string_atom = unsafe { self::get_atom(xconn, b"UTF8_STRING\0") }
-            .expect("Failed to call XInternAtom (UTF8_STRING)");
-
-        let result = unsafe {
-            self::get_property(
-                xconn,
+            let result = self.get_property(
                 root_window_wm_check,
                 wm_name_atom,
                 utf8_string_atom,
-            )
-        };
+            );
 
-        // IceWM requires this. IceWM was also the only WM tested that returns a null-terminated
-        // string. For more fun trivia, IceWM is also unique in including version and uname
-        // information in this string (this means you'll have to be careful if you want to match
-        // against it, though).
-        // The unofficial 1.4 fork of IceWM still includes the extra details, but properly
-        // returns a UTF8 string that isn't null-terminated.
-        let no_utf8 = if let Err(ref err) = result {
-            err.is_actual_property_type(ffi::XA_STRING)
-        } else {
-            false
-        };
+            // IceWM requires this. IceWM was also the only WM tested that returns a null-terminated
+            // string. For more fun trivia, IceWM is also unique in including version and uname
+            // information in this string (this means you'll have to be careful if you want to match
+            // against it, though).
+            // The unofficial 1.4 fork of IceWM still includes the extra details, but properly
+            // returns a UTF8 string that isn't null-terminated.
+            let no_utf8 = if let Err(ref err) = result {
+                err.is_actual_property_type(ffi::XA_STRING)
+            } else {
+                false
+            };
 
-        if no_utf8 {
-            unsafe {
-                self::get_property(
-                    xconn,
+            if no_utf8 {
+                self.get_property(
                     root_window_wm_check,
                     wm_name_atom,
                     ffi::XA_STRING,
                 )
+            } else {
+                result
             }
-        } else {
-            result
-        }
-    }.ok();
+        }.ok();
 
-    wm_name.and_then(|wm_name| String::from_utf8(wm_name).ok())
+        wm_name.and_then(|wm_name| String::from_utf8(wm_name).ok())
+    }
 }


### PR DESCRIPTION
More internal changes:
- Most `util` functions are now `XConnection` methods, which means that they're a bit cleaner to write and no longer require being called on an `Arc`.
- `util` functions where the unsafety is properly encapsulated are no longer marked `unsafe`. This is fortunately most of them, since that's the point of `util` in the first place.
- `util::get_atom` no longer returns a `Result`, since handling that just ends up being boilerplate. `XInternAtom` failing would be too exceptional to be worth handling anyway, so it's simpler just to panic with a nice message.
- `util::PointerState::drop` only calls `XFree` if the relevant pointer isn't null.
- `util::send_client_msg_multi` exists now, and it's a truly beautiful monstrosity of unsafe code. I wrote it when I was trying to implement the startup notification protocol, since that requires using a sequence of client messages to send a body of arbitrary length. It's not used anywhere at present, but now it would be *much* easier for someone else to implement startup notification or anything else that requires this.
- The real highlight of this PR is the `util::Formattable` trait, which statically constrains the types accepted by `util::get_property`, `util::change_propterty`, and `util::send_client_msg_multi`. This was handled using runtime checks before, which was neither idiomatic nor convenient. This also removes the need for manually specifying `util::Format` *ever*, since the correct format is now statically known.