### PR TITLE
Fix DPI with 0 width/hight reported by xorg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
+- On X11, if width or height is reported as 0, the DPI is now 1.0 instead of +inf
+- On X11, the environment variable `WINIT_HIDPI_FACTOR` has been added for overriding DPI factor
 
 # Version 0.15.0 (2018-05-22)
 

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -53,6 +53,11 @@ pub fn calc_dpi_factor(
     (width_px, height_px): (u32, u32),
     (width_mm, height_mm): (u64, u64),
 ) -> f64 {
+    // See http://xpra.org/trac/ticket/728 for more information
+    if width_mm == 0 || width_mm == 0 {
+        return 1.0;
+    }
+
     let ppmm = (
         (width_px as f64 * height_px as f64) / (width_mm as f64 * height_mm as f64)
     ).sqrt();

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -1,4 +1,4 @@
-use std::{slice, env};
+use std::{env, slice};
 use std::str::FromStr;
 
 use super::*;

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -57,6 +57,10 @@ pub fn calc_dpi_factor(
     // Override DPI if `WINIT_HIDPI_FACTOR` variable is set
     if let Ok(dpi_factor_str) = env::var("WINIT_HIDPI_FACTOR") {
         if let Ok(dpi_factor) = f64::from_str(&dpi_factor_str) {
+            if dpi_factor <= 0. {
+                panic!("Expected `WINIT_HIDPI_FACTOR` to be bigger than 0, got '{}'", dpi_factor);
+            }
+
             return dpi_factor;
         }
     }

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use std::{slice, env};
+use std::str::FromStr;
 
 use super::*;
 use super::ffi::{

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -1,4 +1,5 @@
-use std::slice;
+use std::str::FromStr;
+use std::{slice, env};
 
 use super::*;
 use super::ffi::{
@@ -53,6 +54,13 @@ pub fn calc_dpi_factor(
     (width_px, height_px): (u32, u32),
     (width_mm, height_mm): (u64, u64),
 ) -> f64 {
+    // Override DPI if `WINIT_HIDPI_FACTOR` variable is set
+    if let Ok(dpi_factor_str) = env::var("WINIT_HIDPI_FACTOR") {
+        if let Ok(dpi_factor) = f64::from_str(&dpi_factor_str) {
+            return dpi_factor;
+        }
+    }
+
     // See http://xpra.org/trac/ticket/728 for more information
     if width_mm == 0 || width_mm == 0 {
         return 1.0;

--- a/src/window.rs
+++ b/src/window.rs
@@ -346,7 +346,7 @@ impl Window {
     /// and two for a retina display.
     ///
     /// ## Platform-specific
-    /// On X11 the DPI factor can be overwritten using the `WINIT_HIDPI_FACTOR` environment
+    /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
     /// variable.
     #[inline]
     pub fn hidpi_factor(&self) -> f32 {
@@ -473,7 +473,7 @@ impl MonitorId {
     /// Returns the ratio between the monitor's physical pixels and logical pixels.
     ///
     /// ## Platform-specific
-    /// On X11 the DPI factor can be overwritten using the `WINIT_HIDPI_FACTOR` environment
+    /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
     /// variable.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f32 {

--- a/src/window.rs
+++ b/src/window.rs
@@ -333,6 +333,10 @@ impl Window {
     /// Returns the ratio between the backing framebuffer resolution and the
     /// window size in screen pixels. This is typically one for a normal display
     /// and two for a retina display.
+    ///
+    /// ## Platform-specific
+    /// On X11 the DPI factor can be overwritten using the `WINIT_HIDPI_FACTOR` environment
+    /// variable.
     #[inline]
     pub fn hidpi_factor(&self) -> f32 {
         self.window.hidpi_factor()
@@ -456,6 +460,10 @@ impl MonitorId {
     }
 
     /// Returns the ratio between the monitor's physical pixels and logical pixels.
+    ///
+    /// ## Platform-specific
+    /// On X11 the DPI factor can be overwritten using the `WINIT_HIDPI_FACTOR` environment
+    /// variable.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f32 {
         self.inner.get_hidpi_factor()


### PR DESCRIPTION
There is an issue with xorg reporting 0 width or height which leads to a division by zero with floating point numbers. This will result in a DPI factor of +inf. As a workaround to this when either width or height are 0 the DPI is now set to a fixed value (1.0).

In #543 the option of setting this as an environment variable has been discussed and I'd be happy to add this to the PR if it is desired.

This fixes #543.