### PR TITLE
X11: Flatten window model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- On X11, the `Moved` event is no longer sent when the window is resized without changing position.
+- `MouseCursor` and `CursorState` now implement `Default`.
+
 # Version 0.15.0 (2018-05-22)
 
 - `Icon::to_cardinals` is no longer public, since it was never supposed to be.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,12 @@ pub enum MouseCursor {
     RowResize,
 }
 
+impl Default for MouseCursor {
+    fn default() -> Self {
+        MouseCursor::Default
+    }
+}
+
 /// Describes how winit handles the cursor.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CursorState {
@@ -389,6 +395,12 @@ pub enum CursorState {
     ///
     /// This is useful for first-person cameras for example.
     Grab,
+}
+
+impl Default for CursorState {
+    fn default() -> Self {
+        CursorState::Normal
+    }
 }
 
 /// Attributes to use when creating a window.

--- a/src/platform/linux/x11/util/mod.rs
+++ b/src/platform/linux/x11/util/mod.rs
@@ -31,6 +31,16 @@ use std::os::raw::*;
 
 use super::{ffi, XConnection, XError};
 
+pub fn maybe_change<T: PartialEq>(field: &mut Option<T>, value: T) -> bool {
+    let wrapped = Some(value);
+    if *field != wrapped {
+        *field = wrapped;
+        true
+    } else {
+        false
+    }
+}
+
 #[must_use = "This request was made asynchronously, and is still in the output buffer. You must explicitly choose to either `.flush()` (empty the output buffer, sending the request now) or `.queue()` (wait to send the request, allowing you to continue to add more requests without additional round-trips). For more information, see the documentation for `util::flush_requests`."]
 pub struct Flusher<'a> {
     xconn: &'a XConnection,


### PR DESCRIPTION
X11 HiDPI will be finished soon, I promise! I'm actually very nearly done with it, but some internal design issues in the X11 backend were actively complicating my work. So, this is yet another refactor PR.

Before this PR:
- `Window` owns a `Window2`, which contains all the actual methods and additionally owns an `XWindow`.
- `Window2` owns `SharedState`, which is shared with `EventsLoop` via `RefCell<HashMap<WindowId, Weak<Mutex<window::SharedState>>>>`.
- `EventsLoop` shares `Arc<Mutex<HashMap<WindowId, WindowData>>>` with `Window`, but not with `Window2`. `Window` has it so it can remove itself from it in `drop`, and `EventsLoop` uses it to store various state related to the window. Nested in `WindowData` is `WindowConfig`.
- There's no way to call methods on `Window2` from `EventsLoop`.

So, to recap, there are 3 window types (`Window`, `Window2`, and `XWindow`) and 3 window state types (`WindowData`, `WindowConfig`, and `SharedState`). Chances are, what you want to access isn't going to be where you need it to be. For instance, that's why I didn't work on #242 for the 0.15.0 release, since it would've involved some tedious state coordination and function duplication.

After this PR:
- `XWindow` has been flattened into `Window2`, and `Window2` has been renamed to `UnownedWindow`. This name represents the fact that `UnownedWindow` is just a bundle of state that's used for calling methods, and not a managed resource.
- `Window` owns an `UnownedWindow`, and cleans up after it.
- `WindowConfig` has been flattened into `WindowData`, and `WindowData` has been flattened into `SharedState`!
- `EventsLoop` has access to every `UnownedWindow` via `RefCell<HashMap<WindowId, Weak<UnownedWindow>>>`. This makes it possible to call `UnownedWindow` methods.
- `EventsLoop::with_window` makes it much more ergonomic to operate on windows.

Before:
```rust
self.shared_state
    .borrow()
    .get(&WindowId(xev.window))
    .map(|window_state| {
        if let Some(window_state) = window_state.upgrade() {
            (*window_state.lock()).frame_extents.take();
        }
    });
```
After:
```rust
self.with_window(xev.window, |window| {
    window.invalidate_cached_frame_extents();
});
```

`with_window` can also return any `Option<T>` you want it to, so it generally can do what you need it to without you having to think about it.

There are still some gotchas, i.e.
```rust
let window_rect = self.with_window(xev.window, |window| {
    let mut shared_state_lock = window.shared_state.lock();
    // Various methods try to lock `SharedState`,
    // so will deadlock if you already have a lock.
    window.get_rect()
});
```

Even with that proviso, this design is ***much*** easier to work with than the existing one.