### PR TITLE
appveyor.yml: Test additional Rust channels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,19 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: nightly
+  - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: stable
+  - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: 1.24.1
   - TARGET: i686-pc-windows-msvc
+    CHANNEL: nightly
   - TARGET: i686-pc-windows-gnu
+    CHANNEL: nightly
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
-  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %CHANNEL% --default-host %TARGET%
+  - SET PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V
   - cargo -V


### PR DESCRIPTION
In addition to nightly, also test the current stable version and Rust
1.24.1.

This might help with #531.