### PR TITLE
X11: Fix flickering when resizing with transparency enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
 - `WindowBuilder::with_resizable` implemented for Windows.
+- On X11, enabling transparency no longer causes the window contents to flicker when resizing.
 
 # Version 0.15.0 (2018-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `MouseCursor` and `CursorState` now implement `Default`.
 - `WindowBuilder::with_resizable` implemented for Windows.
 - On X11, enabling transparency no longer causes the window contents to flicker when resizing.
+- On X11, `with_override_redirect` now actually enables override redirect.
 
 # Version 0.15.0 (2018-05-22)
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -102,18 +102,11 @@ impl UnownedWindow {
                 | ffi::ButtonReleaseMask
                 | ffi::PointerMotionMask;
             swa.border_pixel = 0;
-            if window_attrs.transparent {
-                swa.background_pixel = 0;
-            }
             swa.override_redirect = 0;
             swa
         };
 
         let mut window_attributes = ffi::CWBorderPixel | ffi::CWColormap | ffi::CWEventMask;
-
-        if window_attrs.transparent {
-            window_attributes |= ffi::CWBackPixel;
-        }
 
         if pl_attribs.override_redirect {
             window_attributes |= ffi::CWOverrideRedirect;

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -102,7 +102,7 @@ impl UnownedWindow {
                 | ffi::ButtonReleaseMask
                 | ffi::PointerMotionMask;
             swa.border_pixel = 0;
-            swa.override_redirect = 0;
+            swa.override_redirect = pl_attribs.override_redirect as c_int;
             swa
         };
 


### PR DESCRIPTION
Fixes tomaka/glutin#1019

This simply removes the transparency code from winit. Trying to get transparency on X11 without a graphics context never worked to begin with. The relevant code was added way back in tomaka/glutin#484; with it removed, everything works exactly the same as with it present, just without the flickering.

This was apparently also a problem in SDL (https://bugzilla.libsdl.org/show_bug.cgi?id=2101) though I don't bother to explicitly specify the defaults here.

This also fixes `with_override_redirect`, since it was right next to the transparency code, and looking into this made me realize I implemented that incorrectly.