### PR TITLE
DPI for everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
 - On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
-- On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
-- The Windows backend is now DPI aware. `WindowEvent::HiDPIFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values. Window creation along with returned positions and sizes now correctly use pixels rather than points.
+- The Windows backend is now DPI aware. `WindowEvent::HiDpiFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values.
+- `WindowEvent::HiDpiFactorChanged` implemented on X11.
+- On macOS, `Window::set_cursor_position` is now relative to the client area.
+- On macOS, setting the maximum and minimum dimensions now applies to the client area rather than to the window.
 - **Breaking:** All deprecated methods have been removed.
 
 # Version 0.15.1 (2018-06-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - On Emscripten, `MonitorId::get_hidpi_factor` now returns the same value as `Window::get_hidpi_factor` (it previously would always return 1.0).
 - **Breaking:** The entire API for sizes, positions, etc. has changed. In the majority of cases, winit produces and consumes positions and sizes as `LogicalPosition` and `LogicalSize`, respectively. The notable exception is `MonitorId` methods, which deal in `PhysicalPosition` and `PhysicalSize`. See the documentation for specifics and explanations of the types. Additionally, winit automatically conserves logical size when the DPI factor changes.
 - **Breaking:** All deprecated methods have been removed. For `Window::platform_display` and `Window::platform_window`, switch to the appropriate platform-specific `WindowExt` methods. For `Window::get_inner_size_points` and `Window::get_inner_size_pixels`, use the `LogicalSize` returned by `Window::get_inner_size` and convert as needed.
+- HiDPI support for Wayland.
 
 # Version 0.15.1 (2018-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
 - On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
-- **Breaking:** `Window::hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
+- **Breaking:** `Window::get_hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
 - The Windows backend is now DPI aware. `WindowEvent::HiDpiFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values.
-- `WindowEvent::HiDpiFactorChanged` implemented on X11.
+- Implemented `WindowEvent::HiDpiFactorChanged` on X11.
 - On macOS, `Window::set_cursor_position` is now relative to the client area.
-- On macOS, setting the maximum and minimum dimensions now applies to the client area rather than to the window.
+- On macOS, setting the maximum and minimum dimensions now applies to the client area dimensions rather than to the window dimensions.
 - On iOS, `MonitorId::get_dimensions` has been implemented and both `MonitorId::get_hidpi_factor` and `Window::get_hidpi_factor` return accurate values.
 - On Emscripten, `MonitorId::get_hidpi_factor` now returns the same value as `Window::get_hidpi_factor` (it previously would always return 1.0).
 - **Breaking:** The entire API for sizes, positions, etc. has changed. In the majority of cases, winit produces and consumes positions and sizes as `LogicalPosition` and `LogicalSize`, respectively. The notable exception is `MonitorId` methods, which deal in `PhysicalPosition` and `PhysicalSize`. See the documentation for specifics and explanations of the types. Additionally, winit automatically conserves logical size when the DPI factor changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On macOS, `Window::set_cursor_position` is now relative to the client area.
 - On macOS, setting the maximum and minimum dimensions now applies to the client area rather than to the window.
 - On iOS, `MonitorId::get_dimensions` has been implemented and both `MonitorId::get_hidpi_factor` and `Window::get_hidpi_factor` return accurate values.
+- On Emscripten, `MonitorId::get_hidpi_factor` now returns the same value as `Window::get_hidpi_factor` (it previously would always return 1.0).
 - **Breaking:** The entire API for sizes, positions, etc. has changed. In the majority of cases, winit produces and consumes positions and sizes as `LogicalPosition` and `LogicalSize`, respectively. The notable exception is `MonitorId` methods, which deal in `PhysicalPosition` and `PhysicalSize`. See the documentation for specifics and explanations of the types. Additionally, winit automatically conserves logical size when the DPI factor changes.
 - **Breaking:** All deprecated methods have been removed. For `Window::platform_display` and `Window::platform_window`, switch to the appropriate platform-specific `WindowExt` methods. For `Window::get_inner_size_points` and `Window::get_inner_size_pixels`, use the `LogicalSize` returned by `Window::get_inner_size` and convert as needed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 - `WindowEvent::HiDpiFactorChanged` implemented on X11.
 - On macOS, `Window::set_cursor_position` is now relative to the client area.
 - On macOS, setting the maximum and minimum dimensions now applies to the client area rather than to the window.
-- **Breaking:** All deprecated methods have been removed.
+- **Breaking:** The entire API for sizes, positions, etc. has changed. In the majority of cases, winit produces and consumes positions and sizes as `LogicalPosition` and `LogicalSize`, respectively. The notable exception is `MonitorId` methods, which deal in `PhysicalPosition` and `PhysicalSize`. See the documentation for specifics and explanations of the types. Additionally, winit automatically conserves logical size when the DPI factor changes.
+- **Breaking:** `Window::hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
+- **Breaking:** All deprecated methods have been removed. For `Window::platform_display` and `Window::platform_window`, switch to the appropriate platform-specific `WindowExt` methods. For `Window::get_inner_size_points` and `Window::get_inner_size_pixels`, use the `LogicalSize` returned by `Window::get_inner_size` and convert as needed.
 
 # Version 0.15.1 (2018-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
 - On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
+- **Breaking:** `Window::hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
 - The Windows backend is now DPI aware. `WindowEvent::HiDpiFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values.
 - `WindowEvent::HiDpiFactorChanged` implemented on X11.
 - On macOS, `Window::set_cursor_position` is now relative to the client area.
 - On macOS, setting the maximum and minimum dimensions now applies to the client area rather than to the window.
+- On iOS, `MonitorId::get_dimensions` has been implemented and both `MonitorId::get_hidpi_factor` and `Window::get_hidpi_factor` return accurate values.
 - **Breaking:** The entire API for sizes, positions, etc. has changed. In the majority of cases, winit produces and consumes positions and sizes as `LogicalPosition` and `LogicalSize`, respectively. The notable exception is `MonitorId` methods, which deal in `PhysicalPosition` and `PhysicalSize`. See the documentation for specifics and explanations of the types. Additionally, winit automatically conserves logical size when the DPI factor changes.
-- **Breaking:** `Window::hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
 - **Breaking:** All deprecated methods have been removed. For `Window::platform_display` and `Window::platform_window`, switch to the appropriate platform-specific `WindowExt` methods. For `Window::get_inner_size_points` and `Window::get_inner_size_pixels`, use the `LogicalSize` returned by `Window::get_inner_size` and convert as needed.
 
 # Version 0.15.1 (2018-06-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
 - On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
-- **Breaking:** `Window::get_hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to ``WindowEvent::HiDpiFactorChanged``. DPI factors are always represented as `f64` instead of `f32` now.
+- **Breaking:** `Window::hidpi_factor` has been renamed to `Window::get_hidpi_factor` for better consistency. `WindowEvent::HiDPIFactorChanged` has been renamed to `WindowEvent::HiDpiFactorChanged`. DPI factors are always represented as `f64` instead of `f32` now.
 - The Windows backend is now DPI aware. `WindowEvent::HiDpiFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values.
 - Implemented `WindowEvent::HiDpiFactorChanged` on X11.
 - On macOS, `Window::set_cursor_position` is now relative to the client area.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
+- On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
 
 # Version 0.15.1 (2018-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - **Breaking:** Removed `VirtualKeyCode::LMenu` and `VirtualKeyCode::RMenu`; Windows now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead.
 - On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
+- On X11, exiting fullscreen no longer leaves the window in the monitor's top left corner.
+- The Windows backend is now DPI aware. `WindowEvent::HiDPIFactorChanged` is implemented, and `MonitorId::get_hidpi_factor` and `Window::hidpi_factor` return accurate values. Window creation along with returned positions and sizes now correctly use pixels rather than points.
+- **Breaking:** All deprecated methods have been removed.
 
 # Version 0.15.1 (2018-06-13)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ features = [
     "objbase",
     "processthreadsapi",
     "shellapi",
+    "shellscalingapi",
     "shobjidl_core",
     "unknwnbase",
     "windowsx",

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+use winit::LogicalSize;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
@@ -7,8 +9,8 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
-    window.set_min_dimensions(Some((400, 200)));
-    window.set_max_dimensions(Some((800, 400)));
+    window.set_min_dimensions(Some(LogicalSize::new(400.0, 200.0)));
+    window.set_max_dimensions(Some(LogicalSize::new(800.0, 400.0)));
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -1,6 +1,6 @@
 extern crate winit;
 
-use winit::LogicalSize;
+use winit::dpi::LogicalSize;
 
 fn main() {
     let mut events_loop = winit::EventsLoop::new();

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -7,7 +7,7 @@ fn main() {
 
     let window = winit::WindowBuilder::new()
         .with_title("Hit space to toggle resizability.")
-        .with_dimensions(400, 200)
+        .with_dimensions((400, 200).into())
         .with_resizable(resizable)
         .build(&events_loop)
         .unwrap();

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -1,52 +1,52 @@
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct LogicalCoordinates {
+pub struct LogicalPosition {
     pub x: f64,
     pub y: f64,
 }
 
-impl LogicalCoordinates {
+impl LogicalPosition {
     #[inline]
     pub fn new(x: f64, y: f64) -> Self {
-        LogicalCoordinates { x, y }
+        LogicalPosition { x, y }
     }
 
     #[inline]
-    pub fn from_physical<T: Into<PhysicalCoordinates>>(physical: T, dpi_factor: f64) -> Self {
+    pub fn from_physical<T: Into<PhysicalPosition>>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalCoordinates {
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalPosition {
         assert!(dpi_factor > 0.0);
         let x = self.x * dpi_factor;
         let y = self.y * dpi_factor;
-        PhysicalCoordinates::new(x, y)
+        PhysicalPosition::new(x, y)
     }
 }
 
-impl From<(f64, f64)> for LogicalCoordinates {
+impl From<(f64, f64)> for LogicalPosition {
     #[inline]
     fn from((x, y): (f64, f64)) -> Self {
         Self::new(x, y)
     }
 }
 
-impl From<(i32, i32)> for LogicalCoordinates {
+impl From<(i32, i32)> for LogicalPosition {
     #[inline]
     fn from((x, y): (i32, i32)) -> Self {
         Self::new(x as f64, y as f64)
     }
 }
 
-impl Into<(f64, f64)> for LogicalCoordinates {
+impl Into<(f64, f64)> for LogicalPosition {
     #[inline]
     fn into(self) -> (f64, f64) {
         (self.x, self.y)
     }
 }
 
-impl Into<(i32, i32)> for LogicalCoordinates {
+impl Into<(i32, i32)> for LogicalPosition {
     #[inline]
     fn into(self) -> (i32, i32) {
         (self.x.round() as _, self.y.round() as _)
@@ -54,53 +54,53 @@ impl Into<(i32, i32)> for LogicalCoordinates {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct PhysicalCoordinates {
+pub struct PhysicalPosition {
     pub x: f64,
     pub y: f64,
 }
 
-impl PhysicalCoordinates {
+impl PhysicalPosition {
     #[inline]
     pub fn new(x: f64, y: f64) -> Self {
-        PhysicalCoordinates { x, y }
+        PhysicalPosition { x, y }
     }
 
     #[inline]
-    pub fn from_logical<T: Into<LogicalCoordinates>>(logical: T, dpi_factor: f64) -> Self {
+    pub fn from_logical<T: Into<LogicalPosition>>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalCoordinates {
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalPosition {
         assert!(dpi_factor > 0.0);
         let x = self.x / dpi_factor;
         let y = self.y / dpi_factor;
-        LogicalCoordinates::new(x, y)
+        LogicalPosition::new(x, y)
     }
 }
 
-impl From<(f64, f64)> for PhysicalCoordinates {
+impl From<(f64, f64)> for PhysicalPosition {
     #[inline]
     fn from((x, y): (f64, f64)) -> Self {
         Self::new(x, y)
     }
 }
 
-impl From<(i32, i32)> for PhysicalCoordinates {
+impl From<(i32, i32)> for PhysicalPosition {
     #[inline]
     fn from((x, y): (i32, i32)) -> Self {
         Self::new(x as f64, y as f64)
     }
 }
 
-impl Into<(f64, f64)> for PhysicalCoordinates {
+impl Into<(f64, f64)> for PhysicalPosition {
     #[inline]
     fn into(self) -> (f64, f64) {
         (self.x, self.y)
     }
 }
 
-impl Into<(i32, i32)> for PhysicalCoordinates {
+impl Into<(i32, i32)> for PhysicalPosition {
     #[inline]
     fn into(self) -> (i32, i32) {
         (self.x.round() as _, self.y.round() as _)
@@ -108,53 +108,53 @@ impl Into<(i32, i32)> for PhysicalCoordinates {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct LogicalDimensions {
+pub struct LogicalSize {
     pub width: f64,
     pub height: f64,
 }
 
-impl LogicalDimensions {
+impl LogicalSize {
     #[inline]
     pub fn new(width: f64, height: f64) -> Self {
-        LogicalDimensions { width, height }
+        LogicalSize { width, height }
     }
 
     #[inline]
-    pub fn from_physical<T: Into<PhysicalDimensions>>(physical: T, dpi_factor: f64) -> Self {
+    pub fn from_physical<T: Into<PhysicalSize>>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalDimensions {
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalSize {
         assert!(dpi_factor > 0.0);
         let width = self.width * dpi_factor;
         let height = self.height * dpi_factor;
-        PhysicalDimensions::new(width, height)
+        PhysicalSize::new(width, height)
     }
 }
 
-impl From<(f64, f64)> for LogicalDimensions {
+impl From<(f64, f64)> for LogicalSize {
     #[inline]
     fn from((width, height): (f64, f64)) -> Self {
         Self::new(width, height)
     }
 }
 
-impl From<(u32, u32)> for LogicalDimensions {
+impl From<(u32, u32)> for LogicalSize {
     #[inline]
     fn from((width, height): (u32, u32)) -> Self {
         Self::new(width as f64, height as f64)
     }
 }
 
-impl Into<(f64, f64)> for LogicalDimensions {
+impl Into<(f64, f64)> for LogicalSize {
     #[inline]
     fn into(self) -> (f64, f64) {
         (self.width, self.height)
     }
 }
 
-impl Into<(u32, u32)> for LogicalDimensions {
+impl Into<(u32, u32)> for LogicalSize {
     #[inline]
     fn into(self) -> (u32, u32) {
         (self.width.round() as _, self.height.round() as _)
@@ -162,53 +162,53 @@ impl Into<(u32, u32)> for LogicalDimensions {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct PhysicalDimensions {
+pub struct PhysicalSize {
     pub width: f64,
     pub height: f64,
 }
 
-impl PhysicalDimensions {
+impl PhysicalSize {
     #[inline]
     pub fn new(width: f64, height: f64) -> Self {
-        PhysicalDimensions { width, height }
+        PhysicalSize { width, height }
     }
 
     #[inline]
-    pub fn from_logical<T: Into<LogicalDimensions>>(logical: T, dpi_factor: f64) -> Self {
+    pub fn from_logical<T: Into<LogicalSize>>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalDimensions {
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
         assert!(dpi_factor > 0.0);
         let width = self.width / dpi_factor;
         let height = self.height / dpi_factor;
-        LogicalDimensions::new(width, height)
+        LogicalSize::new(width, height)
     }
 }
 
-impl From<(f64, f64)> for PhysicalDimensions {
+impl From<(f64, f64)> for PhysicalSize {
     #[inline]
     fn from((width, height): (f64, f64)) -> Self {
         Self::new(width, height)
     }
 }
 
-impl From<(u32, u32)> for PhysicalDimensions {
+impl From<(u32, u32)> for PhysicalSize {
     #[inline]
     fn from((width, height): (u32, u32)) -> Self {
         Self::new(width as f64, height as f64)
     }
 }
 
-impl Into<(f64, f64)> for PhysicalDimensions {
+impl Into<(f64, f64)> for PhysicalSize {
     #[inline]
     fn into(self) -> (f64, f64) {
         (self.width, self.height)
     }
 }
 
-impl Into<(u32, u32)> for PhysicalDimensions {
+impl Into<(u32, u32)> for PhysicalSize {
     #[inline]
     fn into(self) -> (u32, u32) {
         (self.width.round() as _, self.height.round() as _)

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -1,0 +1,146 @@
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct LogicalCoordinates {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl LogicalCoordinates {
+    #[inline]
+    pub fn new(x: f64, y: f64) -> Self {
+        LogicalCoordinates { x, y }
+    }
+
+    #[inline]
+    pub fn from_physical<T: Into<PhysicalCoordinates>>(physical: T, dpi_factor: f64) -> Self {
+        physical.into().to_logical(dpi_factor)
+    }
+
+    #[inline]
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalCoordinates {
+        assert!(dpi_factor > 0.0);
+        let x = self.x * dpi_factor;
+        let y = self.y * dpi_factor;
+        PhysicalCoordinates::new(x, y)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PhysicalCoordinates {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl PhysicalCoordinates {
+    #[inline]
+    pub fn new(x: f64, y: f64) -> Self {
+        PhysicalCoordinates { x, y }
+    }
+
+    #[inline]
+    pub fn from_logical(logical: LogicalCoordinates, dpi_factor: f64) -> Self {
+        logical.to_physical(dpi_factor)
+    }
+
+    #[inline]
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalCoordinates {
+        assert!(dpi_factor > 0.0);
+        let x = self.x / dpi_factor;
+        let y = self.y / dpi_factor;
+        LogicalCoordinates::new(x, y)
+    }
+}
+
+impl From<(f64, f64)> for PhysicalCoordinates {
+    #[inline]
+    fn from((x, y): (f64, f64)) -> Self {
+        Self::new(x, y)
+    }
+}
+
+impl From<(i32, i32)> for PhysicalCoordinates {
+    #[inline]
+    fn from((x, y): (i32, i32)) -> Self {
+        Self::new(x as f64, y as f64)
+    }
+}
+
+impl Into<(i32, i32)> for PhysicalCoordinates {
+    #[inline]
+    fn into(self) -> (i32, i32) {
+        (self.x.round() as _, self.y.round() as _)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct LogicalDimensions {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl LogicalDimensions {
+    #[inline]
+    pub fn new(width: f64, height: f64) -> Self {
+        LogicalDimensions { width, height }
+    }
+
+    #[inline]
+    pub fn from_physical<T: Into<PhysicalDimensions>>(physical: T, dpi_factor: f64) -> Self {
+        physical.into().to_logical(dpi_factor)
+    }
+
+    #[inline]
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalDimensions {
+        assert!(dpi_factor > 0.0);
+        let width = self.width * dpi_factor;
+        let height = self.height * dpi_factor;
+        PhysicalDimensions::new(width, height)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PhysicalDimensions {
+    pub width: f64,
+    pub height: f64,
+}
+
+impl PhysicalDimensions {
+    #[inline]
+    pub fn new(width: f64, height: f64) -> Self {
+        PhysicalDimensions { width, height }
+    }
+
+    #[inline]
+    pub fn from_logical(logical: LogicalDimensions, dpi_factor: f64) -> Self {
+        logical.to_physical(dpi_factor)
+    }
+
+    #[inline]
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalDimensions {
+        assert!(dpi_factor > 0.0);
+        let width = self.width / dpi_factor;
+        let height = self.height / dpi_factor;
+        LogicalDimensions::new(width, height)
+    }
+}
+
+impl From<(f64, f64)> for PhysicalDimensions {
+    #[inline]
+    fn from((width, height): (f64, f64)) -> Self {
+        Self::new(width, height)
+    }
+}
+
+impl From<(u32, u32)> for PhysicalDimensions {
+    #[inline]
+    fn from((width, height): (u32, u32)) -> Self {
+        Self::new(width as f64, height as f64)
+    }
+}
+
+impl Into<(u32, u32)> for PhysicalDimensions {
+    #[inline]
+    fn into(self) -> (u32, u32) {
+        (self.width.round() as _, self.height.round() as _)
+    }
+}

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -25,6 +25,34 @@ impl LogicalCoordinates {
     }
 }
 
+impl From<(f64, f64)> for LogicalCoordinates {
+    #[inline]
+    fn from((x, y): (f64, f64)) -> Self {
+        Self::new(x, y)
+    }
+}
+
+impl From<(i32, i32)> for LogicalCoordinates {
+    #[inline]
+    fn from((x, y): (i32, i32)) -> Self {
+        Self::new(x as f64, y as f64)
+    }
+}
+
+impl Into<(f64, f64)> for LogicalCoordinates {
+    #[inline]
+    fn into(self) -> (f64, f64) {
+        (self.x, self.y)
+    }
+}
+
+impl Into<(i32, i32)> for LogicalCoordinates {
+    #[inline]
+    fn into(self) -> (i32, i32) {
+        (self.x.round() as _, self.y.round() as _)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PhysicalCoordinates {
     pub x: f64,
@@ -38,8 +66,8 @@ impl PhysicalCoordinates {
     }
 
     #[inline]
-    pub fn from_logical(logical: LogicalCoordinates, dpi_factor: f64) -> Self {
-        logical.to_physical(dpi_factor)
+    pub fn from_logical<T: Into<LogicalCoordinates>>(logical: T, dpi_factor: f64) -> Self {
+        logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
@@ -62,6 +90,13 @@ impl From<(i32, i32)> for PhysicalCoordinates {
     #[inline]
     fn from((x, y): (i32, i32)) -> Self {
         Self::new(x as f64, y as f64)
+    }
+}
+
+impl Into<(f64, f64)> for PhysicalCoordinates {
+    #[inline]
+    fn into(self) -> (f64, f64) {
+        (self.x, self.y)
     }
 }
 
@@ -98,6 +133,34 @@ impl LogicalDimensions {
     }
 }
 
+impl From<(f64, f64)> for LogicalDimensions {
+    #[inline]
+    fn from((width, height): (f64, f64)) -> Self {
+        Self::new(width, height)
+    }
+}
+
+impl From<(u32, u32)> for LogicalDimensions {
+    #[inline]
+    fn from((width, height): (u32, u32)) -> Self {
+        Self::new(width as f64, height as f64)
+    }
+}
+
+impl Into<(f64, f64)> for LogicalDimensions {
+    #[inline]
+    fn into(self) -> (f64, f64) {
+        (self.width, self.height)
+    }
+}
+
+impl Into<(u32, u32)> for LogicalDimensions {
+    #[inline]
+    fn into(self) -> (u32, u32) {
+        (self.width.round() as _, self.height.round() as _)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PhysicalDimensions {
     pub width: f64,
@@ -111,8 +174,8 @@ impl PhysicalDimensions {
     }
 
     #[inline]
-    pub fn from_logical(logical: LogicalDimensions, dpi_factor: f64) -> Self {
-        logical.to_physical(dpi_factor)
+    pub fn from_logical<T: Into<LogicalDimensions>>(logical: T, dpi_factor: f64) -> Self {
+        logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
@@ -135,6 +198,13 @@ impl From<(u32, u32)> for PhysicalDimensions {
     #[inline]
     fn from((width, height): (u32, u32)) -> Self {
         Self::new(width as f64, height as f64)
+    }
+}
+
+impl Into<(f64, f64)> for PhysicalDimensions {
+    #[inline]
+    fn into(self) -> (f64, f64) {
+        (self.width, self.height)
     }
 }
 

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -1,7 +1,62 @@
 
-//! DPI is important.
+//! DPI is important, so read the docs for this module if you don't want to be confused.
+//!
+//! Originally, `winit` dealt entirely in physical pixels (excluding unintentional inconsistencies), but now all
+//! window-related functions both produce and consume logical pixels. Monitor-related functions still use physical
+//! pixels, as do any context-related functions in `glutin`.
+//!
+//! If you've never heard of these terms before, then you're not alone, and this documentation will explain the
+//! concepts.
+//!
+//! Modern screens have a defined physical resolution, most commonly 1920x1080. Indepedent of that is the amount of
+//! space the screen occupies, which is to say, the height and width in millimeters. The relationship between these two
+//! measurements is the *pixel density*. Mobile screens require a high pixel density, as they're held close to the
+//! eyes. Larger displays also require a higher pixel density, hence the growing presence of 1440p and 4K displays.
+//!
+//! So, this presents a problem. Let's say we want to render a square 100px button. It will occupy 100x100 of the
+//! screen's pixels, which in many cases, seems perfectly fine. However, because this size doesn't account for the
+//! screen's dimensions or pixel density, the button's size can vary quite a bit. On a 4K display, it would be unusably
+//! small.
+//!
+//! That's a description of what happens when the button is 100x100 *physical* pixels. Instead, let's try using 100x100
+//! *logical* pixels. To map logical pixels to physical pixels, we simply multiply by the DPI factor. On a "typical"
+//! desktop display, the DPI factor will be 1.0, so 100x100 logical pixels equates to 100x100 physical pixels. However,
+//! a 1440p display may have a DPI factor of 1.25, so the button is rendered as 125x125 physical pixels. Ideally, the
+//! button now has approximately the same perceived size across varying displays.
+//!
+//! Failure to account for the DPI factor can create a badly degraded user experience. Most notably, it can make users
+//! feel like they have bad eyesight, which will potentially cause them to think about growing elderly, resulting in
+//! them entering an existential panic. Once users enter that state, they will no longer be focused on your application.
+//!
+//! There are two ways to get the DPI factor: either by calling
+//! [`MonitorId::get_hidpi_factor`](../struct.MonitorId.html#method.get_hidpi_factor), or
+//! [`Window::get_hidpi_factor`](../struct.Window.html#method.get_hidpi_factor). You'll almost always use the latter,
+//! which is basically equivalent to `window.get_current_monitor().get_hidpi_factor()` anyway.
+//!
+//! Here's an overview of what sort of DPI factors you can expect, and where they come from:
+//! - **Windows:** On Windows 8 and 10, per-monitor scaling is readily configured by users from the display settings.
+//! While users are free to select any option they want, they're only given a selection of "nice" DPI factors, i.e.
+//! 1.0, 1.25, 1.5... on Windows 7, the DPI factor is global and changing it requires logging out.
+//! - **macOS:** The buzzword is "retina displays", which have a DPI factor of 2.0. Otherwise, the DPI factor is 1.0.
+//! Intermediate DPI factors are never used, thus 1440p displays/etc. aren't properly supported. It's possible for any
+//! display to use that 2.0 DPI factor, given the use of the command line.
+//! - **X11:** On X11, we calcuate the DPI factor based on the millimeter dimensions provided by XRandR. This can
+//! result in a wide range of possible values, including some interesting ones like 1.0833333333333333. This can be
+//! overridden using the `WINIT_HIDPI_FACTOR` environment variable, though that's not recommended.
+//! - **Wayland:** On Wayland, DPI factors are very much at the discretion of the user.
+//! - **iOS:** DPI factors are both constant and device-specific on iOS.
+//! - **Android:** This feature isn't yet implemented on Android, so the DPI factor will always be returned as 1.0.
+//!
+//! The window's logical size is conserved across DPI changes, resulting in the physical size changing instead. This
+//! may be surprising on X11, but is quite standard elsewhere. Physical size changes produce a
+//! [`Resized`](../enum.WindowEvent.html#variant.Resized) event, even on platforms where no resize actually occurs,
+//! such as macOS and Wayland. As a result, it's not necessary to separately handle
+//! [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged) if you're only listening for size.
+//!
+//! Your GPU has no awareness of the concept of logical pixels, and unless you like wasting pixel density, your
+//! framebuffer's size should be in physical pixels.
 
-/// Checks that the DPI factor is a normal positive `f64`
+/// Checks that the DPI factor is a normal positive `f64`.
 ///
 /// All functions that take a DPI factor assert that this will return `true`. If you're sourcing DPI factors from
 /// anywhere other than winit, it's recommended to validate them using this function before passing them to winit;
@@ -11,6 +66,11 @@ pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
     dpi_factor.is_sign_positive() && dpi_factor.is_normal()
 }
 
+/// A position represented in logical pixels.
+///
+/// The position is stored as floats, so please be careful. Casting floats to integers truncates the fractional part,
+/// which can cause noticable issues. To help with that, an `Into<(i32, i32)>` implementation is provided which
+/// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct LogicalPosition {
     pub x: f64,
@@ -59,12 +119,18 @@ impl Into<(f64, f64)> for LogicalPosition {
 }
 
 impl Into<(i32, i32)> for LogicalPosition {
+    /// Note that this rounds instead of truncating.
     #[inline]
     fn into(self) -> (i32, i32) {
         (self.x.round() as _, self.y.round() as _)
     }
 }
 
+/// A position represented in physical pixels.
+///
+/// The position is stored as floats, so please be careful. Casting floats to integers truncates the fractional part,
+/// which can cause noticable issues. To help with that, an `Into<(i32, i32)>` implementation is provided which
+/// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PhysicalPosition {
     pub x: f64,
@@ -113,12 +179,18 @@ impl Into<(f64, f64)> for PhysicalPosition {
 }
 
 impl Into<(i32, i32)> for PhysicalPosition {
+    /// Note that this rounds instead of truncating.
     #[inline]
     fn into(self) -> (i32, i32) {
         (self.x.round() as _, self.y.round() as _)
     }
 }
 
+/// A size represented in logical pixels.
+///
+/// The size is stored as floats, so please be careful. Casting floats to integers truncates the fractional part,
+/// which can cause noticable issues. To help with that, an `Into<(u32, u32)>` implementation is provided which
+/// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct LogicalSize {
     pub width: f64,
@@ -167,12 +239,18 @@ impl Into<(f64, f64)> for LogicalSize {
 }
 
 impl Into<(u32, u32)> for LogicalSize {
+    /// Note that this rounds instead of truncating.
     #[inline]
     fn into(self) -> (u32, u32) {
         (self.width.round() as _, self.height.round() as _)
     }
 }
 
+/// A size represented in physical pixels.
+///
+/// The size is stored as floats, so please be careful. Casting floats to integers truncates the fractional part,
+/// which can cause noticable issues. To help with that, an `Into<(u32, u32)>` implementation is provided which
+/// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PhysicalSize {
     pub width: f64,
@@ -221,6 +299,7 @@ impl Into<(f64, f64)> for PhysicalSize {
 }
 
 impl Into<(u32, u32)> for PhysicalSize {
+    /// Note that this rounds instead of truncating.
     #[inline]
     fn into(self) -> (u32, u32) {
         (self.width.round() as _, self.height.round() as _)

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -1,4 +1,16 @@
 
+//! DPI is important.
+
+/// Checks that the DPI factor is a normal positive `f64`
+///
+/// All functions that take a DPI factor assert that this will return `true`. If you're sourcing DPI factors from
+/// anywhere other than winit, it's recommended to validate them using this function before passing them to winit;
+/// otherwise, you risk panics.
+#[inline]
+pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
+    dpi_factor.is_sign_positive() && dpi_factor.is_normal()
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct LogicalPosition {
     pub x: f64,
@@ -18,7 +30,7 @@ impl LogicalPosition {
 
     #[inline]
     pub fn to_physical(&self, dpi_factor: f64) -> PhysicalPosition {
-        assert!(dpi_factor > 0.0);
+        assert!(validate_hidpi_factor(dpi_factor));
         let x = self.x * dpi_factor;
         let y = self.y * dpi_factor;
         PhysicalPosition::new(x, y)
@@ -72,7 +84,7 @@ impl PhysicalPosition {
 
     #[inline]
     pub fn to_logical(&self, dpi_factor: f64) -> LogicalPosition {
-        assert!(dpi_factor > 0.0);
+        assert!(validate_hidpi_factor(dpi_factor));
         let x = self.x / dpi_factor;
         let y = self.y / dpi_factor;
         LogicalPosition::new(x, y)
@@ -126,7 +138,7 @@ impl LogicalSize {
 
     #[inline]
     pub fn to_physical(&self, dpi_factor: f64) -> PhysicalSize {
-        assert!(dpi_factor > 0.0);
+        assert!(validate_hidpi_factor(dpi_factor));
         let width = self.width * dpi_factor;
         let height = self.height * dpi_factor;
         PhysicalSize::new(width, height)
@@ -180,7 +192,7 @@ impl PhysicalSize {
 
     #[inline]
     pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
-        assert!(dpi_factor > 0.0);
+        assert!(validate_hidpi_factor(dpi_factor));
         let width = self.width / dpi_factor;
         let height = self.height / dpi_factor;
         LogicalSize::new(width, height)

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use {DeviceId, LogicalCoordinates, LogicalDimensions, WindowId};
+use {DeviceId, LogicalPosition, LogicalSize, WindowId};
 
 /// Describes a generic event.
 #[derive(Clone, Debug)]
@@ -25,10 +25,10 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub enum WindowEvent {
     /// The size of the window has changed. Contains the client area's new dimensions.
-    Resized(LogicalDimensions),
+    Resized(LogicalSize),
 
     /// The position of the window has changed. Contains the window's new position.
-    Moved(LogicalCoordinates),
+    Moved(LogicalPosition),
 
     /// The window has been requested to close.
     CloseRequested,

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
-use {WindowId, DeviceId};
+
+use {DeviceId, LogicalCoordinates, LogicalDimensions, WindowId};
 
 /// Describes a generic event.
 #[derive(Clone, Debug)]
@@ -23,12 +24,11 @@ pub enum Event {
 /// Describes an event from a `Window`.
 #[derive(Clone, Debug)]
 pub enum WindowEvent {
-
     /// The size of the window has changed. Contains the client area's new dimensions.
-    Resized(u32, u32),
+    Resized(LogicalDimensions),
 
     /// The position of the window has changed. Contains the window's new position.
-    Moved(i32, i32),
+    Moved(LogicalCoordinates),
 
     /// The window has been requested to close.
     CloseRequested,
@@ -103,7 +103,7 @@ pub enum WindowEvent {
     /// * A user changes the resolution.
     /// * A user changes the desktop scaling value (e.g. in Control Panel on Windows).
     /// * A user moves the application window to a display with a different DPI.
-    HiDPIFactorChanged(f32),
+    HiDpiFactorChanged(f64),
 }
 
 /// Represents raw hardware events that are not associated with any particular window.

--- a/src/events.rs
+++ b/src/events.rs
@@ -63,7 +63,7 @@ pub enum WindowEvent {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-        position: (f64, f64),
+        position: LogicalPosition,
         modifiers: ModifiersState
     },
 
@@ -242,7 +242,7 @@ pub enum MouseScrollDelta {
 	/// Scroll events are expressed as a PixelDelta if
 	/// supported by the device (eg. a touchpad) and
 	/// platform.
-	PixelDelta(f32, f32)
+	PixelDelta(LogicalPosition),
 }
 
 /// Symbolic name for a keyboard key.

--- a/src/events.rs
+++ b/src/events.rs
@@ -197,7 +197,7 @@ pub enum TouchPhase {
 pub struct Touch {
     pub device_id: DeviceId,
     pub phase: TouchPhase,
-    pub location: (f64,f64),
+    pub location: LogicalPosition,
     /// unique identifier of a finger.
     pub id: u64
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -96,13 +96,15 @@ pub enum WindowEvent {
     /// Touch event has been received
     Touch(Touch),
 
-    /// DPI scaling factor of the window has changed.
+    /// The DPI factor of the window has changed.
     ///
-    /// The following actions cause DPI changes:
+    /// The following user actions can cause DPI changes:
     ///
-    /// * A user changes the resolution.
-    /// * A user changes the desktop scaling value (e.g. in Control Panel on Windows).
-    /// * A user moves the application window to a display with a different DPI.
+    /// * Changing the display's resolution.
+    /// * Changing the display's DPI factor (e.g. in Control Panel on Windows).
+    /// * Moving the window to a display with a different DPI factor.
+    ///
+    /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
     HiDpiFactorChanged(f64),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,15 @@
 //! screen, such as video games.
 //!
 //! ```no_run
-//! use winit::{Event, WindowEvent};
+//! use winit::{Event, LogicalSize, WindowEvent};
 //! # use winit::EventsLoop;
 //! # let mut events_loop = EventsLoop::new();
 //!
 //! loop {
 //!     events_loop.poll_events(|event| {
 //!         match event {
-//!             Event::WindowEvent { event: WindowEvent::Resized(w, h), .. } => {
-//!                 println!("The window was resized to {}x{}", w, h);
+//!             Event::WindowEvent { event: WindowEvent::Resized(LogicalSize { width, height }), .. } => {
+//!                 println!("The window was resized to {}x{}", width, height);
 //!             },
 //!             _ => ()
 //!         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 //! to create an OpenGL/Vulkan/DirectX/Metal/etc. context that will draw on the window.
 //!
 
+#[allow(unused_imports)]
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,10 @@
 //! loop {
 //!     events_loop.poll_events(|event| {
 //!         match event {
-//!             Event::WindowEvent { event: WindowEvent::Resized(LogicalSize { width, height }), .. } => {
+//!             Event::WindowEvent {
+//!                 event: WindowEvent::Resized(LogicalSize { width, height }),
+//!                 ..
+//!             } => {
 //!                 println!("The window was resized to {}x{}", width, height);
 //!             },
 //!             _ => ()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,17 +411,17 @@ pub struct WindowAttributes {
     /// used.
     ///
     /// The default is `None`.
-    pub dimensions: Option<(u32, u32)>,
+    pub dimensions: Option<LogicalSize>,
 
     /// The minimum dimensions a window can be, If this is `None`, the window will have no minimum dimensions (aside from reserved).
     ///
     /// The default is `None`.
-    pub min_dimensions: Option<(u32, u32)>,
+    pub min_dimensions: Option<LogicalSize>,
 
     /// The maximum dimensions a window can be, If this is `None`, the maximum will have no maximum or will be set to the primary monitor's dimensions by the platform.
     ///
     /// The default is `None`.
-    pub max_dimensions: Option<(u32, u32)>,
+    pub max_dimensions: Option<LogicalSize>,
 
     /// Whether the window is resizable or not.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@
 //! screen, such as video games.
 //!
 //! ```no_run
-//! use winit::{Event, LogicalSize, WindowEvent};
+//! use winit::{Event, WindowEvent};
+//! use winit::dpi::LogicalSize;
 //! # use winit::EventsLoop;
 //! # let mut events_loop = EventsLoop::new();
 //!
@@ -110,12 +111,12 @@ extern crate percent_encoding;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
 extern crate smithay_client_toolkit as sctk;
 
-pub use dpi::*;
+pub(crate) use dpi::*; // TODO: Actually change the imports throughout the codebase.
 pub use events::*;
 pub use window::{AvailableMonitorsIter, MonitorId};
 pub use icon::*;
 
-mod dpi;
+pub mod dpi;
 mod events;
 mod icon;
 mod platform;
@@ -233,6 +234,11 @@ impl EventsLoop {
     /// Calls `callback` every time an event is received. If no event is available, sleeps the
     /// current thread and waits for an event. If the callback returns `ControlFlow::Break` then
     /// `run_forever` will immediately return.
+    ///
+    /// # Danger!
+    ///
+    /// The callback is run after *every* event, so if its execution time is non-trivial the event queue may not empty
+    /// at a sufficient rate. Rendering in the callback with vsync enabled **will** cause significant lag.
     #[inline]
     pub fn run_forever<F>(&mut self, callback: F)
         where F: FnMut(Event) -> ControlFlow

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,14 +106,16 @@ extern crate percent_encoding;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
 extern crate smithay_client_toolkit as sctk;
 
+pub use dpi::*;
 pub use events::*;
 pub use window::{AvailableMonitorsIter, MonitorId};
 pub use icon::*;
 
-mod platform;
+mod dpi;
 mod events;
-mod window;
 mod icon;
+mod platform;
+mod window;
 
 pub mod os;
 
@@ -403,7 +405,7 @@ impl Default for CursorState {
 }
 
 /// Attributes to use when creating a window.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct WindowAttributes {
     /// The dimensions of the window. If this is `None`, some platform-specific dimensions will be
     /// used.

--- a/src/os/ios.rs
+++ b/src/os/ios.rs
@@ -1,0 +1,43 @@
+#![cfg(target_os = "ios")]
+
+use std::os::raw::c_void;
+
+use {MonitorId, Window};
+
+/// Additional methods on `Window` that are specific to iOS.
+pub trait WindowExt {
+    /// Returns a pointer to the `UIWindow` that is used by this window.
+    ///
+    /// The pointer will become invalid when the `Window` is destroyed.
+    fn get_uiwindow(&self) -> *mut c_void;
+
+    /// Returns a pointer to the `UIView` that is used by this window.
+    ///
+    /// The pointer will become invalid when the `Window` is destroyed.
+    fn get_uiview(&self) -> *mut c_void;
+}
+
+impl WindowExt for Window {
+    #[inline]
+    fn get_uiwindow(&self) -> *mut c_void {
+        self.window.get_uiwindow() as _
+    }
+
+    #[inline]
+    fn get_uiview(&self) -> *mut c_void {
+        self.window.get_uiview() as _
+    }
+}
+
+/// Additional methods on `MonitorId` that are specific to iOS.
+pub trait MonitorIdExt {
+    /// Returns a pointer to the `UIScreen` that is used by this monitor.
+    fn get_uiscreen(&self) -> *mut c_void;
+}
+
+impl MonitorIdExt for MonitorId {
+    #[inline]
+    fn get_uiscreen(&self) -> *mut c_void {
+        self.inner.get_uiscreen() as _
+    }
+}

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -3,7 +3,7 @@
 use std::convert::From;
 use std::os::raw::c_void;
 use cocoa::appkit::NSApplicationActivationPolicy;
-use {MonitorId, Window, WindowBuilder};
+use {LogicalSize, MonitorId, Window, WindowBuilder};
 
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExt {
@@ -86,7 +86,7 @@ pub trait WindowBuilderExt {
     /// Makes the window content appear behind the titlebar.
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
     /// Build window with `resizeIncrements` property. Values must not be 0.
-    fn with_resize_increments(self, width_inc: u32, height_inc: u32) -> WindowBuilder;
+    fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -133,8 +133,8 @@ impl WindowBuilderExt for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, width_inc: u32, height_inc: u32) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some((width_inc, height_inc));
+    fn with_resize_increments(mut self, increments: LogicalSize) -> WindowBuilder {
+        self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 }

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -3,6 +3,7 @@
 //! Contains the follow modules:
 //!
 //!  - `android`
+//!  - `ios`
 //!  - `macos`
 //!  - `unix`
 //!  - `windows`
@@ -10,6 +11,7 @@
 //! However only the module corresponding to the platform you're compiling to will be available.
 //!
 pub mod android;
+pub mod ios;
 pub mod macos;
 pub mod unix;
 pub mod windows;

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,14 +1,19 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 use std::os::raw;
-use std::sync::Arc;
 use std::ptr;
-use EventsLoop;
-use MonitorId;
-use Window;
-use platform::EventsLoop as LinuxEventsLoop;
-use platform::Window as LinuxWindow;
-use WindowBuilder;
+use std::sync::Arc;
+
+use {
+    EventsLoop,
+    MonitorId,
+    Window,
+    WindowBuilder,
+};
+use platform::{
+    EventsLoop as LinuxEventsLoop,
+    Window as LinuxWindow,
+};
 use platform::x11::XConnection;
 use platform::x11::ffi::XVisualInfo;
 
@@ -214,9 +219,9 @@ pub trait WindowBuilderExt {
     /// Build window with `_NET_WM_WINDOW_TYPE` hint; defaults to `Normal`. Only relevant on X11.
     fn with_x11_window_type(self, x11_window_type: XWindowType) -> WindowBuilder;
     /// Build window with resize increment hint. Only implemented on X11.
-    fn with_resize_increments(self, width_inc: u32, height_inc: u32) -> WindowBuilder;
+    fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
     /// Build window with base size hint. Only implemented on X11.
-    fn with_base_size(self, base_width: u32, base_height: u32) -> WindowBuilder;
+    fn with_base_size(self, base_size: LogicalSize) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -253,14 +258,14 @@ impl WindowBuilderExt for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, width_inc: u32, height_inc: u32) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some((width_inc, height_inc));
+    fn with_resize_increments(mut self, increments: LogicalSize) -> WindowBuilder {
+        self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 
     #[inline]
-    fn with_base_size(mut self, base_width: u32, base_height: u32) -> WindowBuilder {
-        self.platform_specific.base_size = Some((base_width, base_height));
+    fn with_base_size(mut self, base_size: LogicalSize) -> WindowBuilder {
+        self.platform_specific.base_size = Some(base_size.into());
         self
     }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use {
     EventsLoop,
+    LogicalSize,
     MonitorId,
     Window,
     WindowBuilder,

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -72,6 +72,7 @@ impl EventsLoopExt for EventsLoop {
     }
 
     #[inline]
+    #[doc(hidden)]
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         self.events_loop.x_connection().cloned()
     }
@@ -93,6 +94,7 @@ pub trait WindowExt {
 
     fn get_xlib_screen_id(&self) -> Option<raw::c_int>;
 
+    #[doc(hidden)]
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>>;
 
     /// Set window urgency hint (`XUrgencyHint`). Only relevant on X.
@@ -155,6 +157,7 @@ impl WindowExt for Window {
     }
 
     #[inline]
+    #[doc(hidden)]
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.get_xlib_xconnection()),

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -5,7 +5,25 @@ use std::os::raw::c_void;
 use libc;
 use winapi::shared::windef::HWND;
 
-use {DeviceId, Icon, MonitorId, Window, WindowBuilder};
+use {DeviceId, EventsLoop, Icon, MonitorId, Window, WindowBuilder};
+use platform::EventsLoop as WindowsEventsLoop;
+
+/// Additional methods on `EventsLoop` that are specific to Windows.
+pub trait EventsLoopExt {
+    /// By default, winit on Windows will attempt to enable process-wide DPI awareness. If that's
+    /// undesirable, you can create an `EventsLoop` using this function instead.
+    fn new_dpi_unaware() -> Self where Self: Sized;
+}
+
+impl EventsLoopExt for EventsLoop {
+    #[inline]
+    fn new_dpi_unaware() -> Self {
+        EventsLoop {
+            events_loop: WindowsEventsLoop::with_dpi_awareness(false),
+            _marker: ::std::marker::PhantomData,
+        }
+    }
+}
 
 /// Additional methods on `Window` that are specific to Windows.
 pub trait WindowExt {

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -37,7 +37,7 @@ impl EventsLoop {
 
     #[inline]
     pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
-        let mut rb = VecDeque::new();
+        let mut rb = VecDeque::with_capacity(1);
         rb.push_back(MonitorId);
         rb
     }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -2,24 +2,34 @@
 
 extern crate android_glue;
 
-use libc;
-use std::sync::mpsc::{Receiver, channel};
+mod ffi;
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::fmt;
 use std::os::raw::c_void;
-use {CreationError, Event, WindowEvent, MouseCursor};
+use std::sync::mpsc::{Receiver, channel};
+
+use {
+    CreationError,
+    CursorState,
+    Event,
+    LogicalPosition,
+    LogicalSize,
+    MouseCursor,
+    PhysicalPosition,
+    PhysicalSize,
+    WindowAttributes,
+    WindowEvent,
+    WindowId as RootWindowId,
+};
 use CreationError::OsError;
-use WindowId as RootWindowId;
 use events::{Touch, TouchPhase};
 use window::MonitorId as RootMonitorId;
 
-use std::collections::VecDeque;
-use std::cell::RefCell;
-
-use CursorState;
-use WindowAttributes;
-
 pub struct EventsLoop {
     event_rx: Receiver<android_glue::Event>,
-    suspend_callback: RefCell<Option<Box<Fn(bool) -> ()>>>
+    suspend_callback: RefCell<Option<Box<Fn(bool) -> ()>>>,
 }
 
 #[derive(Clone)]
@@ -31,7 +41,7 @@ impl EventsLoop {
         android_glue::add_sender(tx);
         EventsLoop {
             event_rx: rx,
-            suspend_callback: RefCell::new(None),
+            suspend_callback: Default::default(),
         }
     }
 
@@ -47,14 +57,17 @@ impl EventsLoop {
         MonitorId
     }
 
-
     pub fn poll_events<F>(&mut self, mut callback: F)
         where F: FnMut(::Event)
     {
         while let Ok(event) = self.event_rx.try_recv() {
-
             let e = match event{
                 android_glue::Event::EventMotion(motion) => {
+                    let dpi_factor = MonitorId.get_hidpi_factor();
+                    let location = LogicalPosition::from_physical(
+                        (motion.x as f64, motion.y as f64),
+                        dpi_factor,
+                    );
                     Some(Event::WindowEvent {
                         window_id: RootWindowId(WindowId),
                         event: WindowEvent::Touch(Touch {
@@ -64,7 +77,7 @@ impl EventsLoop {
                                 android_glue::MotionAction::Up => TouchPhase::Ended,
                                 android_glue::MotionAction::Cancel => TouchPhase::Cancelled,
                             },
-                            location: (motion.x as f64, motion.y as f64),
+                            location,
                             id: motion.pointer_id as u64,
                             device_id: DEVICE_ID,
                         }),
@@ -91,11 +104,12 @@ impl EventsLoop {
                     if native_window.is_null() {
                         None
                     } else {
-                        let w = unsafe { ffi::ANativeWindow_getWidth(native_window as *const _) } as u32;
-                        let h = unsafe { ffi::ANativeWindow_getHeight(native_window as *const _) } as u32;
+                        let dpi_factor = MonitorId.get_hidpi_factor();
+                        let physical_size = MonitorId.get_dimensions();
+                        let size = LogicalSize::from_physical(physical_size, dpi_factor);
                         Some(Event::WindowEvent {
                             window_id: RootWindowId(WindowId),
-                            event: WindowEvent::Resized(w, h),
+                            event: WindowEvent::Resized(size),
                         })
                     }
                 },
@@ -164,10 +178,29 @@ pub struct Window {
     native_window: *const c_void,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MonitorId;
 
-mod ffi;
+impl fmt::Debug for MonitorId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[derive(Debug)]
+        struct MonitorId {
+            name: Option<String>,
+            dimensions: PhysicalSize,
+            position: PhysicalPosition,
+            hidpi_factor: f64,
+        }
+
+        let monitor_id_proxy = MonitorId {
+            name: self.get_name(),
+            dimensions: self.get_dimensions(),
+            position: self.get_position(),
+            hidpi_factor: self.get_hidpi_factor(),
+        };
+
+        monitor_id_proxy.fmt(f)
+    }
+}
 
 impl MonitorId {
     #[inline]
@@ -176,21 +209,24 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_dimensions(&self) -> (u32, u32) {
+    pub fn get_dimensions(&self) -> PhysicalSize {
         unsafe {
             let window = android_glue::get_native_window();
-            (ffi::ANativeWindow_getWidth(window) as u32, ffi::ANativeWindow_getHeight(window) as u32)
+            (
+                ffi::ANativeWindow_getWidth(window) as f64,
+                ffi::ANativeWindow_getHeight(window) as f64,
+            ).into()
         }
     }
 
     #[inline]
-    pub fn get_position(&self) -> (i32, i32) {
+    pub fn get_position(&self) -> PhysicalPosition {
         // Android assumes single screen
-        (0, 0)
+        (0, 0).into()
     }
 
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         1.0
     }
 }
@@ -205,10 +241,6 @@ impl Window {
                _: PlatformSpecificWindowBuilderAttributes)
                -> Result<Window, CreationError>
     {
-        // not implemented
-        assert!(win_attribs.min_dimensions.is_none());
-        assert!(win_attribs.max_dimensions.is_none());
-
         let native_window = unsafe { android_glue::get_native_window() };
         if native_window.is_null() {
             return Err(OsError(format!("Android's native window is null")));
@@ -228,98 +260,103 @@ impl Window {
 
     #[inline]
     pub fn set_title(&self, _: &str) {
+        // N/A
     }
 
     #[inline]
     pub fn show(&self) {
+        // N/A
     }
 
     #[inline]
     pub fn hide(&self) {
+        // N/A
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
+        // N/A
         None
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
+        // N/A
         None
     }
 
     #[inline]
-    pub fn set_position(&self, _x: i32, _y: i32) {
+    pub fn set_position(&self, _position: LogicalPosition) {
+        // N/A
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+    pub fn set_min_dimensions(&self, _dimensions: Option<LogicalSize>) {
+        // N/A
+    }
 
     #[inline]
-    pub fn set_max_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+    pub fn set_max_dimensions(&self, _dimensions: Option<LogicalSize>) {
+        // N/A
+    }
 
     #[inline]
     pub fn set_resizable(&self, _resizable: bool) {
         // N/A
     }
-    
+
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
         if self.native_window.is_null() {
             None
         } else {
-            Some((
-                unsafe { ffi::ANativeWindow_getWidth(self.native_window as *const _) } as u32,
-                unsafe { ffi::ANativeWindow_getHeight(self.native_window as *const _) } as u32
-            ))
+            let dpi_factor = self.get_hidpi_factor();
+            let physical_size = self.get_current_monitor().get_dimensions();
+            Some(LogicalSize::from_physical(physical_size, dpi_factor))
         }
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         self.get_inner_size()
     }
 
     #[inline]
-    pub fn set_inner_size(&self, _x: u32, _y: u32) {
+    pub fn set_inner_size(&self, _size: LogicalSize) {
+        // N/A
     }
 
     #[inline]
-    pub fn platform_display(&self) -> *mut libc::c_void {
-        unimplemented!();
-    }
-
-    #[inline]
-    pub fn platform_window(&self) -> *mut libc::c_void {
-        unimplemented!()
+    pub fn get_hidpi_factor(&self) -> f64 {
+        self.get_current_monitor().get_hidpi_factor()
     }
 
     #[inline]
     pub fn set_cursor(&self, _: MouseCursor) {
+        // N/A
     }
 
     #[inline]
     pub fn set_cursor_state(&self, _state: CursorState) -> Result<(), String> {
+        // N/A
         Ok(())
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
-        1.0
-    }
-
-    #[inline]
-    pub fn set_cursor_position(&self, _x: i32, _y: i32) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, _position: LogicalPosition) -> Result<(), ()> {
+        // N/A
         Ok(())
     }
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        // N/A
         // Android has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        // N/A
         // Android has single screen maximized apps so nothing to do
     }
 
@@ -339,15 +376,16 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, _x: i32, _y: i32) {
+    pub fn set_ime_spot(&self, _spot: LogicalPosition) {
         // N/A
     }
 
     #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
-        RootMonitorId{inner: MonitorId}
+        RootMonitorId { inner: MonitorId }
     }
 
+    #[inline]
     pub fn id(&self) -> WindowId {
         WindowId
     }

--- a/src/platform/emscripten/ffi.rs
+++ b/src/platform/emscripten/ffi.rs
@@ -1,6 +1,4 @@
-#![allow(dead_code)]
-#![allow(non_snake_case)]
-#![allow(non_camel_case_types)]
+#![allow(dead_code, non_camel_case_types, non_snake_case)]
 
 use std::os::raw::{c_int, c_char, c_void, c_ulong, c_double, c_long, c_ushort};
 #[cfg(test)]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! ```rust, ignore
 //! #[no_mangle]
-//! pub extern fn start_glutin_app() {
+//! pub extern fn start_winit_app() {
 //!     start_inner()
 //! }
 //!
@@ -29,13 +29,13 @@
 //!
 //! ```
 //!
-//! Compile project and then drag resulting .a into Xcode project. Add glutin.h to xcode.
+//! Compile project and then drag resulting .a into Xcode project. Add winit.h to xcode.
 //!
 //! ```ignore
-//! void start_glutin_app();
+//! void start_winit_app();
 //! ```
 //!
-//! Use start_glutin_app inside your xcode's main function.
+//! Use start_winit_app inside your xcode's main function.
 //!
 //!
 //! # App lifecycle and events
@@ -45,7 +45,7 @@
 //! [app lifecycle](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/).
 //!
 //!
-//! This is how those event are represented in glutin:
+//! This is how those event are represented in winit:
 //!
 //!  - applicationDidBecomeActive is Focused(true)
 //!  - applicationWillResignActive is Focused(false)
@@ -60,100 +60,147 @@
 
 #![cfg(target_os = "ios")]
 
+use std::{fmt, mem, ptr};
 use std::collections::VecDeque;
-use std::ptr;
-use std::mem;
-use std::os::raw::c_void;
+use std::os::raw::*;
 
-use libc;
-use libc::c_int;
-use objc::runtime::{Class, Object, Sel, BOOL, YES };
-use objc::declare::{ ClassDecl };
+use objc::declare::ClassDecl;
+use objc::runtime::{BOOL, Class, Object, Sel, YES};
 
-use { CreationError, CursorState, MouseCursor, WindowAttributes };
-use WindowId as RootEventId;
-use WindowEvent;
-use Event;
-use events::{ Touch, TouchPhase };
+use {
+    CreationError,
+    CursorState,
+    Event,
+    LogicalPosition,
+    LogicalSize,
+    MouseCursor,
+    PhysicalPosition,
+    PhysicalSize,
+    WindowAttributes,
+    WindowEvent,
+    WindowId as RootEventId,
+};
+use events::{Touch, TouchPhase};
 use window::MonitorId as RootMonitorId;
 
 mod ffi;
 use self::ffi::{
-    setjmp,
-    UIApplicationMain,
     CFTimeInterval,
     CFRunLoopRunInMode,
+    CGFloat,
+    CGPoint,
+    CGRect,
+    id,
     kCFRunLoopDefaultMode,
     kCFRunLoopRunHandledSource,
-    id,
+    longjmp,
     nil,
     NSString,
-    CGFloat,
-    longjmp,
-    CGRect,
-    CGPoint
+    setjmp,
+    UIApplicationMain,
+    UIViewAutoresizingFlexibleWidth,
+    UIViewAutoresizingFlexibleHeight,
  };
 
-static mut jmpbuf: [c_int;27] = [0;27];
-
-#[derive(Debug, Clone)]
-pub struct MonitorId;
+static mut JMPBUF: [c_int; 27] = [0; 27];
 
 pub struct Window {
-    delegate_state: *mut DelegateState
+    delegate_state: *mut DelegateState,
 }
 
-#[derive(Clone)]
-pub struct WindowProxy;
+unsafe impl Send for Window {}
+unsafe impl Sync for Window {}
 
 #[derive(Debug)]
 struct DelegateState {
     events_queue: VecDeque<Event>,
     window: id,
     controller: id,
-    size: (u32,u32),
-    scale: f32
+    view: id,
+    size: LogicalSize,
+    scale: f64,
 }
 
-
 impl DelegateState {
-    #[inline]
-    fn new(window: id, controller:id, size: (u32,u32), scale: f32) -> DelegateState {
+    fn new(window: id, controller: id, view: id, size: LogicalSize, scale: f64) -> DelegateState {
         DelegateState {
             events_queue: VecDeque::new(),
-            window: window,
-            controller: controller,
-            size: size,
-            scale: scale
+            window,
+            controller,
+            view,
+            size,
+            scale,
         }
     }
 }
 
+impl Drop for DelegateState {
+    fn drop(&mut self) {
+        unsafe {
+            let _: () = msg_send![self.window, release];
+            let _: () = msg_send![self.controller, release];
+            let _: () = msg_send![self.view, release];
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MonitorId;
+
+impl fmt::Debug for MonitorId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[derive(Debug)]
+        struct MonitorId {
+            name: Option<String>,
+            dimensions: PhysicalSize,
+            position: PhysicalPosition,
+            hidpi_factor: f64,
+        }
+
+        let monitor_id_proxy = MonitorId {
+            name: self.get_name(),
+            dimensions: self.get_dimensions(),
+            position: self.get_position(),
+            hidpi_factor: self.get_hidpi_factor(),
+        };
+
+        monitor_id_proxy.fmt(f)
+    }
+}
+
 impl MonitorId {
+    #[inline]
+    pub fn get_uiscreen(&self) -> id {
+        let class = Class::get("UIScreen").expect("Failed to get class `UIScreen`");
+        unsafe { msg_send![class, mainScreen] }
+    }
+
     #[inline]
     pub fn get_name(&self) -> Option<String> {
         Some("Primary".to_string())
     }
 
     #[inline]
-    pub fn get_dimensions(&self) -> (u32, u32) {
-        unimplemented!()
+    pub fn get_dimensions(&self) -> PhysicalSize {
+        let bounds: CGRect = unsafe { msg_send![self.get_uiscreen(), nativeBounds] };
+        (bounds.size.width as f64, bounds.size.height as f64).into()
     }
 
     #[inline]
-    pub fn get_position(&self) -> (i32, i32) {
+    pub fn get_position(&self) -> PhysicalPosition {
         // iOS assumes single screen
-        (0, 0)
+        (0, 0).into()
     }
 
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
-        1.0
+    pub fn get_hidpi_factor(&self) -> f64 {
+        let scale: CGFloat = unsafe { msg_send![self.get_uiscreen(), nativeScale] };
+        scale as f64
     }
 }
 
 pub struct EventsLoop {
-    delegate_state: *mut DelegateState
+    delegate_state: *mut DelegateState,
 }
 
 #[derive(Clone)]
@@ -162,30 +209,26 @@ pub struct EventsLoopProxy;
 impl EventsLoop {
     pub fn new() -> EventsLoop {
         unsafe {
-            if setjmp(mem::transmute(&mut jmpbuf)) != 0 {
-                let app: id = msg_send![Class::get("UIApplication").unwrap(), sharedApplication];
+            if setjmp(mem::transmute(&mut JMPBUF)) != 0 {
+                let app_class = Class::get("UIApplication").expect("Failed to get class `UIApplication`");
+                let app: id = msg_send![app_class, sharedApplication];
                 let delegate: id = msg_send![app, delegate];
-                let state: *mut c_void = *(&*delegate).get_ivar("glutinState");
-                let state = state as *mut DelegateState;
-
-                let events_loop = EventsLoop {
-                    delegate_state: state
-                };
-
-                return events_loop;
+                let state: *mut c_void = *(&*delegate).get_ivar("winitState");
+                let delegate_state = state as *mut DelegateState;
+                return EventsLoop { delegate_state };
             }
         }
 
-        create_delegate_class();
         create_view_class();
+        create_delegate_class();
         start_app();
 
-        panic!("Couldn't create UIApplication")
+        panic!("Couldn't create `UIApplication`!")
     }
 
     #[inline]
     pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
-        let mut rb = VecDeque::new();
+        let mut rb = VecDeque::with_capacity(1);
         rb.push_back(MonitorId);
         rb
     }
@@ -207,7 +250,7 @@ impl EventsLoop {
             }
 
             // jump hack, so we won't quit on willTerminate event before processing it
-            if setjmp(mem::transmute(&mut jmpbuf)) != 0 {
+            if setjmp(mem::transmute(&mut JMPBUF)) != 0 {
                 if let Some(event) = state.events_queue.pop_front() {
                     callback(event);
                     return;
@@ -262,111 +305,120 @@ pub struct DeviceId;
 #[derive(Clone, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes;
 
+// TODO: AFAIK transparency is enabled by default on iOS,
+// so to be consistent with other platforms we have to change that.
 impl Window {
-    pub fn new(ev: &EventsLoop, _: WindowAttributes, _: PlatformSpecificWindowBuilderAttributes)
-               -> Result<Window, CreationError>
-    {
-        Ok(Window {
-            delegate_state: ev.delegate_state,
-        })
+    pub fn new(
+        ev: &EventsLoop,
+        _attributes: WindowAttributes,
+        _pl_alltributes: PlatformSpecificWindowBuilderAttributes,
+    ) -> Result<Window, CreationError> {
+        Ok(Window { delegate_state: ev.delegate_state })
     }
 
     #[inline]
-    pub fn set_title(&self, _: &str) {
+    pub fn get_uiwindow(&self) -> id {
+        unsafe { (*self.delegate_state).window }
+    }
+
+    #[inline]
+    pub fn get_uiview(&self) -> id {
+        unsafe { (*self.delegate_state).view }
+    }
+
+    #[inline]
+    pub fn set_title(&self, _title: &str) {
+        // N/A
     }
 
     #[inline]
     pub fn show(&self) {
+        // N/A
     }
 
     #[inline]
     pub fn hide(&self) {
+        // N/A
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
+        // N/A
         None
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
+        // N/A
         None
     }
 
     #[inline]
-    pub fn set_position(&self, _x: i32, _y: i32) {
+    pub fn set_position(&self, _position: LogicalPosition) {
+        // N/A
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
         unsafe { Some((&*self.delegate_state).size) }
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         self.get_inner_size()
     }
 
     #[inline]
-    pub fn set_inner_size(&self, _x: u32, _y: u32) {
+    pub fn set_inner_size(&self, _size: LogicalSize) {
+        // N/A
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+    pub fn set_min_dimensions(&self, _dimensions: Option<LogicalSize>) {
+        // N/A
+    }
 
     #[inline]
-    pub fn set_max_dimensions(&self, _dimensions: Option<(u32, u32)>) { }
+    pub fn set_max_dimensions(&self, _dimensions: Option<LogicalSize>) {
+        // N/A
+    }
 
     #[inline]
     pub fn set_resizable(&self, _resizable: bool) {
         // N/A
     }
-    
+
     #[inline]
-    pub fn platform_display(&self) -> *mut libc::c_void {
-        unimplemented!();
+    pub fn set_cursor(&self, _cursor: MouseCursor) {
+        // N/A
     }
 
     #[inline]
-    pub fn platform_window(&self) -> *mut libc::c_void {
-        unimplemented!()
-    }
-
-    #[inline]
-    pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
-    }
-
-    #[inline]
-    pub fn set_cursor(&self, _: MouseCursor) {
-    }
-
-    #[inline]
-    pub fn set_cursor_state(&self, _: CursorState) -> Result<(), String> {
+    pub fn set_cursor_state(&self, _cursor_state: CursorState) -> Result<(), String> {
+        // N/A
         Ok(())
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         unsafe { (&*self.delegate_state) }.scale
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _x: i32, _y: i32) -> Result<(), ()> {
-        unimplemented!();
-    }
-
-    #[inline]
-    pub fn create_window_proxy(&self) -> WindowProxy {
-        WindowProxy
+    pub fn set_cursor_position(&self, _position: LogicalPosition) -> Result<(), ()> {
+        // N/A
+        Ok(())
     }
 
     #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
+        // N/A
         // iOS has single screen maximized apps so nothing to do
     }
 
     #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
+        // N/A
         // iOS has single screen maximized apps so nothing to do
     }
 
@@ -386,13 +438,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, _x: i32, _y: i32) {
+    pub fn set_ime_spot(&self, _logical_spot: LogicalPosition) {
         // N/A
     }
 
     #[inline]
     pub fn get_current_monitor(&self) -> RootMonitorId {
-        RootMonitorId{inner: MonitorId}
+        RootMonitorId { inner: MonitorId }
     }
 
     #[inline]
@@ -403,26 +455,32 @@ impl Window {
 
 fn create_delegate_class() {
     extern fn did_finish_launching(this: &mut Object, _: Sel, _: id, _: id) -> BOOL {
+        let screen_class = Class::get("UIScreen").expect("Failed to get class `UIScreen`");
+        let window_class = Class::get("UIWindow").expect("Failed to get class `UIWindow`");
+        let controller_class = Class::get("MainViewController").expect("Failed to get class `MainViewController`");
+        let view_class = Class::get("MainView").expect("Failed to get class `MainView`");
         unsafe {
-            let main_screen: id = msg_send![Class::get("UIScreen").unwrap(), mainScreen];
+            let main_screen: id = msg_send![screen_class, mainScreen];
             let bounds: CGRect = msg_send![main_screen, bounds];
             let scale: CGFloat = msg_send![main_screen, nativeScale];
 
-            let window: id = msg_send![Class::get("UIWindow").unwrap(), alloc];
+            let window: id = msg_send![window_class, alloc];
             let window: id = msg_send![window, initWithFrame:bounds.clone()];
 
-            let size = (bounds.size.width as u32, bounds.size.height as u32);
+            let size = (bounds.size.width as f64, bounds.size.height as f64).into();
 
-            let view_controller: id = msg_send![Class::get("MainViewController").unwrap(), alloc];
+            let view_controller: id = msg_send![controller_class, alloc];
             let view_controller: id = msg_send![view_controller, init];
+
+            let view: id = msg_send![view_class, alloc];
+            let view: id = msg_send![view, initForGl:&bounds];
 
             let _: () = msg_send![window, setRootViewController:view_controller];
             let _: () = msg_send![window, makeKeyAndVisible];
 
-            let state = Box::new(DelegateState::new(window, view_controller, size, scale as f32));
+            let state = Box::new(DelegateState::new(window, view_controller, view, size, scale as f64));
             let state_ptr: *mut DelegateState = mem::transmute(state);
-            this.set_ivar("glutinState", state_ptr as *mut c_void);
-
+            this.set_ivar("winitState", state_ptr as *mut c_void);
 
             let _: () = msg_send![this, performSelector:sel!(postLaunch:) withObject:nil afterDelay:0.0];
         }
@@ -430,12 +488,12 @@ fn create_delegate_class() {
     }
 
     extern fn post_launch(_: &Object, _: Sel, _: id) {
-        unsafe { longjmp(mem::transmute(&mut jmpbuf),1); }
+        unsafe { longjmp(mem::transmute(&mut JMPBUF),1); }
     }
 
     extern fn did_become_active(this: &Object, _: Sel, _: id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
             state.events_queue.push_back(Event::WindowEvent {
                 window_id: RootEventId(WindowId),
@@ -446,7 +504,7 @@ fn create_delegate_class() {
 
     extern fn will_resign_active(this: &Object, _: Sel, _: id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
             state.events_queue.push_back(Event::WindowEvent {
                 window_id: RootEventId(WindowId),
@@ -457,7 +515,7 @@ fn create_delegate_class() {
 
     extern fn will_enter_foreground(this: &Object, _: Sel, _: id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
             state.events_queue.push_back(Event::Suspended(false));
         }
@@ -465,7 +523,7 @@ fn create_delegate_class() {
 
     extern fn did_enter_background(this: &Object, _: Sel, _: id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
             state.events_queue.push_back(Event::Suspended(true));
         }
@@ -473,7 +531,7 @@ fn create_delegate_class() {
 
     extern fn will_terminate(this: &Object, _: Sel, _: id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
             // push event to the front to garantee that we'll process it
             // immidiatly after jump
@@ -481,13 +539,13 @@ fn create_delegate_class() {
                 window_id: RootEventId(WindowId),
                 event: WindowEvent::Destroyed,
             });
-            longjmp(mem::transmute(&mut jmpbuf),1);
+            longjmp(mem::transmute(&mut JMPBUF),1);
         }
     }
 
     extern fn handle_touches(this: &Object, _: Sel, touches: id, _:id) {
         unsafe {
-            let state: *mut c_void = *this.get_ivar("glutinState");
+            let state: *mut c_void = *this.get_ivar("winitState");
             let state = &mut *(state as *mut DelegateState);
 
             let touches_enum: id = msg_send![touches, objectEnumerator];
@@ -506,7 +564,7 @@ fn create_delegate_class() {
                     event: WindowEvent::Touch(Touch {
                         device_id: DEVICE_ID,
                         id: touch_id,
-                        location: (location.x as f64, location.y as f64),
+                        location: (location.x as f64, location.y as f64).into(),
                         phase: match phase {
                             0 => TouchPhase::Started,
                             1 => TouchPhase::Moved,
@@ -521,8 +579,8 @@ fn create_delegate_class() {
         }
     }
 
-    let ui_responder = Class::get("UIResponder").unwrap();
-    let mut decl = ClassDecl::new("AppDelegate", ui_responder).unwrap();
+    let ui_responder = Class::get("UIResponder").expect("Failed to get class `UIResponder`");
+    let mut decl = ClassDecl::new("AppDelegate", ui_responder).expect("Failed to declare class `AppDelegate`");
 
     unsafe {
         decl.add_method(sel!(application:didFinishLaunchingWithOptions:),
@@ -560,17 +618,45 @@ fn create_delegate_class() {
         decl.add_method(sel!(postLaunch:),
                         post_launch as extern fn(&Object, Sel, id));
 
-        decl.add_ivar::<*mut c_void>("glutinState");
+        decl.add_ivar::<*mut c_void>("winitState");
 
         decl.register();
     }
 }
 
-fn create_view_class() {
-    let ui_view_controller = Class::get("UIViewController").unwrap();
-    let decl = ClassDecl::new("MainViewController", ui_view_controller).unwrap();
-
+// TODO: winit shouldn't contain GL-specfiic code
+pub fn create_view_class() {
+    let superclass = Class::get("UIViewController").expect("Failed to get class `UIViewController`");
+    let decl = ClassDecl::new("MainViewController", superclass).expect("Failed to declare class `MainViewController`");
     decl.register();
+
+    extern fn init_for_gl(this: &Object, _: Sel, frame: *const c_void) -> id {
+        unsafe {
+            let bounds = frame as *const CGRect;
+            let view: id = msg_send![this, initWithFrame:(*bounds).clone()];
+
+            let mask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            let _: () = msg_send![view, setAutoresizingMask:mask];
+            let _: () = msg_send![view, setAutoresizesSubviews:YES];
+
+            let layer: id = msg_send![view, layer];
+            let _ : () = msg_send![layer, setOpaque:YES];
+
+            view
+        }
+    }
+
+    extern fn layer_class(_: &Class, _: Sel) -> *const Class {
+        unsafe { mem::transmute(Class::get("CAEAGLLayer").expect("Failed to get class `CAEAGLLayer`")) }
+    }
+
+    let superclass = Class::get("GLKView").expect("Failed to get class `GLKView`");
+    let mut decl = ClassDecl::new("MainView", superclass).expect("Failed to declare class `MainView`");
+    unsafe {
+        decl.add_method(sel!(initForGl:), init_for_gl as extern fn(&Object, Sel, *const c_void) -> id);
+        decl.add_class_method(sel!(layerClass), layer_class as extern fn(&Class, Sel) -> *const Class);
+        decl.register();
+    }
 }
 
 #[inline]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -16,6 +16,8 @@ use {
     LogicalPosition,
     LogicalSize,
     MouseCursor,
+    PhysicalPosition,
+    PhysicalSize,
     ControlFlow,
     WindowAttributes,
 };
@@ -95,18 +97,20 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_dimensions(&self) -> (u32, u32) {
+    pub fn get_dimensions(&self) -> PhysicalSize {
         match self {
             &MonitorId::X(ref m) => m.get_dimensions(),
-            &MonitorId::Wayland(ref m) => m.get_dimensions(),
+            //&MonitorId::Wayland(ref m) => m.get_dimensions(),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn get_position(&self) -> (i32, i32) {
+    pub fn get_position(&self) -> PhysicalPosition {
         match self {
             &MonitorId::X(ref m) => m.get_position(),
-            &MonitorId::Wayland(ref m) => m.get_position(),
+            //&MonitorId::Wayland(ref m) => m.get_position(),
+            _ => unimplemented!(),
         }
     }
 
@@ -114,7 +118,7 @@ impl MonitorId {
     pub fn get_hidpi_factor(&self) -> f64 {
         match self {
             &MonitorId::X(ref m) => m.get_hidpi_factor(),
-            &MonitorId::Wayland(ref m) => m.get_hidpi_factor(),
+            &MonitorId::Wayland(ref m) => m.get_hidpi_factor() as f64,
         }
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -8,9 +8,6 @@ use std::sync::Arc;
 
 use sctk::reexports::client::ConnectError;
 
-// `std::os::raw::c_void` and `libc::c_void` are NOT interchangeable!
-use libc;
-
 use {
     CreationError,
     CursorState,
@@ -114,7 +111,7 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         match self {
             &MonitorId::X(ref m) => m.get_hidpi_factor(),
             &MonitorId::Wayland(ref m) => m.get_hidpi_factor(),
@@ -242,7 +239,7 @@ impl Window {
             _ => (),
         }
     }
-    
+
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         match self {
@@ -281,22 +278,6 @@ impl Window {
             &Window::X(ref w) => w.set_cursor_position(position),
             //&Window::Wayland(ref w) => w.set_cursor_position(x, y),
             _ => unimplemented!(),
-        }
-    }
-
-    #[inline]
-    pub fn platform_display(&self) -> *mut libc::c_void {
-        match self {
-            &Window::X(ref w) => w.platform_display(),
-            &Window::Wayland(ref w) => w.get_display().c_ptr() as *mut _
-        }
-    }
-
-    #[inline]
-    pub fn platform_window(&self) -> *mut libc::c_void {
-        match self {
-            &Window::X(ref w) => w.platform_window(),
-            &Window::Wayland(ref w) => w.get_surface().c_ptr() as *mut _
         }
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -13,8 +13,8 @@ use {
     CursorState,
     EventsLoopClosed,
     Icon,
-    LogicalCoordinates,
-    LogicalDimensions,
+    LogicalPosition,
+    LogicalSize,
     MouseCursor,
     ControlFlow,
     WindowAttributes,
@@ -169,7 +169,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
         match self {
             &Window::X(ref w) => w.get_position(),
             //&Window::Wayland(ref w) => w.get_position(),
@@ -178,7 +178,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         match self {
             &Window::X(ref m) => m.get_inner_position(),
             //&Window::Wayland(ref m) => m.get_inner_position(),
@@ -187,7 +187,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_position(&self, position: LogicalCoordinates) {
+    pub fn set_position(&self, position: LogicalPosition) {
         match self {
             &Window::X(ref w) => w.set_position(position),
             //&Window::Wayland(ref w) => w.set_position(x, y),
@@ -196,7 +196,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
         match self {
             &Window::X(ref w) => w.get_inner_size(),
             //&Window::Wayland(ref w) => w.get_inner_size(),
@@ -205,7 +205,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         match self {
             &Window::X(ref w) => w.get_outer_size(),
             //&Window::Wayland(ref w) => w.get_outer_size(),
@@ -214,7 +214,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalDimensions) {
+    pub fn set_inner_size(&self, size: LogicalSize) {
         match self {
             &Window::X(ref w) => w.set_inner_size(size),
             //&Window::Wayland(ref w) => w.set_inner_size(x, y),
@@ -223,7 +223,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<LogicalDimensions>) {
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         match self {
             &Window::X(ref w) => w.set_min_dimensions(dimensions),
             //&Window::Wayland(ref w) => w.set_min_dimensions(dimensions),
@@ -232,7 +232,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<LogicalDimensions>) {
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
         match self {
             &Window::X(ref w) => w.set_max_dimensions(dimensions),
             //&Window::Wayland(ref w) => w.set_max_dimensions(dimensions),
@@ -273,7 +273,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, position: LogicalCoordinates) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ()> {
         match self {
             &Window::X(ref w) => w.set_cursor_position(position),
             //&Window::Wayland(ref w) => w.set_cursor_position(x, y),
@@ -322,7 +322,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, position: LogicalCoordinates) {
+    pub fn set_ime_spot(&self, position: LogicalPosition) {
         match self {
             &Window::X(ref w) => w.set_ime_spot(position),
             &Window::Wayland(_) => (),

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -100,8 +100,7 @@ impl MonitorId {
     pub fn get_dimensions(&self) -> PhysicalSize {
         match self {
             &MonitorId::X(ref m) => m.get_dimensions(),
-            //&MonitorId::Wayland(ref m) => m.get_dimensions(),
-            _ => unimplemented!(),
+            &MonitorId::Wayland(ref m) => m.get_dimensions(),
         }
     }
 
@@ -109,8 +108,7 @@ impl MonitorId {
     pub fn get_position(&self) -> PhysicalPosition {
         match self {
             &MonitorId::X(ref m) => m.get_position(),
-            //&MonitorId::Wayland(ref m) => m.get_position(),
-            _ => unimplemented!(),
+            &MonitorId::Wayland(ref m) => m.get_position(),
         }
     }
 
@@ -176,8 +174,7 @@ impl Window {
     pub fn get_position(&self) -> Option<LogicalPosition> {
         match self {
             &Window::X(ref w) => w.get_position(),
-            //&Window::Wayland(ref w) => w.get_position(),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.get_position(),
         }
     }
 
@@ -185,8 +182,7 @@ impl Window {
     pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         match self {
             &Window::X(ref m) => m.get_inner_position(),
-            //&Window::Wayland(ref m) => m.get_inner_position(),
-            _ => unimplemented!(),
+            &Window::Wayland(ref m) => m.get_inner_position(),
         }
     }
 
@@ -194,8 +190,7 @@ impl Window {
     pub fn set_position(&self, position: LogicalPosition) {
         match self {
             &Window::X(ref w) => w.set_position(position),
-            //&Window::Wayland(ref w) => w.set_position(x, y),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_position(position),
         }
     }
 
@@ -203,8 +198,7 @@ impl Window {
     pub fn get_inner_size(&self) -> Option<LogicalSize> {
         match self {
             &Window::X(ref w) => w.get_inner_size(),
-            //&Window::Wayland(ref w) => w.get_inner_size(),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.get_inner_size(),
         }
     }
 
@@ -212,8 +206,7 @@ impl Window {
     pub fn get_outer_size(&self) -> Option<LogicalSize> {
         match self {
             &Window::X(ref w) => w.get_outer_size(),
-            //&Window::Wayland(ref w) => w.get_outer_size(),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.get_outer_size(),
         }
     }
 
@@ -221,8 +214,7 @@ impl Window {
     pub fn set_inner_size(&self, size: LogicalSize) {
         match self {
             &Window::X(ref w) => w.set_inner_size(size),
-            //&Window::Wayland(ref w) => w.set_inner_size(x, y),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_inner_size(size),
         }
     }
 
@@ -230,8 +222,7 @@ impl Window {
     pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         match self {
             &Window::X(ref w) => w.set_min_dimensions(dimensions),
-            //&Window::Wayland(ref w) => w.set_min_dimensions(dimensions),
-            _ => (),
+            &Window::Wayland(ref w) => w.set_min_dimensions(dimensions),
         }
     }
 
@@ -239,8 +230,7 @@ impl Window {
     pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
         match self {
             &Window::X(ref w) => w.set_max_dimensions(dimensions),
-            //&Window::Wayland(ref w) => w.set_max_dimensions(dimensions),
-            _ => (),
+            &Window::Wayland(ref w) => w.set_max_dimensions(dimensions),
         }
     }
 
@@ -280,8 +270,7 @@ impl Window {
     pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ()> {
         match self {
             &Window::X(ref w) => w.set_cursor_position(position),
-            //&Window::Wayland(ref w) => w.set_cursor_position(x, y),
-            _ => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_cursor_position(position),
         }
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -16,6 +16,8 @@ use {
     CursorState,
     EventsLoopClosed,
     Icon,
+    LogicalCoordinates,
+    LogicalDimensions,
     MouseCursor,
     ControlFlow,
     WindowAttributes,
@@ -57,19 +59,19 @@ thread_local!(
 
 pub enum Window {
     X(x11::Window),
-    Wayland(wayland::Window)
+    Wayland(wayland::Window),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowId {
     X(x11::WindowId),
-    Wayland(wayland::WindowId)
+    Wayland(wayland::WindowId),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceId {
     X(x11::DeviceId),
-    Wayland(wayland::DeviceId)
+    Wayland(wayland::DeviceId),
 }
 
 #[derive(Debug, Clone)]
@@ -141,7 +143,7 @@ impl Window {
     pub fn id(&self) -> WindowId {
         match self {
             &Window::X(ref w) => WindowId::X(w.id()),
-            &Window::Wayland(ref w) => WindowId::Wayland(w.id())
+            &Window::Wayland(ref w) => WindowId::Wayland(w.id()),
         }
     }
 
@@ -149,7 +151,7 @@ impl Window {
     pub fn set_title(&self, title: &str) {
         match self {
             &Window::X(ref w) => w.set_title(title),
-            &Window::Wayland(ref w) => w.set_title(title)
+            &Window::Wayland(ref w) => w.set_title(title),
         }
     }
 
@@ -157,7 +159,7 @@ impl Window {
     pub fn show(&self) {
         match self {
             &Window::X(ref w) => w.show(),
-            &Window::Wayland(ref w) => w.show()
+            &Window::Wayland(ref w) => w.show(),
         }
     }
 
@@ -165,71 +167,79 @@ impl Window {
     pub fn hide(&self) {
         match self {
             &Window::X(ref w) => w.hide(),
-            &Window::Wayland(ref w) => w.hide()
+            &Window::Wayland(ref w) => w.hide(),
         }
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalCoordinates> {
         match self {
             &Window::X(ref w) => w.get_position(),
-            &Window::Wayland(ref w) => w.get_position()
+            //&Window::Wayland(ref w) => w.get_position(),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
         match self {
             &Window::X(ref m) => m.get_inner_position(),
-            &Window::Wayland(ref m) => m.get_inner_position(),
+            //&Window::Wayland(ref m) => m.get_inner_position(),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn set_position(&self, x: i32, y: i32) {
+    pub fn set_position(&self, position: LogicalCoordinates) {
         match self {
-            &Window::X(ref w) => w.set_position(x, y),
-            &Window::Wayland(ref w) => w.set_position(x, y)
+            &Window::X(ref w) => w.set_position(position),
+            //&Window::Wayland(ref w) => w.set_position(x, y),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
         match self {
             &Window::X(ref w) => w.get_inner_size(),
-            &Window::Wayland(ref w) => w.get_inner_size()
+            //&Window::Wayland(ref w) => w.get_inner_size(),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
         match self {
             &Window::X(ref w) => w.get_outer_size(),
-            &Window::Wayland(ref w) => w.get_outer_size()
+            //&Window::Wayland(ref w) => w.get_outer_size(),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn set_inner_size(&self, x: u32, y: u32) {
+    pub fn set_inner_size(&self, size: LogicalDimensions) {
         match self {
-            &Window::X(ref w) => w.set_inner_size(x, y),
-            &Window::Wayland(ref w) => w.set_inner_size(x, y)
+            &Window::X(ref w) => w.set_inner_size(size),
+            //&Window::Wayland(ref w) => w.set_inner_size(x, y),
+            _ => unimplemented!(),
         }
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalDimensions>) {
         match self {
             &Window::X(ref w) => w.set_min_dimensions(dimensions),
-            &Window::Wayland(ref w) => w.set_min_dimensions(dimensions)
+            //&Window::Wayland(ref w) => w.set_min_dimensions(dimensions),
+            _ => (),
         }
     }
 
     #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalDimensions>) {
         match self {
             &Window::X(ref w) => w.set_max_dimensions(dimensions),
-            &Window::Wayland(ref w) => w.set_max_dimensions(dimensions)
+            //&Window::Wayland(ref w) => w.set_max_dimensions(dimensions),
+            _ => (),
         }
     }
     
@@ -258,18 +268,19 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
        match self {
-            &Window::X(ref w) => w.hidpi_factor(),
-            &Window::Wayland(ref w) => w.hidpi_factor()
+            &Window::X(ref w) => w.get_hidpi_factor(),
+            &Window::Wayland(ref w) => w.hidpi_factor() as f64,
         }
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, position: LogicalCoordinates) -> Result<(), ()> {
         match self {
-            &Window::X(ref w) => w.set_cursor_position(x, y),
-            &Window::Wayland(ref w) => w.set_cursor_position(x, y)
+            &Window::X(ref w) => w.set_cursor_position(position),
+            //&Window::Wayland(ref w) => w.set_cursor_position(x, y),
+            _ => unimplemented!(),
         }
     }
 
@@ -330,9 +341,9 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, x: i32, y: i32) {
+    pub fn set_ime_spot(&self, position: LogicalCoordinates) {
         match self {
-            &Window::X(ref w) => w.send_xim_spot(x as i16, y as i16),
+            &Window::X(ref w) => w.set_ime_spot(position),
             &Window::Wayland(_) => (),
         }
     }
@@ -447,14 +458,17 @@ r#"Failed to initialize any backend!
     #[inline]
     pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
         match *self {
-            EventsLoop::Wayland(ref evlp) => evlp.get_available_monitors()
-                                    .into_iter()
-                                    .map(MonitorId::Wayland)
-                                    .collect(),
-            EventsLoop::X(ref evlp) => x11::get_available_monitors(evlp.x_connection())
-                                        .into_iter()
-                                        .map(MonitorId::X)
-                                        .collect(),
+            EventsLoop::Wayland(ref evlp) => evlp
+                .get_available_monitors()
+                .into_iter()
+                .map(MonitorId::Wayland)
+                .collect(),
+            EventsLoop::X(ref evlp) => evlp
+                .x_connection()
+                .get_available_monitors()
+                .into_iter()
+                .map(MonitorId::X)
+                .collect(),
         }
     }
 
@@ -462,7 +476,7 @@ r#"Failed to initialize any backend!
     pub fn get_primary_monitor(&self) -> MonitorId {
         match *self {
             EventsLoop::Wayland(ref evlp) => MonitorId::Wayland(evlp.get_primary_monitor()),
-            EventsLoop::X(ref evlp) => MonitorId::X(x11::get_primary_monitor(evlp.x_connection())),
+            EventsLoop::X(ref evlp) => MonitorId::X(evlp.x_connection().get_primary_monitor()),
         }
     }
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -253,7 +253,8 @@ impl EventsLoop {
                     if let Some((w, h)) = newsize {
                         frame.resize(w as u32, h as u32);
                         frame.refresh();
-                        sink.send_event(::WindowEvent::Resized(w as u32, h as u32), wid);
+                        let logical_size = ::LogicalDimensions::new(w as f64, h as f64);
+                        sink.send_event(::WindowEvent::Resized(logical_size), wid);
                     } else if frame_refresh {
                         frame.refresh();
                     }

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -253,7 +253,7 @@ impl EventsLoop {
                     if let Some((w, h)) = newsize {
                         frame.resize(w as u32, h as u32);
                         frame.refresh();
-                        let logical_size = ::LogicalDimensions::new(w as f64, h as f64);
+                        let logical_size = ::LogicalSize::new(w as f64, h as f64);
                         sink.send_event(::WindowEvent::Resized(logical_size), wid);
                     } else if frame_refresh {
                         frame.refresh();

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -439,16 +439,16 @@ impl fmt::Debug for MonitorId {
         struct MonitorId {
             name: Option<String>,
             native_identifier: u32,
-            dimensions: (u32, u32),
-            position: (i32, i32),
+            dimensions: PhysicalSize,
+            position: PhysicalPosition,
             hidpi_factor: i32,
         }
 
         let monitor_id_proxy = MonitorId {
             name: self.get_name(),
             native_identifier: self.get_native_identifier(),
-            dimensions: self.get_dimensions().into(),
-            position: self.get_position().into(),
+            dimensions: self.get_dimensions(),
+            position: self.get_position(),
             hidpi_factor: self.get_hidpi_factor(),
         };
 

--- a/src/platform/linux/wayland/pointer.rs
+++ b/src/platform/linux/wayland/pointer.rs
@@ -42,7 +42,7 @@ pub fn implement_pointer(
                     sink.send_event(
                         WindowEvent::CursorMoved {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            position: (surface_x, surface_y),
+                            position: (surface_x, surface_y).into(),
                             // TODO: replace dummy value with actual modifier state
                             modifiers: ModifiersState::default(),
                         },
@@ -71,7 +71,7 @@ pub fn implement_pointer(
                     sink.send_event(
                         WindowEvent::CursorMoved {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            position: (surface_x, surface_y),
+                            position: (surface_x, surface_y).into(),
                             // TODO: replace dummy value with actual modifier state
                             modifiers: ModifiersState::default(),
                         },
@@ -117,7 +117,7 @@ pub fn implement_pointer(
                         sink.send_event(
                             WindowEvent::MouseWheel {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                delta: MouseScrollDelta::PixelDelta(x as f32, y as f32),
+                                delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
                                 phase: TouchPhase::Moved,
                                 // TODO: replace dummy value with actual modifier state
                                 modifiers: ModifiersState::default(),
@@ -158,7 +158,7 @@ pub fn implement_pointer(
                         sink.send_event(
                             WindowEvent::MouseWheel {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                delta: MouseScrollDelta::PixelDelta(x as f32, y as f32),
+                                delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
                                 phase: axis_state,
                                 // TODO: replace dummy value with actual modifier state
                                 modifiers: ModifiersState::default(),

--- a/src/platform/linux/wayland/touch.rs
+++ b/src/platform/linux/wayland/touch.rs
@@ -34,7 +34,7 @@ pub(crate) fn implement_touch(
                         WindowEvent::Touch(::Touch {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                             phase: TouchPhase::Started,
-                            location: (x, y),
+                            location: (x, y).into(),
                             id: id as u64,
                         }),
                         wid,
@@ -54,7 +54,7 @@ pub(crate) fn implement_touch(
                         WindowEvent::Touch(::Touch {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                             phase: TouchPhase::Ended,
-                            location: pt.location,
+                            location: pt.location.into(),
                             id: id as u64,
                         }),
                         pt.wid,
@@ -69,7 +69,7 @@ pub(crate) fn implement_touch(
                         WindowEvent::Touch(::Touch {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                             phase: TouchPhase::Moved,
-                            location: (x, y),
+                            location: (x, y).into(),
                             id: id as u64,
                         }),
                         pt.wid,
@@ -82,7 +82,7 @@ pub(crate) fn implement_touch(
                     WindowEvent::Touch(::Touch {
                         device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                         phase: TouchPhase::Cancelled,
-                        location: pt.location,
+                        location: pt.location.into(),
                         id: pt.id as u64,
                     }),
                     pt.wid,

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -24,7 +24,9 @@ pub struct Window {
 
 impl Window {
     pub fn new(evlp: &EventsLoop, attributes: WindowAttributes) -> Result<Window, CreationError> {
-        let (width, height) = attributes.dimensions.unwrap_or((800, 600));
+        // TODO: Update for new DPI API
+        //let (width, height) = attributes.dimensions.unwrap_or((800, 600));
+        let (width, height) = (64, 64);
         // Create the window
         let size = Arc::new(Mutex::new((width, height)));
 
@@ -107,8 +109,9 @@ impl Window {
         frame.set_decorate(attributes.decorations);
 
         // min-max dimensions
-        frame.set_min_size(attributes.min_dimensions);
-        frame.set_max_size(attributes.max_dimensions);
+        // TODO: Update for new DPI API
+        //frame.set_min_size(attributes.min_dimensions);
+        //frame.set_max_size(attributes.max_dimensions);
 
         let kill_switch = Arc::new(Mutex::new(false));
         let need_frame_refresh = Arc::new(Mutex::new(true));

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -1,12 +1,12 @@
 use std::sync::{Arc, Mutex, Weak};
 
-use {CreationError, CursorState, MouseCursor, WindowAttributes};
+use {CreationError, CursorState, MouseCursor, WindowAttributes, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use platform::MonitorId as PlatformMonitorId;
 use window::MonitorId as RootMonitorId;
 
 use sctk::window::{BasicFrame, Event as WEvent, Window as SWindow};
 use sctk::reexports::client::{Display, Proxy};
-use sctk::reexports::client::protocol::{wl_seat, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_surface, wl_output};
 use sctk::reexports::client::protocol::wl_compositor::RequestsTrait as CompositorRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
 
@@ -15,7 +15,7 @@ use super::{make_wid, EventsLoop, MonitorId, WindowId};
 pub struct Window {
     surface: Proxy<wl_surface::WlSurface>,
     frame: Arc<Mutex<SWindow<BasicFrame>>>,
-    monitors: Arc<Mutex<Vec<MonitorId>>>,
+    monitors: Arc<Mutex<MonitorList>>,
     size: Arc<Mutex<(u32, u32)>>,
     kill_switch: (Arc<Mutex<bool>>, Arc<Mutex<bool>>),
     display: Arc<Display>,
@@ -31,18 +31,35 @@ impl Window {
         let size = Arc::new(Mutex::new((width, height)));
 
         // monitor tracking
-        let monitor_list = Arc::new(Mutex::new(Vec::new()));
+        let monitor_list = Arc::new(Mutex::new(MonitorList::new()));
 
         let surface = evlp.env.compositor.create_surface().unwrap().implement({
             let list = monitor_list.clone();
             let omgr = evlp.env.outputs.clone();
-            move |event, _| match event {
-                wl_surface::Event::Enter { output } => list.lock().unwrap().push(MonitorId {
-                    proxy: output,
-                    mgr: omgr.clone(),
-                }),
+            let window_store = evlp.store.clone();
+            move |event, surface: Proxy<wl_surface::WlSurface>| match event {
+                wl_surface::Event::Enter { output } => {
+                    let dpi_change = list.lock().unwrap().add_output(MonitorId {
+                        proxy: output,
+                        mgr: omgr.clone(),
+                    });
+                    if let Some(dpi) = dpi_change {
+                        if surface.version() >= 3 {
+                            // without version 3 we can't be dpi aware
+                            window_store.lock().unwrap().dpi_change(&surface, dpi);
+                            surface.set_buffer_scale(dpi);
+                        }
+                    }
+                },
                 wl_surface::Event::Leave { output } => {
-                    list.lock().unwrap().retain(|m| !m.proxy.equals(&output));
+                    let dpi_change = list.lock().unwrap().del_output(&output);
+                    if let Some(dpi) = dpi_change {
+                        if surface.version() >= 3 {
+                            // without version 3 we can't be dpi aware
+                            window_store.lock().unwrap().dpi_change(&surface, dpi);
+                            surface.set_buffer_scale(dpi);
+                        }
+                    }
                 }
             }
         });
@@ -61,7 +78,7 @@ impl Window {
                     let mut store = window_store.lock().unwrap();
                     for window in &mut store.windows {
                         if window.surface.equals(&my_surface) {
-                            window.newsize = new_size.map(|(w, h)| (w as i32, h as i32));
+                            window.newsize = new_size;
                             window.need_refresh = true;
                             *(window.need_frame_refresh.lock().unwrap()) = true;
                             return;
@@ -120,11 +137,14 @@ impl Window {
         evlp.store.lock().unwrap().windows.push(InternalWindow {
             closed: false,
             newsize: None,
+            size: size.clone(),
             need_refresh: false,
             need_frame_refresh: need_frame_refresh.clone(),
             surface: surface.clone(),
             kill_switch: kill_switch.clone(),
             frame: Arc::downgrade(&frame),
+            current_dpi: 1,
+            new_dpi: None,
         });
         evlp.evq.borrow_mut().sync_roundtrip().unwrap();
 
@@ -159,48 +179,49 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
         // Not possible with wayland
         None
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         // Not possible with wayland
         None
     }
 
     #[inline]
-    pub fn set_position(&self, _x: i32, _y: i32) {
+    pub fn set_position(&self, _pos: LogicalPosition) {
         // Not possible with wayland
     }
 
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
-        Some(self.size.lock().unwrap().clone())
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
+        Some(self.size.lock().unwrap().clone().into())
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         let (w, h) = self.size.lock().unwrap().clone();
         // let (w, h) = super::wayland_window::add_borders(w as i32, h as i32);
-        Some((w as u32, h as u32))
+        Some((w, h).into())
     }
 
     #[inline]
     // NOTE: This will only resize the borders, the contents must be updated by the user
-    pub fn set_inner_size(&self, x: u32, y: u32) {
-        self.frame.lock().unwrap().resize(x, y);
-        *(self.size.lock().unwrap()) = (x, y);
+    pub fn set_inner_size(&self, size: LogicalSize) {
+        let (w, h) = size.into();
+        self.frame.lock().unwrap().resize(w, h);
+        *(self.size.lock().unwrap()) = (w, h);
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        self.frame.lock().unwrap().set_min_size(dimensions);
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
+        self.frame.lock().unwrap().set_min_size(dimensions.map(Into::into));
     }
 
     #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        self.frame.lock().unwrap().set_max_size(dimensions);
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
+        self.frame.lock().unwrap().set_max_size(dimensions.map(Into::into));
     }
 
     #[inline]
@@ -225,14 +246,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
-        let mut factor: f32 = 1.0;
-        let guard = self.monitors.lock().unwrap();
-        for monitor_id in guard.iter() {
-            let hidpif = monitor_id.get_hidpi_factor();
-            factor = factor.max(hidpif);
-        }
-        factor
+    pub fn hidpi_factor(&self) -> i32 {
+        self.monitors.lock().unwrap().compute_hidpi_factor()
     }
 
     pub fn set_decorations(&self, decorate: bool) {
@@ -263,7 +278,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _x: i32, _y: i32) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, _pos: LogicalPosition) -> Result<(), ()> {
         // TODO: not yet possible on wayland
         Err(())
     }
@@ -280,7 +295,7 @@ impl Window {
         // we don't know how much each monitor sees us so...
         // just return the most recent one ?
         let guard = self.monitors.lock().unwrap();
-        guard.last().unwrap().clone()
+        guard.monitors.last().unwrap().clone()
     }
 }
 
@@ -297,12 +312,15 @@ impl Drop for Window {
 
 struct InternalWindow {
     surface: Proxy<wl_surface::WlSurface>,
-    newsize: Option<(i32, i32)>,
+    newsize: Option<(u32, u32)>,
+    size: Arc<Mutex<(u32, u32)>>,
     need_refresh: bool,
     need_frame_refresh: Arc<Mutex<bool>>,
     closed: bool,
     kill_switch: Arc<Mutex<bool>>,
     frame: Weak<Mutex<SWindow<BasicFrame>>>,
+    current_dpi: i32,
+    new_dpi: Option<i32>
 }
 
 pub struct WindowStore {
@@ -348,24 +366,84 @@ impl WindowStore {
         }
     }
 
+    fn dpi_change(&mut self, surface: &Proxy<wl_surface::WlSurface>, new: i32) {
+        for window in &mut self.windows {
+            if surface.equals(&window.surface) {
+                window.new_dpi = Some(new);
+            }
+        }
+    }
+
     pub fn for_each<F>(&mut self, mut f: F)
     where
-        F: FnMut(Option<(i32, i32)>, bool, bool, bool, WindowId, Option<&mut SWindow<BasicFrame>>),
+        F: FnMut(Option<(u32, u32)>, &mut (u32, u32), Option<i32>, bool, bool, bool, WindowId, Option<&mut SWindow<BasicFrame>>),
     {
         for window in &mut self.windows {
             let opt_arc = window.frame.upgrade();
             let mut opt_mutex_lock = opt_arc.as_ref().map(|m| m.lock().unwrap());
             f(
                 window.newsize.take(),
+                &mut *(window.size.lock().unwrap()),
+                window.new_dpi,
                 window.need_refresh,
                 ::std::mem::replace(&mut *window.need_frame_refresh.lock().unwrap(), false),
                 window.closed,
                 make_wid(&window.surface),
                 opt_mutex_lock.as_mut().map(|m| &mut **m),
             );
+            if let Some(dpi) = window.new_dpi.take() {
+                window.current_dpi = dpi;
+            }
             window.need_refresh = false;
             // avoid re-spamming the event
             window.closed = false;
+        }
+    }
+}
+
+/*
+ * Monitor list with some covenience method to compute DPI
+ */
+
+struct MonitorList {
+    monitors: Vec<MonitorId>
+}
+
+impl MonitorList {
+    fn new() -> MonitorList {
+        MonitorList {
+            monitors: Vec::new()
+        }
+    }
+
+    fn compute_hidpi_factor(&self) -> i32 {
+        let mut factor = 1;
+        for monitor_id in &self.monitors {
+            let monitor_dpi = monitor_id.get_hidpi_factor();
+            if monitor_dpi > factor { factor = monitor_dpi; }
+        }
+        factor
+    }
+
+    fn add_output(&mut self, monitor: MonitorId) -> Option<i32> {
+        let old_dpi = self.compute_hidpi_factor();
+        let monitor_dpi = monitor.get_hidpi_factor();
+        self.monitors.push(monitor);
+        if monitor_dpi > old_dpi {
+            Some(monitor_dpi)
+        } else {
+            None
+        }
+    }
+
+    fn del_output(&mut self, output: &Proxy<wl_output::WlOutput>) -> Option<i32> {
+        let old_dpi = self.compute_hidpi_factor();
+        self.monitors.retain(|m| !m.proxy.equals(output));
+        let new_dpi = self.compute_hidpi_factor();
+        if new_dpi != old_dpi {
+            Some(new_dpi)
+        } else {
+            None
         }
     }
 }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, Weak};
 
-use {CreationError, CursorState, MouseCursor, WindowAttributes, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use {CreationError, CursorState, MouseCursor, WindowAttributes, LogicalPosition, LogicalSize};
 use platform::MonitorId as PlatformMonitorId;
 use window::MonitorId as RootMonitorId;
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -31,8 +31,8 @@ use {
     Event,
     EventsLoopClosed,
     KeyboardInput,
-    LogicalCoordinates,
-    LogicalDimensions,
+    LogicalPosition,
+    LogicalSize,
     WindowAttributes,
     WindowEvent,
 };
@@ -457,7 +457,7 @@ impl EventsLoop {
                     let mut events = Events::default();
 
                     if resized {
-                        let logical_size = LogicalDimensions::from_physical(new_inner_size, monitor.hidpi_factor);
+                        let logical_size = LogicalSize::from_physical(new_inner_size, monitor.hidpi_factor);
                         events.resized = Some(WindowEvent::Resized(logical_size));
                     }
 
@@ -474,7 +474,7 @@ impl EventsLoop {
                         let outer = frame_extents.inner_pos_to_outer(new_inner_position.0, new_inner_position.1);
                         shared_state_lock.position = Some(outer);
                         if moved {
-                            let logical_position = LogicalCoordinates::from_physical(outer, monitor.hidpi_factor);
+                            let logical_position = LogicalPosition::from_physical(outer, monitor.hidpi_factor);
                             events.moved = Some(WindowEvent::Moved(logical_position));
                         }
                         outer

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -9,13 +9,7 @@ mod dnd;
 mod ime;
 pub mod util;
 
-pub use self::monitor::{
-    MonitorId,
-    get_available_monitors,
-    get_monitor_for_window,
-    get_primary_monitor,
-    invalidate_cached_monitor_list,
-};
+pub use self::monitor::MonitorId;
 pub use self::window::UnownedWindow;
 pub use self::xdisplay::{XConnection, XNotSupported, XError};
 
@@ -29,7 +23,6 @@ use std::sync::{Arc, mpsc, Weak};
 use std::sync::atomic::{self, AtomicBool};
 
 use libc::{self, setlocale, LC_CTYPE};
-use parking_lot::Mutex;
 
 use {
     ControlFlow,
@@ -38,6 +31,8 @@ use {
     Event,
     EventsLoopClosed,
     KeyboardInput,
+    LogicalCoordinates,
+    LogicalDimensions,
     WindowAttributes,
     WindowEvent,
 };
@@ -92,7 +87,7 @@ impl EventsLoop {
             result.expect("Failed to set input method destruction callback")
         });
 
-        let randr_event_offset = monitor::select_input(&xconn, root)
+        let randr_event_offset = xconn.select_xrandr_input(root)
             .expect("Failed to query XRandR extension");
 
         let xi2ext = unsafe {
@@ -394,6 +389,13 @@ impl EventsLoop {
             }
 
             ffi::ConfigureNotify => {
+                #[derive(Debug, Default)]
+                struct Events {
+                    resized: Option<WindowEvent>,
+                    moved: Option<WindowEvent>,
+                    dpi_changed: Option<WindowEvent>,
+                }
+
                 let xev: &ffi::XConfigureEvent = xev.as_ref();
                 let xwindow = xev.window;
                 let events = self.with_window(xwindow, |window| {
@@ -406,9 +408,11 @@ impl EventsLoop {
                     // that has a position relative to the parent window.
                     let is_synthetic = xev.send_event == ffi::True;
 
+                    // These are both in physical space.
                     let new_inner_size = (xev.width as u32, xev.height as u32);
                     let new_inner_position = (xev.x as i32, xev.y as i32);
 
+                    let monitor = window.get_current_monitor(); // This must be done *before* locking!
                     let mut shared_state_lock = window.shared_state.lock();
 
                     let (resized, moved) = {
@@ -431,14 +435,33 @@ impl EventsLoop {
                         (resized, moved)
                     };
 
-                    let capacity = resized as usize + moved as usize;
-                    let mut events = Vec::with_capacity(capacity);
-
-                    if resized {
-                        events.push(WindowEvent::Resized(new_inner_size.0, new_inner_size.1));
+                    // This is a hack to ensure that the DPI adjusted resize is actually applied on all WMs. KWin
+                    // doesn't need this, but Xfwm does.
+                    if let Some(adjusted_size) = shared_state_lock.dpi_adjusted {
+                        let rounded_size = (adjusted_size.0.round() as u32, adjusted_size.1.round() as u32);
+                        if new_inner_size == rounded_size {
+                            // When this finally happens, the event will not be synthetic.
+                            shared_state_lock.dpi_adjusted = None;
+                        } else {
+                            unsafe {
+                                (self.xconn.xlib.XResizeWindow)(
+                                    self.xconn.display,
+                                    xwindow,
+                                    rounded_size.0 as c_uint,
+                                    rounded_size.1 as c_uint,
+                                );
+                            }
+                        }
                     }
 
-                    if moved || shared_state_lock.position.is_none() {
+                    let mut events = Events::default();
+
+                    if resized {
+                        let logical_size = LogicalDimensions::from_physical(new_inner_size, monitor.hidpi_factor);
+                        events.resized = Some(WindowEvent::Resized(logical_size));
+                    }
+
+                    let new_outer_position = if moved || shared_state_lock.position.is_none() {
                         // We need to convert client area position to window position.
                         let frame_extents = shared_state_lock.frame_extents
                             .as_ref()
@@ -451,19 +474,59 @@ impl EventsLoop {
                         let outer = frame_extents.inner_pos_to_outer(new_inner_position.0, new_inner_position.1);
                         shared_state_lock.position = Some(outer);
                         if moved {
-                            events.push(WindowEvent::Moved(outer.0, outer.1));
+                            let logical_position = LogicalCoordinates::from_physical(outer, monitor.hidpi_factor);
+                            events.moved = Some(WindowEvent::Moved(logical_position));
                         }
+                        outer
+                    } else {
+                        shared_state_lock.position.unwrap()
+                    };
+
+                    // If we don't use the existing adjusted value when available, then the user can screw up the
+                    // resizing by dragging across monitors *without* dropping the window.
+                    let (width, height) = shared_state_lock.dpi_adjusted
+                        .unwrap_or_else(|| (xev.width as f64, xev.height as f64));
+                    let last_hidpi_factor = if shared_state_lock.is_new_window {
+                        shared_state_lock.is_new_window = false;
+                        1.0
+                    } else {
+                        shared_state_lock.last_monitor
+                            .as_ref()
+                            .map(|last_monitor| last_monitor.hidpi_factor)
+                            .unwrap_or(1.0)
+                    };
+                    let new_hidpi_factor = {
+                        let window_rect = util::Rect::new(new_outer_position, new_inner_size);
+                        let monitor = self.xconn.get_monitor_for_window(Some(window_rect));
+                        let new_hidpi_factor = monitor.hidpi_factor;
+                        shared_state_lock.last_monitor = Some(monitor);
+                        new_hidpi_factor
+                    };
+                    if last_hidpi_factor != new_hidpi_factor {
+                        events.dpi_changed = Some(WindowEvent::HiDpiFactorChanged(new_hidpi_factor));
+                        let (new_width, new_height, flusher) = window.adjust_for_dpi(
+                            last_hidpi_factor,
+                            new_hidpi_factor,
+                            width,
+                            height,
+                        );
+                        flusher.queue();
+                        shared_state_lock.dpi_adjusted = Some((new_width, new_height));
                     }
 
                     events
                 });
 
                 if let Some(events) = events {
-                    for event in events {
-                        callback(Event::WindowEvent {
-                            window_id: mkwid(xwindow),
-                            event,
-                        });
+                    let window_id = mkwid(xwindow);
+                    if let Some(event) = events.resized {
+                        callback(Event::WindowEvent { window_id, event });
+                    }
+                    if let Some(event) = events.moved {
+                        callback(Event::WindowEvent { window_id, event });
+                    }
+                    if let Some(event) = events.dpi_changed {
+                        callback(Event::WindowEvent { window_id, event });
                     }
                 }
             }
@@ -986,7 +1049,44 @@ impl EventsLoop {
             _ => {
                 if event_type == self.randr_event_offset {
                     // In the future, it would be quite easy to emit monitor hotplug events.
-                    monitor::invalidate_cached_monitor_list();
+                    let prev_list = monitor::invalidate_cached_monitor_list();
+                    if let Some(prev_list) = prev_list {
+                        let new_list = self.xconn.get_available_monitors();
+                        for new_monitor in new_list {
+                            prev_list
+                                .iter()
+                                .find(|prev_monitor| prev_monitor.name == new_monitor.name)
+                                .map(|prev_monitor| {
+                                    if new_monitor.hidpi_factor != prev_monitor.hidpi_factor {
+                                        for (window_id, window) in self.windows.borrow().iter() {
+                                            if let Some(window) = window.upgrade() {
+                                                // Check if the window is on this monitor
+                                                let monitor = window.get_current_monitor();
+                                                if monitor.name == new_monitor.name {
+                                                    callback(Event::WindowEvent {
+                                                        window_id: mkwid(window_id.0),
+                                                        event: WindowEvent::HiDpiFactorChanged(
+                                                            new_monitor.hidpi_factor
+                                                        ),
+                                                    });
+                                                    let (width, height) = match window.get_inner_size_physical() {
+                                                        Some(result) => result,
+                                                        None => continue,
+                                                    };
+                                                    let (_, _, flusher) = window.adjust_for_dpi(
+                                                        prev_monitor.hidpi_factor,
+                                                        new_monitor.hidpi_factor,
+                                                        width as f64,
+                                                        height as f64,
+                                                    );
+                                                    flusher.queue();
+                                                }
+                                            }
+                                        }
+                                    }
+                                });
+                        }
+                    }
                 }
             },
         }
@@ -1110,16 +1210,13 @@ pub struct WindowId(ffi::Window);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(c_int);
 
-pub struct Window {
-    pub window: Arc<UnownedWindow>,
-    ime_sender: Mutex<ImeSender>,
-}
+pub struct Window(Arc<UnownedWindow>);
 
 impl Deref for Window {
     type Target = UnownedWindow;
     #[inline]
     fn deref(&self) -> &UnownedWindow {
-        &*self.window
+        &*self.0
     }
 }
 
@@ -1130,35 +1227,19 @@ impl Window {
         pl_attribs: PlatformSpecificWindowBuilderAttributes
     ) -> Result<Self, CreationError> {
         let window = Arc::new(UnownedWindow::new(&event_loop, attribs, pl_attribs)?);
-
         event_loop.windows
             .borrow_mut()
             .insert(window.id(), Arc::downgrade(&window));
-
-        event_loop.ime
-            .borrow_mut()
-            .create_context(window.id().0)
-            .expect("Failed to create input context");
-
-        Ok(Window {
-            window,
-            ime_sender: Mutex::new(event_loop.ime_sender.clone()),
-        })
-    }
-
-    #[inline]
-    pub fn send_xim_spot(&self, x: i16, y: i16) {
-        let _ = self.ime_sender
-            .lock()
-            .send((self.window.id().0, x, y));
+        Ok(Window(window))
     }
 }
 
 impl Drop for Window {
     fn drop(&mut self) {
-        let xconn = &self.window.xconn;
+        let window = self.deref();
+        let xconn = &window.xconn;
         unsafe {
-            (xconn.xlib.XDestroyWindow)(xconn.display, self.window.id().0);
+            (xconn.xlib.XDestroyWindow)(xconn.display, window.id().0);
             // If the window was somehow already destroyed, we'll get a `BadWindow` error, which we don't care about.
             let _ = xconn.check_errors();
         }

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -2,6 +2,8 @@ use std::os::raw::*;
 
 use parking_lot::Mutex;
 
+use {PhysicalPosition, PhysicalSize};
+use super::{util, XConnection, XError};
 use super::ffi::{
     RRCrtcChangeNotifyMask,
     RROutputPropertyNotifyMask,
@@ -10,7 +12,6 @@ use super::ffi::{
     Window,
     XRRScreenResources,
 };
-use super::{util, XConnection, XError};
 
 // Used to test XRandR < 1.5 code path. This should always be committed as false.
 const FORCE_RANDR_COMPAT: bool = false;
@@ -88,17 +89,17 @@ impl MonitorId {
         self.id as u32
     }
 
-    pub fn get_dimensions(&self) -> (u32, u32) {
-        self.dimensions
+    pub fn get_dimensions(&self) -> PhysicalSize {
+        self.dimensions.into()
     }
 
-    pub fn get_position(&self) -> (i32, i32) {
-        self.position
+    pub fn get_position(&self) -> PhysicalPosition {
+        self.position.into()
     }
 
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
-        self.hidpi_factor as f32
+    pub fn get_hidpi_factor(&self) -> f64 {
+        self.hidpi_factor
     }
 }
 

--- a/src/platform/linux/x11/util/geometry.rs
+++ b/src/platform/linux/x11/util/geometry.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use super::*;
-use {LogicalCoordinates, LogicalDimensions};
+use {LogicalPosition, LogicalSize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rect {
@@ -122,7 +122,7 @@ impl FrameExtentsHeuristic {
         }
     }
 
-    pub fn inner_pos_to_outer_logical(&self, mut logical: LogicalCoordinates, factor: f64) -> LogicalCoordinates {
+    pub fn inner_pos_to_outer_logical(&self, mut logical: LogicalPosition, factor: f64) -> LogicalPosition {
         use self::FrameExtentsHeuristicPath::*;
         if self.heuristic_path != UnsupportedBordered {
             let frame_extents = self.frame_extents.as_logical(factor);
@@ -143,7 +143,7 @@ impl FrameExtentsHeuristic {
         )
     }
 
-    pub fn inner_size_to_outer_logical(&self, mut logical: LogicalDimensions, factor: f64) -> LogicalDimensions {
+    pub fn inner_size_to_outer_logical(&self, mut logical: LogicalSize, factor: f64) -> LogicalSize {
         let frame_extents = self.frame_extents.as_logical(factor);
         logical.width += frame_extents.left + frame_extents.right;
         logical.height += frame_extents.top + frame_extents.bottom;

--- a/src/platform/linux/x11/util/mod.rs
+++ b/src/platform/linux/x11/util/mod.rs
@@ -27,9 +27,15 @@ pub use self::wm::*;
 
 use std::mem;
 use std::ptr;
+use std::ops::BitAnd;
 use std::os::raw::*;
 
 use super::{ffi, XConnection, XError};
+
+pub fn reinterpret<'a, A, B>(a: &'a A) -> &'a B {
+    let b_ptr = a as *const _ as *const B;
+    unsafe { &*b_ptr }
+}
 
 pub fn maybe_change<T: PartialEq>(field: &mut Option<T>, value: T) -> bool {
     let wrapped = Some(value);
@@ -39,6 +45,13 @@ pub fn maybe_change<T: PartialEq>(field: &mut Option<T>, value: T) -> bool {
     } else {
         false
     }
+}
+
+pub fn has_flag<T>(bitset: T, flag: T) -> bool
+where T:
+    Copy + PartialEq + BitAnd<T, Output = T>
+{
+    bitset & flag == flag
 }
 
 #[must_use = "This request was made asynchronously, and is still in the output buffer. You must explicitly choose to either `.flush()` (empty the output buffer, sending the request now) or `.queue()` (wait to send the request, allowing you to continue to add more requests without additional round-trips). For more information, see the documentation for `util::flush_requests`."]

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -2,20 +2,40 @@ use std::{env, slice};
 use std::str::FromStr;
 
 use super::*;
-use super::ffi::{
-    RROutput,
-    XRRCrtcInfo,
-    XRRMonitorInfo,
-    XRRScreenResources,
-};
+
+pub fn calc_dpi_factor(
+    (width_px, height_px): (u32, u32),
+    (width_mm, height_mm): (u64, u64),
+) -> f64 {
+    // Override DPI if `WINIT_HIDPI_FACTOR` variable is set.
+    if let Ok(dpi_factor_str) = env::var("WINIT_HIDPI_FACTOR") {
+        if let Ok(dpi_factor) = f64::from_str(&dpi_factor_str) {
+            if dpi_factor <= 0. {
+                panic!("Expected `WINIT_HIDPI_FACTOR` to be bigger than 0, got '{}'", dpi_factor);
+            }
+            return dpi_factor;
+        }
+    }
+
+    // See http://xpra.org/trac/ticket/728 for more information.
+    if width_mm == 0 || width_mm == 0 {
+        return 1.0;
+    }
+
+    let ppmm = (
+        (width_px as f64 * height_px as f64) / (width_mm as f64 * height_mm as f64)
+    ).sqrt();
+    // Quantize 1/12 step size
+    ((ppmm * (12.0 * 25.4 / 96.0)).round() / 12.0).max(1.0)
+}
 
 pub enum MonitorRepr {
-    Monitor(*mut XRRMonitorInfo),
-    Crtc(*mut XRRCrtcInfo),
+    Monitor(*mut ffi::XRRMonitorInfo),
+    Crtc(*mut ffi::XRRCrtcInfo),
 }
 
 impl MonitorRepr {
-    pub unsafe fn get_output(&self) -> RROutput {
+    pub unsafe fn get_output(&self) -> ffi::RROutput {
         match *self {
             // Same member names, but different locations within the struct...
             MonitorRepr::Monitor(monitor) => *((*monitor).outputs.offset(0)),
@@ -38,47 +58,20 @@ impl MonitorRepr {
     }
 }
 
-impl From<*mut XRRMonitorInfo> for MonitorRepr {
-    fn from(monitor: *mut XRRMonitorInfo) -> Self {
+impl From<*mut ffi::XRRMonitorInfo> for MonitorRepr {
+    fn from(monitor: *mut ffi::XRRMonitorInfo) -> Self {
         MonitorRepr::Monitor(monitor)
     }
 }
 
-impl From<*mut XRRCrtcInfo> for MonitorRepr {
-    fn from(crtc: *mut XRRCrtcInfo) -> Self {
+impl From<*mut ffi::XRRCrtcInfo> for MonitorRepr {
+    fn from(crtc: *mut ffi::XRRCrtcInfo) -> Self {
         MonitorRepr::Crtc(crtc)
     }
 }
 
-pub fn calc_dpi_factor(
-    (width_px, height_px): (u32, u32),
-    (width_mm, height_mm): (u64, u64),
-) -> f64 {
-    // Override DPI if `WINIT_HIDPI_FACTOR` variable is set
-    if let Ok(dpi_factor_str) = env::var("WINIT_HIDPI_FACTOR") {
-        if let Ok(dpi_factor) = f64::from_str(&dpi_factor_str) {
-            if dpi_factor <= 0. {
-                panic!("Expected `WINIT_HIDPI_FACTOR` to be bigger than 0, got '{}'", dpi_factor);
-            }
-
-            return dpi_factor;
-        }
-    }
-
-    // See http://xpra.org/trac/ticket/728 for more information
-    if width_mm == 0 || width_mm == 0 {
-        return 1.0;
-    }
-
-    let ppmm = (
-        (width_px as f64 * height_px as f64) / (width_mm as f64 * height_mm as f64)
-    ).sqrt();
-    // Quantize 1/12 step size
-    ((ppmm * (12.0 * 25.4 / 96.0)).round() / 12.0).max(1.0)
-}
-
 impl XConnection {
-    pub unsafe fn get_output_info(&self, resources: *mut XRRScreenResources, repr: &MonitorRepr) -> (String, f32) {
+    pub unsafe fn get_output_info(&self, resources: *mut ffi::XRRScreenResources, repr: &MonitorRepr) -> (String, f64) {
         let output_info = (self.xrandr.XRRGetOutputInfo)(
             self.display,
             resources,
@@ -92,7 +85,7 @@ impl XConnection {
         let hidpi_factor = calc_dpi_factor(
             repr.get_dimensions(),
             ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
-        ) as f32;
+        );
         (self.xrandr.XRRFreeOutputInfo)(output_info);
         (name, hidpi_factor)
     }

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -798,12 +798,12 @@ impl UnownedWindow {
 
     pub(crate) fn adjust_for_dpi(
         &self,
-        old_dpi: f64,
-        new_dpi: f64,
+        old_dpi_factor: f64,
+        new_dpi_factor: f64,
         width: f64,
         height: f64,
     ) -> (f64, f64, util::Flusher) {
-        let scale_factor = new_dpi / old_dpi;
+        let scale_factor = new_dpi_factor / old_dpi_factor;
         let new_width = width * scale_factor;
         let new_height = height * scale_factor;
         self.update_normal_hints(|normal_hints| {

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -7,15 +7,14 @@ use std::sync::Arc;
 use libc;
 use parking_lot::Mutex;
 
-use {CursorState, Icon, MouseCursor, WindowAttributes};
+use {CursorState, Icon, LogicalCoordinates, LogicalDimensions, MouseCursor, WindowAttributes};
 use CreationError::{self, OsError};
 use platform::MonitorId as PlatformMonitorId;
 use platform::PlatformSpecificWindowBuilderAttributes;
 use platform::x11::MonitorId as X11MonitorId;
-use platform::x11::monitor::get_monitor_for_window;
 use window::MonitorId as RootMonitorId;
 
-use super::{ffi, util, XConnection, XError, WindowId, EventsLoop};
+use super::{ffi, util, ImeSender, XConnection, XError, WindowId, EventsLoop};
 
 unsafe extern "C" fn visibility_predicate(
     _display: *mut ffi::Display,
@@ -29,7 +28,8 @@ unsafe extern "C" fn visibility_predicate(
 
 #[derive(Debug, Default)]
 pub struct SharedState {
-    pub multitouch: bool,
+    // Window creation assumes a DPI factor of 1.0, so we use this flag to handle that special case.
+    pub is_new_window: bool,
     pub cursor_pos: Option<(f64, f64)>,
     pub size: Option<(u32, u32)>,
     pub position: Option<(i32, i32)>,
@@ -37,9 +37,19 @@ pub struct SharedState {
     pub inner_position_rel_parent: Option<(i32, i32)>,
     pub last_monitor: Option<X11MonitorId>,
     pub dpi_adjusted: Option<(f64, f64)>,
+    // Used to restore position after exiting fullscreen.
+    pub restore_position: Option<(i32, i32)>,
     pub frame_extents: Option<util::FrameExtentsHeuristic>,
-    pub min_dimensions: Option<(u32, u32)>,
-    pub max_dimensions: Option<(u32, u32)>,
+    pub min_dimensions: Option<LogicalDimensions>,
+    pub max_dimensions: Option<LogicalDimensions>,
+}
+
+impl SharedState {
+    fn new() -> Mutex<Self> {
+        let mut shared_state = SharedState::default();
+        shared_state.is_new_window = true;
+        Mutex::new(shared_state)
+    }
 }
 
 unsafe impl Send for UnownedWindow {}
@@ -52,6 +62,7 @@ pub struct UnownedWindow {
     screen_id: i32, // never changes
     cursor: Mutex<MouseCursor>,
     cursor_state: Mutex<CursorState>,
+    ime_sender: Mutex<ImeSender>,
     pub multitouch: bool, // never changes
     pub shared_state: Mutex<SharedState>,
 }
@@ -145,8 +156,9 @@ impl UnownedWindow {
             screen_id,
             cursor: Default::default(),
             cursor_state: Default::default(),
+            ime_sender: Mutex::new(event_loop.ime_sender.clone()),
             multitouch: window_attrs.multitouch,
-            shared_state: Default::default(),
+            shared_state: SharedState::new(),
         };
 
         // Title must be set before mapping. Some tiling window managers (i.e. i3) use the window
@@ -218,46 +230,26 @@ impl UnownedWindow {
 
             // set size hints
             {
-                (*window.shared_state.lock()).min_dimensions = window_attrs.min_dimensions;
-                (*window.shared_state.lock()).max_dimensions = window_attrs.max_dimensions;
                 let mut min_dimensions = window_attrs.min_dimensions;
                 let mut max_dimensions = window_attrs.max_dimensions;
                 if !window_attrs.resizable && !util::wm_name_is_one_of(&["Xfwm4"]) {
                     max_dimensions = Some(dimensions);
                     min_dimensions = Some(dimensions);
+
+                    let mut shared_state_lock = window.shared_state.lock();
+                    shared_state_lock.min_dimensions = window_attrs.min_dimensions
+                        .map(|s| LogicalDimensions::new(s.0 as _, s.1 as _));
+                    shared_state_lock.max_dimensions = window_attrs.max_dimensions
+                        .map(|s| LogicalDimensions::new(s.0 as _, s.1 as _));
                 }
 
-                let mut size_hints = xconn.alloc_size_hints();
-                (*size_hints).flags = ffi::PSize;
-                (*size_hints).width = dimensions.0 as c_int;
-                (*size_hints).height = dimensions.1 as c_int;
-                if let Some((min_width, min_height)) = min_dimensions {
-                    (*size_hints).flags |= ffi::PMinSize;
-                    (*size_hints).min_width = min_width as c_int;
-                    (*size_hints).min_height = min_height as c_int;
-                }
-                if let Some((max_width, max_height)) = max_dimensions {
-                    (*size_hints).flags |= ffi::PMaxSize;
-                    (*size_hints).max_width = max_width as c_int;
-                    (*size_hints).max_height = max_height as c_int;
-                }
-                if let Some((width_inc, height_inc)) = pl_attribs.resize_increments {
-                    (*size_hints).flags |= ffi::PResizeInc;
-                    (*size_hints).width_inc = width_inc as c_int;
-                    (*size_hints).height_inc = height_inc as c_int;
-                }
-                if let Some((base_width, base_height)) = pl_attribs.base_size {
-                    (*size_hints).flags |= ffi::PBaseSize;
-                    (*size_hints).base_width = base_width as c_int;
-                    (*size_hints).base_height = base_height as c_int;
-                }
-                unsafe {
-                    (xconn.xlib.XSetWMNormalHints)(
-                        xconn.display,
-                        window.xwindow,
-                        size_hints.ptr,
-                    );
-                }//.queue();
+                let mut normal_hints = util::NormalHints::new(xconn);
+                normal_hints.set_size(Some(dimensions));
+                normal_hints.set_min_size(min_dimensions);
+                normal_hints.set_max_size(max_dimensions);
+                normal_hints.set_resize_increments(pl_attribs.resize_increments);
+                normal_hints.set_base_size(pl_attribs.base_size);
+                xconn.set_normal_hints(window.xwindow, normal_hints).queue();
             }
 
             // Set window icons
@@ -291,7 +283,7 @@ impl UnownedWindow {
                     &mut supported_ptr,
                 );
                 if supported_ptr == ffi::False {
-                    return Err(OsError(format!("XkbSetDetectableAutoRepeat failed")));
+                    return Err(OsError(format!("`XkbSetDetectableAutoRepeat` failed")));
                 }
             }
 
@@ -314,6 +306,15 @@ impl UnownedWindow {
                 mask
             };
             xconn.select_xinput_events(window.xwindow, ffi::XIAllMasterDevices, mask).queue();
+
+            {
+                let result = event_loop.ime
+                    .borrow_mut()
+                    .create_context(window.xwindow);
+                if let Err(err) = result {
+                    return Err(OsError(format!("Failed to create input context: {:?}", err)));
+                }
+            }
 
             // These properties must be set after mapping
             if window_attrs.maximized {
@@ -353,6 +354,16 @@ impl UnownedWindow {
             .map_err(|x_err| OsError(
                 format!("X server returned error while building window: {:?}", x_err)
             ))
+    }
+
+    fn logicalize_coords(&self, (x, y): (i32, i32)) -> LogicalCoordinates {
+        let dpi = self.get_hidpi_factor();
+        LogicalCoordinates::from_physical((x, y), dpi)
+    }
+
+    fn logicalize_size(&self, (width, height): (u32, u32)) -> LogicalDimensions {
+        let dpi = self.get_hidpi_factor();
+        LogicalDimensions::from_physical((width, height), dpi)
     }
 
     fn set_pid(&self) -> Option<util::Flusher> {
@@ -400,6 +411,7 @@ impl UnownedWindow {
         )
     }
 
+    #[inline]
     pub fn set_urgent(&self, is_urgent: bool) {
         let mut wm_hints = self.xconn.get_wm_hints(self.xwindow).expect("`XGetWMHints` failed");
         if is_urgent {
@@ -439,17 +451,24 @@ impl UnownedWindow {
     fn set_fullscreen_inner(&self, monitor: Option<RootMonitorId>) -> util::Flusher {
         match monitor {
             None => {
-                self.set_fullscreen_hint(false)
+                let flusher = self.set_fullscreen_hint(false);
+                if let Some(position) = self.shared_state.lock().restore_position.take() {
+                    self.set_position_inner(position.0, position.1).queue();
+                }
+                flusher
             },
             Some(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
-                let screenpos = monitor.get_position();
-                self.set_position(screenpos.0 as i32, screenpos.1 as i32);
+                let window_position = self.get_position_physical();
+                self.shared_state.lock().restore_position = window_position;
+                let monitor_origin = monitor.get_position();
+                self.set_position_inner(monitor_origin.0 as i32, monitor_origin.1 as i32).queue();
                 self.set_fullscreen_hint(true)
             }
             _ => unreachable!(),
         }
     }
 
+    #[inline]
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         self.set_fullscreen_inner(monitor)
             .flush()
@@ -459,15 +478,26 @@ impl UnownedWindow {
 
     fn get_rect(&self) -> Option<util::Rect> {
         // TODO: This might round-trip more times than needed.
-        if let (Some(position), Some(size)) = (self.get_position(), self.get_outer_size()) {
+        if let (Some(position), Some(size)) = (self.get_position_physical(), self.get_outer_size_physical()) {
             Some(util::Rect::new(position, size))
         } else {
             None
         }
     }
 
+    #[inline]
     pub fn get_current_monitor(&self) -> X11MonitorId {
-        get_monitor_for_window(&self.xconn, self.get_rect()).to_owned()
+        let monitor = self.shared_state
+            .lock()
+            .last_monitor
+            .as_ref()
+            .cloned();
+        monitor
+            .unwrap_or_else(|| {
+                let monitor = self.xconn.get_monitor_for_window(self.get_rect()).to_owned();
+                self.shared_state.lock().last_monitor = Some(monitor.clone());
+                monitor
+            })
     }
 
     fn set_maximized_inner(&self, maximized: bool) -> util::Flusher {
@@ -476,6 +506,7 @@ impl UnownedWindow {
         self.set_netwm(maximized.into(), (horz_atom as c_long, vert_atom as c_long, 0, 0))
     }
 
+    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         self.set_maximized_inner(maximized)
             .flush()
@@ -503,6 +534,7 @@ impl UnownedWindow {
         }
     }
 
+    #[inline]
     pub fn set_title(&self, title: &str) {
         self.set_title_inner(title)
             .flush()
@@ -526,6 +558,7 @@ impl UnownedWindow {
         )
     }
 
+    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         self.set_decorations_inner(decorations)
             .flush()
@@ -538,6 +571,7 @@ impl UnownedWindow {
         self.set_netwm(always_on_top.into(), (above_atom as c_long, 0, 0, 0))
     }
 
+    #[inline]
     pub fn set_always_on_top(&self, always_on_top: bool) {
         self.set_always_on_top_inner(always_on_top)
             .flush()
@@ -568,6 +602,7 @@ impl UnownedWindow {
         )
     }
 
+    #[inline]
     pub fn set_window_icon(&self, icon: Option<Icon>) {
         match icon {
             Some(icon) => self.set_icon_inner(icon),
@@ -575,6 +610,7 @@ impl UnownedWindow {
         }.flush().expect("Failed to set icons");
     }
 
+    #[inline]
     pub fn show(&self) {
         unsafe {
             (self.xconn.xlib.XMapRaised)(self.xconn.display, self.xwindow);
@@ -583,6 +619,7 @@ impl UnownedWindow {
         }
     }
 
+    #[inline]
     pub fn hide(&self) {
         unsafe {
             (self.xconn.xlib.XUnmapWindow)(self.xconn.display, self.xwindow);
@@ -596,31 +633,46 @@ impl UnownedWindow {
         (*self.shared_state.lock()).frame_extents = Some(extents);
     }
 
-    pub fn invalidate_cached_frame_extents(&self) {
+    pub(crate) fn invalidate_cached_frame_extents(&self) {
         (*self.shared_state.lock()).frame_extents.take();
     }
 
-    #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub(crate) fn get_position_physical(&self) -> Option<(i32, i32)> {
         let extents = (*self.shared_state.lock()).frame_extents.clone();
         if let Some(extents) = extents {
-            self.get_inner_position().map(|(x, y)|
-                extents.inner_pos_to_outer(x, y)
-            )
+            self.get_inner_position_physical()
+                .map(|(x, y)| extents.inner_pos_to_outer(x, y))
+        } else {
+            self.update_cached_frame_extents();
+            self.get_position_physical()
+        }
+    }
+
+    #[inline]
+    pub fn get_position(&self) -> Option<LogicalCoordinates> {
+        let extents = (*self.shared_state.lock()).frame_extents.clone();
+        if let Some(extents) = extents {
+            self.get_inner_position()
+                .map(|logical| extents.inner_pos_to_outer_logical(logical, self.get_hidpi_factor()))
         } else {
             self.update_cached_frame_extents();
             self.get_position()
         }
     }
 
-    #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
-        self.xconn.translate_coords(self.xwindow, self.root )
+    pub(crate) fn get_inner_position_physical(&self) -> Option<(i32, i32)> {
+        self.xconn.translate_coords(self.xwindow, self.root)
             .ok()
             .map(|coords| (coords.x_rel_root, coords.y_rel_root))
     }
 
-    pub fn set_position(&self, mut x: i32, mut y: i32) {
+    #[inline]
+    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
+        self.get_inner_position_physical()
+            .map(|coords| self.logicalize_coords(coords))
+    }
+
+    pub fn set_position_inner(&self, mut x: i32, mut y: i32) -> util::Flusher {
         // There are a few WMs that set client area position rather than window position, so
         // we'll translate for consistency.
         if util::wm_name_is_one_of(&["Enlightenment", "FVWM"]) {
@@ -630,7 +682,7 @@ impl UnownedWindow {
                 y += extents.frame_extents.top as i32;
             } else {
                 self.update_cached_frame_extents();
-                self.set_position(x, y)
+                return self.set_position_inner(x, y);
             }
         }
         unsafe {
@@ -640,32 +692,58 @@ impl UnownedWindow {
                 x as c_int,
                 y as c_int,
             );
-            self.xconn.flush_requests()
-        }.expect("Failed to call XMoveWindow");
+        }
+        util::Flusher::new(&self.xconn)
+    }
+
+    pub fn set_position_physical(&self, x: i32, y: i32) {
+        self.set_position_inner(x, y)
+            .flush()
+            .expect("Failed to call `XMoveWindow`");
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+    pub fn set_position(&self, logical_position: LogicalCoordinates) {
+        let (x, y) = logical_position.to_physical(self.get_hidpi_factor()).into();
+        self.set_position_physical(x, y);
+    }
+
+    pub fn get_inner_size_physical(&self) -> Option<(u32, u32)> {
         self.xconn.get_geometry(self.xwindow)
             .ok()
             .map(|geo| (geo.width, geo.height))
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
-        let extents = (*self.shared_state.lock()).frame_extents.clone();
+    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
+        self.get_inner_size_physical()
+            .map(|size| self.logicalize_size(size))
+    }
+
+    pub fn get_outer_size_physical(&self) -> Option<(u32, u32)> {
+        let extents = self.shared_state.lock().frame_extents.clone();
         if let Some(extents) = extents {
-            self.get_inner_size().map(|(w, h)|
-                extents.inner_size_to_outer(w, h)
-            )
+            self.get_inner_size_physical()
+                .map(|(w, h)| extents.inner_size_to_outer(w, h))
+        } else {
+            self.update_cached_frame_extents();
+            self.get_outer_size_physical()
+        }
+    }
+
+    #[inline]
+    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
+        let extents = self.shared_state.lock().frame_extents.clone();
+        if let Some(extents) = extents {
+            self.get_inner_size()
+                .map(|logical| extents.inner_size_to_outer_logical(logical, self.get_hidpi_factor()))
         } else {
             self.update_cached_frame_extents();
             self.get_outer_size()
         }
     }
 
-    #[inline]
-    pub fn set_inner_size(&self, width: u32, height: u32) {
+    pub fn set_inner_size_physical(&self, width: u32, height: u32) {
         unsafe {
             (self.xconn.xlib.XResizeWindow)(
                 self.xconn.display,
@@ -674,62 +752,86 @@ impl UnownedWindow {
                 height as c_uint,
             );
             self.xconn.flush_requests()
-        }.expect("Failed to call XResizeWindow");
+        }.expect("Failed to call `XResizeWindow`");
     }
 
-    unsafe fn update_normal_hints<F>(&self, callback: F) -> Result<(), XError>
-        where F: FnOnce(*mut ffi::XSizeHints) -> ()
+    #[inline]
+    pub fn set_inner_size(&self, logical_size: LogicalDimensions) {
+        let dpi_factor = self.get_hidpi_factor();
+        let (width, height) = logical_size.to_physical(dpi_factor).into();
+        self.set_inner_size_physical(width, height);
+    }
+
+    fn update_normal_hints<F>(&self, callback: F) -> Result<(), XError>
+        where F: FnOnce(&mut util::NormalHints) -> ()
     {
-        let size_hints = self.xconn.alloc_size_hints();
-        let mut flags: c_long = mem::uninitialized();
-        (self.xconn.xlib.XGetWMNormalHints)(
-            self.xconn.display,
-            self.xwindow,
-            size_hints.ptr,
-            &mut flags,
-        );
-        self.xconn.check_errors()?;
-
-        callback(size_hints.ptr);
-
-        (self.xconn.xlib.XSetWMNormalHints)(
-            self.xconn.display,
-            self.xwindow,
-            size_hints.ptr,
-        );
-        self.xconn.flush_requests()?;
-
-        Ok(())
+        let mut normal_hints = self.xconn.get_normal_hints(self.xwindow)?;
+        callback(&mut normal_hints);
+        self.xconn.set_normal_hints(self.xwindow, normal_hints).flush()
     }
 
-    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        (*self.shared_state.lock()).min_dimensions = dimensions;
-        unsafe {
-            self.update_normal_hints(|size_hints| {
-                if let Some((width, height)) = dimensions {
-                    (*size_hints).flags |= ffi::PMinSize;
-                    (*size_hints).min_width = width as c_int;
-                    (*size_hints).min_height = height as c_int;
-                } else {
-                    (*size_hints).flags &= !ffi::PMinSize;
-                }
-            })
-        }.expect("Failed to call XSetWMNormalHints");
+    pub fn set_min_dimensions_physical(&self, dimensions: Option<(u32, u32)>) {
+        self.update_normal_hints(|normal_hints| normal_hints.set_min_size(dimensions))
+            .expect("Failed to call `XSetWMNormalHints`");
     }
 
-    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
-        (*self.shared_state.lock()).max_dimensions = dimensions;
+    #[inline]
+    pub fn set_min_dimensions(&self, logical_dimensions: Option<LogicalDimensions>) {
+        self.shared_state.lock().min_dimensions = logical_dimensions;
+        let physical_dimensions = logical_dimensions.map(|logical_dimensions| {
+            logical_dimensions.to_physical(self.get_hidpi_factor()).into()
+        });
+        self.set_min_dimensions_physical(physical_dimensions);
+    }
+
+    pub fn set_max_dimensions_physical(&self, dimensions: Option<(u32, u32)>) {
+        self.update_normal_hints(|normal_hints| normal_hints.set_max_size(dimensions))
+            .expect("Failed to call `XSetWMNormalHints`");
+    }
+
+    #[inline]
+    pub fn set_max_dimensions(&self, logical_dimensions: Option<LogicalDimensions>) {
+        self.shared_state.lock().max_dimensions = logical_dimensions;
+        let physical_dimensions = logical_dimensions.map(|logical_dimensions| {
+            logical_dimensions.to_physical(self.get_hidpi_factor()).into()
+        });
+        self.set_max_dimensions_physical(physical_dimensions);
+    }
+
+    pub(crate) fn adjust_for_dpi(
+        &self,
+        old_dpi: f64,
+        new_dpi: f64,
+        width: f64,
+        height: f64,
+    ) -> (f64, f64, util::Flusher) {
+        let scale_factor = new_dpi / old_dpi;
+        let new_width = width * scale_factor;
+        let new_height = height * scale_factor;
+        self.update_normal_hints(|normal_hints| {
+            let dpi_adjuster = |(width, height): (u32, u32)| -> (u32, u32) {
+                let new_width = width as f64 * scale_factor;
+                let new_height = height as f64 * scale_factor;
+                (new_width.round() as u32, new_height.round() as u32)
+            };
+            let max_size = normal_hints.get_max_size().map(dpi_adjuster);
+            let min_size = normal_hints.get_min_size().map(dpi_adjuster);
+            let resize_increments = normal_hints.get_resize_increments().map(dpi_adjuster);
+            let base_size = normal_hints.get_base_size().map(dpi_adjuster);
+            normal_hints.set_max_size(max_size);
+            normal_hints.set_min_size(min_size);
+            normal_hints.set_resize_increments(resize_increments);
+            normal_hints.set_base_size(base_size);
+        }).expect("Failed to update normal hints");
         unsafe {
-            self.update_normal_hints(|size_hints| {
-                if let Some((width, height)) = dimensions {
-                    (*size_hints).flags |= ffi::PMaxSize;
-                    (*size_hints).max_width = width as c_int;
-                    (*size_hints).max_height = height as c_int;
-                } else {
-                    (*size_hints).flags &= !ffi::PMaxSize;
-                }
-            })
-        }.expect("Failed to call XSetWMNormalHints");
+            (self.xconn.xlib.XResizeWindow)(
+                self.xconn.display,
+                self.xwindow,
+                new_width.round() as c_uint,
+                new_height.round() as c_uint,
+            );
+        }
+        (new_width, new_height, util::Flusher::new(&self.xconn))
     }
 
     pub fn set_resizable(&self, resizable: bool) {
@@ -739,24 +841,26 @@ impl UnownedWindow {
             // the lesser of two evils and do nothing.
             return;
         }
-        if resizable {
-            let min_dimensions = (*self.shared_state.lock()).min_dimensions;
-            let max_dimensions = (*self.shared_state.lock()).max_dimensions;
-            self.set_min_dimensions(min_dimensions);
-            self.set_max_dimensions(max_dimensions);
+
+        let (logical_min, logical_max) = if resizable {
+            let shared_state_lock = self.shared_state.lock();
+            (shared_state_lock.min_dimensions, shared_state_lock.max_dimensions)
         } else {
-            unsafe {
-                self.update_normal_hints(|size_hints| {
-                    (*size_hints).flags |= ffi::PMinSize | ffi::PMaxSize;
-                    if let Some((width, height)) = self.get_inner_size() {
-                        (*size_hints).min_width = width as c_int;
-                        (*size_hints).min_height = height as c_int;
-                        (*size_hints).max_width = width as c_int;
-                        (*size_hints).max_height = height as c_int;
-                    }
-                })
-            }.expect("Failed to call XSetWMNormalHints");
-        }
+            let window_size = self.get_inner_size();
+            (window_size.clone(), window_size)
+        };
+
+        let dpi_factor = self.get_hidpi_factor();
+        let min_dimensions = logical_min
+            .map(|logical_size| logical_size.to_physical(dpi_factor))
+            .map(Into::into);
+        let max_dimensions = logical_max
+            .map(|logical_size| logical_size.to_physical(dpi_factor))
+            .map(Into::into);
+        self.update_normal_hints(|normal_hints| {
+            normal_hints.set_min_size(min_dimensions);
+            normal_hints.set_max_size(max_dimensions);
+        }).expect("Failed to call `XSetWMNormalHints`");
     }
 
     #[inline]
@@ -789,6 +893,7 @@ impl UnownedWindow {
         self.xwindow as _
     }
 
+    #[inline]
     pub fn get_xcb_connection(&self) -> *mut c_void {
         unsafe {
             (self.xconn.xlib_xcb.XGetXCBConnection)(self.xconn.display) as *mut _
@@ -886,6 +991,7 @@ impl UnownedWindow {
         }
     }
 
+    #[inline]
     pub fn set_cursor(&self, cursor: MouseCursor) {
         *self.cursor.lock() = cursor;
         if *self.cursor_state.lock() != CursorState::Hide {
@@ -931,6 +1037,7 @@ impl UnownedWindow {
         Some(cursor)
     }
 
+    #[inline]
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {
         use CursorState::*;
 
@@ -994,11 +1101,12 @@ impl UnownedWindow {
         }
     }
 
-    pub fn hidpi_factor(&self) -> f32 {
+    #[inline]
+    pub fn get_hidpi_factor(&self) -> f64 {
         self.get_current_monitor().hidpi_factor
     }
 
-    pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
+    pub fn set_cursor_position_physical(&self, x: i32, y: i32) -> Result<(), ()> {
         unsafe {
             (self.xconn.xlib.XWarpPointer)(
                 self.xconn.display,
@@ -1013,6 +1121,24 @@ impl UnownedWindow {
             );
             self.xconn.flush_requests().map_err(|_| ())
         }
+    }
+
+    #[inline]
+    pub fn set_cursor_position(&self, logical_position: LogicalCoordinates) -> Result<(), ()> {
+        let (x, y) = logical_position.to_physical(self.get_hidpi_factor()).into();
+        self.set_cursor_position_physical(x, y)
+    }
+
+    pub fn set_ime_spot_physical(&self, x: i32, y: i32) {
+        let _ = self.ime_sender
+            .lock()
+            .send((self.xwindow, x as i16, y as i16));
+    }
+
+    #[inline]
+    pub fn set_ime_spot(&self, logical_position: LogicalCoordinates) {
+        let (x, y) = logical_position.to_physical(self.get_hidpi_factor()).into();
+        self.set_ime_spot_physical(x, y);
     }
 
     #[inline]

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -817,10 +817,10 @@ impl UnownedWindow {
                 let new_height = height as f64 * scale_factor;
                 (new_width.round() as u32, new_height.round() as u32)
             };
-            let max_size = normal_hints.get_max_size().map(dpi_adjuster);
-            let min_size = normal_hints.get_min_size().map(dpi_adjuster);
-            let resize_increments = normal_hints.get_resize_increments().map(dpi_adjuster);
-            let base_size = normal_hints.get_base_size().map(dpi_adjuster);
+            let max_size = normal_hints.get_max_size().map(&dpi_adjuster);
+            let min_size = normal_hints.get_min_size().map(&dpi_adjuster);
+            let resize_increments = normal_hints.get_resize_increments().map(&dpi_adjuster);
+            let base_size = normal_hints.get_base_size().map(&dpi_adjuster);
             normal_hints.set_max_size(max_size);
             normal_hints.set_min_size(min_size);
             normal_hints.set_resize_increments(resize_increments);

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -76,15 +76,20 @@ impl UnownedWindow {
         let xconn = &event_loop.xconn;
         let root = event_loop.root;
 
+        let max_dimensions: Option<(u32, u32)> = window_attrs.max_dimensions.map(Into::into);
+        let min_dimensions: Option<(u32, u32)> = window_attrs.min_dimensions.map(Into::into);
+
         let dimensions = {
             // x11 only applies constraints when the window is actively resized
             // by the user, so we have to manually apply the initial constraints
-            let mut dimensions = window_attrs.dimensions.unwrap_or((800, 600));
-            if let Some(max) = window_attrs.max_dimensions {
+            let mut dimensions = window_attrs.dimensions
+                .map(Into::into)
+                .unwrap_or((800, 600));
+            if let Some(max) = max_dimensions {
                 dimensions.0 = cmp::min(dimensions.0, max.0);
                 dimensions.1 = cmp::min(dimensions.1, max.1);
             }
-            if let Some(min) = window_attrs.min_dimensions {
+            if let Some(min) = min_dimensions {
                 dimensions.0 = cmp::max(dimensions.0, min.0);
                 dimensions.1 = cmp::max(dimensions.1, min.1);
             }
@@ -458,8 +463,8 @@ impl UnownedWindow {
             Some(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
                 let window_position = self.get_position_physical();
                 self.shared_state.lock().restore_position = window_position;
-                let monitor_origin = monitor.get_position();
-                self.set_position_inner(monitor_origin.0 as i32, monitor_origin.1 as i32).queue();
+                let monitor_origin: (i32, i32) = monitor.get_position().into();
+                self.set_position_inner(monitor_origin.0, monitor_origin.1).queue();
                 self.set_fullscreen_hint(true)
             }
             _ => unreachable!(),

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -238,18 +238,18 @@ impl UnownedWindow {
                 let mut min_dimensions = window_attrs.min_dimensions;
                 let mut max_dimensions = window_attrs.max_dimensions;
                 if !window_attrs.resizable && !util::wm_name_is_one_of(&["Xfwm4"]) {
-                    max_dimensions = Some(dimensions);
-                    min_dimensions = Some(dimensions);
+                    max_dimensions = Some(dimensions.into());
+                    min_dimensions = Some(dimensions.into());
 
                     let mut shared_state_lock = window.shared_state.lock();
-                    shared_state_lock.min_dimensions = window_attrs.min_dimensions.map(Into::into);
-                    shared_state_lock.max_dimensions = window_attrs.max_dimensions.map(Into::into);
+                    shared_state_lock.min_dimensions = window_attrs.min_dimensions;
+                    shared_state_lock.max_dimensions = window_attrs.max_dimensions;
                 }
 
                 let mut normal_hints = util::NormalHints::new(xconn);
                 normal_hints.set_size(Some(dimensions));
-                normal_hints.set_min_size(min_dimensions);
-                normal_hints.set_max_size(max_dimensions);
+                normal_hints.set_min_size(min_dimensions.map(Into::into));
+                normal_hints.set_max_size(max_dimensions.map(Into::into));
                 normal_hints.set_resize_increments(pl_attribs.resize_increments);
                 normal_hints.set_base_size(pl_attribs.base_size);
                 xconn.set_normal_hints(window.xwindow, normal_hints).queue();

--- a/src/platform/macos/util.rs
+++ b/src/platform/macos/util.rs
@@ -14,8 +14,8 @@ pub const EMPTY_RANGE: ffi::NSRange = ffi::NSRange {
 // For consistency with other platforms, this will...
 // 1. translate the bottom-left window corner into the top-left window corner
 // 2. translate the coordinate from a bottom-left origin coordinate system to a top-left one
-pub fn bottom_left_to_top_left(rect: NSRect) -> i32 {
-    (CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height)) as _
+pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
+    CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height)
 }
 
 pub unsafe fn set_style_mask(window: id, view: id, mask: NSWindowStyleMask) {

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -22,7 +22,7 @@ use platform::platform::window::{get_window_id, IdRef};
 struct ViewState {
     window: id,
     shared: Weak<Shared>,
-    ime_spot: Option<(i32, i32)>,
+    ime_spot: Option<(f64, f64)>,
     raw_characters: Option<String>,
     last_insert: Option<String>,
 }
@@ -43,7 +43,7 @@ pub fn new_view(window: id, shared: Weak<Shared>) -> IdRef {
     }
 }
 
-pub fn set_ime_spot(view: id, input_context: id, x: i32, y: i32) {
+pub fn set_ime_spot(view: id, input_context: id, x: f64, y: f64) {
     unsafe {
         let state_ptr: *mut c_void = *(*view).get_mut_ivar("winitState");
         let state = &mut *(state_ptr as *mut ViewState);
@@ -51,8 +51,8 @@ pub fn set_ime_spot(view: id, input_context: id, x: i32, y: i32) {
             state.window,
             NSWindow::frame(state.window),
         );
-        let base_x = content_rect.origin.x as i32;
-        let base_y = (content_rect.origin.y + content_rect.size.height) as i32;
+        let base_x = content_rect.origin.x as f64;
+        let base_y = (content_rect.origin.y + content_rect.size.height) as f64;
         state.ime_spot = Some((base_x + x, base_y - y));
         let _: () = msg_send![input_context, invalidateCharacterCoordinates];
     }
@@ -249,7 +249,7 @@ extern fn first_rect_for_character_range(
             );
             let x = content_rect.origin.x;
             let y = util::bottom_left_to_top_left(content_rect);
-            (x as i32, y as i32)
+            (x, y)
         });
 
         NSRect::new(
@@ -527,15 +527,14 @@ fn mouse_motion(this: &Object, event: id) {
             return;
         }
 
-        let scale_factor = NSWindow::backingScaleFactor(state.window) as f64;
-        let x = scale_factor * view_point.x as f64;
-        let y = scale_factor * (view_rect.size.height as f64 - view_point.y as f64);
+        let x = view_point.x as f64;
+        let y = view_rect.size.height as f64 - view_point.y as f64;
 
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.window)),
             event: WindowEvent::CursorMoved {
                 device_id: DEVICE_ID,
-                position: (x, y),
+                position: (x, y).into(),
                 modifiers: event_mods(event),
             },
         };

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -235,7 +235,7 @@ impl WindowDelegate {
                 let state = &mut *(state as *mut DelegateState);
                 emit_resize_event(state);
                 let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-                emit_event(state, WindowEvent::HiDPIFactorChanged(scale_factor));
+                emit_event(state, WindowEvent::HiDpiFactorChanged(scale_factor));
             }
         }
 
@@ -244,7 +244,7 @@ impl WindowDelegate {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
                 let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-                emit_event(state, WindowEvent::HiDPIFactorChanged(scale_factor));
+                emit_event(state, WindowEvent::HiDpiFactorChanged(scale_factor));
             }
         }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -519,7 +519,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub titlebar_hidden: bool,
     pub titlebar_buttons_hidden: bool,
     pub fullsize_content_view: bool,
-    pub resize_increments: Option<(u32, u32)>,
+    pub resize_increments: Option<LogicalSize>,
 }
 
 pub struct Window2 {
@@ -827,9 +827,10 @@ impl Window2 {
                     let _: () = msg_send![*window, setLevel:ffi::NSWindowLevel::NSFloatingWindowLevel];
                 }
 
-                if let Some((x, y)) = pl_attrs.resize_increments {
-                    if x >= 1 && y >= 1 {
-                        let size = NSSize::new(x as _, y as _);
+                if let Some(increments) = pl_attrs.resize_increments {
+                    let (x, y) = (increments.width, increments.height);
+                    if x >= 1.0 && y >= 1.0 {
+                        let size = NSSize::new(x as CGFloat, y as CGFloat);
                         window.setResizeIncrements_(size);
                     }
                 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -1,40 +1,52 @@
-use {CreationError, Event, WindowEvent, WindowId, MouseCursor, CursorState};
-use CreationError::OsError;
-use libc;
-
-use WindowAttributes;
-use os::macos::ActivationPolicy;
-use os::macos::WindowExt;
-
-use objc;
-use objc::runtime::{Class, Object, Sel, BOOL, YES, NO};
-use objc::declare::ClassDecl;
-
-use cocoa;
-use cocoa::appkit::{self, NSApplication, NSColor, NSScreen, NSView, NSWindow, NSWindowButton,
-    NSWindowStyleMask};
-use cocoa::base::{id, nil};
-use cocoa::foundation::{NSDictionary, NSPoint, NSRect, NSSize, NSString, NSAutoreleasePool};
-
-use core_graphics::display::CGDisplay;
-
 use std;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::sync::Weak;
 use std::cell::{Cell, RefCell};
 
-use super::events_loop::{EventsLoop, Shared};
-use platform::platform::ffi;
-use platform::platform::util;
-use platform::platform::view::{new_view, set_ime_spot};
+use cocoa;
+use cocoa::appkit::{
+    self,
+    CGFloat,
+    NSApplication,
+    NSColor,
+    NSScreen,
+    NSView,
+    NSWindow,
+    NSWindowButton,
+    NSWindowStyleMask,
+};
+use cocoa::base::{id, nil};
+use cocoa::foundation::{NSAutoreleasePool, NSDictionary, NSPoint, NSRect, NSSize, NSString};
 
+use core_graphics::display::CGDisplay;
+
+use objc;
+use objc::runtime::{Class, Object, Sel, BOOL, YES, NO};
+use objc::declare::ClassDecl;
+
+use {
+    CreationError,
+    CursorState,
+    Event,
+    LogicalPosition,
+    LogicalSize,
+    MouseCursor,
+    WindowAttributes,
+    WindowEvent,
+    WindowId,
+};
+use CreationError::OsError;
+use os::macos::{ActivationPolicy, WindowExt};
+use platform::platform::{ffi, util};
+use platform::platform::events_loop::{EventsLoop, Shared};
+use platform::platform::view::{new_view, set_ime_spot};
 use window::MonitorId as RootMonitorId;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id(pub usize);
 
-struct DelegateState {
+pub struct DelegateState {
     view: IdRef,
     window: IdRef,
     shared: Weak<Shared>,
@@ -47,8 +59,11 @@ struct DelegateState {
     // see comments of `window_did_fail_to_enter_fullscreen`
     handle_with_fullscreen: bool,
 
-    // During windowDidResize, we use this to only send Moved if the position changed.
-    previous_position: Option<(i32, i32)>,
+    // During `windowDidResize`, we use this to only send Moved if the position changed.
+    previous_position: Option<(f64, f64)>,
+
+    // Used to prevent redundant events.
+    previous_dpi_factor: f64,
 }
 
 impl DelegateState {
@@ -150,48 +165,44 @@ pub struct WindowDelegate {
 }
 
 impl WindowDelegate {
+    // Emits an event via the `EventsLoop`'s callback or stores it in the pending queue.
+    pub fn emit_event(state: &mut DelegateState, window_event: WindowEvent) {
+        let window_id = get_window_id(*state.window);
+        let event = Event::WindowEvent {
+            window_id: WindowId(window_id),
+            event: window_event,
+        };
+        if let Some(shared) = state.shared.upgrade() {
+            shared.call_user_callback_with_event_or_store_in_pending(event);
+        }
+    }
+
+    pub fn emit_resize_event(state: &mut DelegateState) {
+        let rect = unsafe { NSView::frame(*state.view) };
+        let size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
+        WindowDelegate::emit_event(state, WindowEvent::Resized(size));
+    }
+
+    pub fn emit_move_event(state: &mut DelegateState) {
+        let rect = unsafe { NSWindow::frame(*state.window) };
+        let x = rect.origin.x as f64;
+        let y = util::bottom_left_to_top_left(rect);
+        let moved = state.previous_position != Some((x, y));
+        if moved {
+            state.previous_position = Some((x, y));
+            WindowDelegate::emit_event(state, WindowEvent::Moved((x, y).into()));
+        }
+    }
+
     /// Get the delegate class, initiailizing it neccessary
     fn class() -> *const Class {
         use std::os::raw::c_void;
-
-        // Emits an event via the `EventsLoop`'s callback or stores it in the pending queue.
-        unsafe fn emit_event(state: &mut DelegateState, window_event: WindowEvent) {
-            let window_id = get_window_id(*state.window);
-            let event = Event::WindowEvent {
-                window_id: WindowId(window_id),
-                event: window_event,
-            };
-
-            if let Some(shared) = state.shared.upgrade() {
-                shared.call_user_callback_with_event_or_store_in_pending(event);
-            }
-        }
-
-        // Called when the window is resized or when the window was moved to a different screen.
-        unsafe fn emit_resize_event(state: &mut DelegateState) {
-            let rect = NSView::frame(*state.view);
-            let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-            let width = (scale_factor * rect.size.width as f32) as u32;
-            let height = (scale_factor * rect.size.height as f32) as u32;
-            emit_event(state, WindowEvent::Resized(width, height));
-        }
-
-        unsafe fn emit_move_event(state: &mut DelegateState) {
-            let frame_rect = NSWindow::frame(*state.window);
-            let x = frame_rect.origin.x as _;
-            let y = util::bottom_left_to_top_left(frame_rect);
-            let moved = state.previous_position != Some((x, y));
-            if moved {
-                state.previous_position = Some((x, y));
-                emit_event(state, WindowEvent::Moved(x, y));
-            }
-        }
 
         extern fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_event(state, WindowEvent::CloseRequested);
+                WindowDelegate::emit_event(state, WindowEvent::CloseRequested);
             }
             NO
         }
@@ -201,7 +212,7 @@ impl WindowDelegate {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
 
-                emit_event(state, WindowEvent::Destroyed);
+                WindowDelegate::emit_event(state, WindowEvent::Destroyed);
 
                 // Remove the window from the shared state.
                 if let Some(shared) = state.shared.upgrade() {
@@ -215,8 +226,8 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_resize_event(state);
-                emit_move_event(state);
+                WindowDelegate::emit_resize_event(state);
+                WindowDelegate::emit_move_event(state);
             }
         }
 
@@ -225,7 +236,7 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_move_event(state);
+                WindowDelegate::emit_move_event(state);
             }
         }
 
@@ -233,18 +244,26 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_resize_event(state);
-                let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-                emit_event(state, WindowEvent::HiDpiFactorChanged(scale_factor));
+                let dpi_factor = NSWindow::backingScaleFactor(*state.window) as f64;
+                if state.previous_dpi_factor != dpi_factor {
+                    state.previous_dpi_factor = dpi_factor;
+                    WindowDelegate::emit_event(state, WindowEvent::HiDpiFactorChanged(dpi_factor));
+                    WindowDelegate::emit_resize_event(state);
+                }
             }
         }
 
+        // This will always be called before `window_did_change_screen`.
         extern fn window_did_change_backing_properties(this: &Object, _:Sel, _:id) {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                let scale_factor = NSWindow::backingScaleFactor(*state.window) as f32;
-                emit_event(state, WindowEvent::HiDpiFactorChanged(scale_factor));
+                let dpi_factor = NSWindow::backingScaleFactor(*state.window) as f64;
+                if state.previous_dpi_factor != dpi_factor {
+                    state.previous_dpi_factor = dpi_factor;
+                    WindowDelegate::emit_event(state, WindowEvent::HiDpiFactorChanged(dpi_factor));
+                    WindowDelegate::emit_resize_event(state);
+                }
             }
         }
 
@@ -254,7 +273,7 @@ impl WindowDelegate {
                 // lost focus
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_event(state, WindowEvent::Focused(true));
+                WindowDelegate::emit_event(state, WindowEvent::Focused(true));
             }
         }
 
@@ -262,7 +281,7 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_event(state, WindowEvent::Focused(false));
+                WindowDelegate::emit_event(state, WindowEvent::Focused(false));
             }
         }
 
@@ -285,7 +304,7 @@ impl WindowDelegate {
 
                     let state: *mut c_void = *this.get_ivar("winitState");
                     let state = &mut *(state as *mut DelegateState);
-                    emit_event(state, WindowEvent::HoveredFile(PathBuf::from(path)));
+                    WindowDelegate::emit_event(state, WindowEvent::HoveredFile(PathBuf::from(path)));
                 }
             };
 
@@ -314,7 +333,7 @@ impl WindowDelegate {
 
                     let state: *mut c_void = *this.get_ivar("winitState");
                     let state = &mut *(state as *mut DelegateState);
-                    emit_event(state, WindowEvent::DroppedFile(PathBuf::from(path)));
+                    WindowDelegate::emit_event(state, WindowEvent::DroppedFile(PathBuf::from(path)));
                 }
             };
 
@@ -329,7 +348,7 @@ impl WindowDelegate {
             unsafe {
                 let state: *mut c_void = *this.get_ivar("winitState");
                 let state = &mut *(state as *mut DelegateState);
-                emit_event(state, WindowEvent::HoveredFileCancelled);
+                WindowDelegate::emit_event(state, WindowEvent::HoveredFileCancelled);
             }
         }
 
@@ -617,12 +636,11 @@ impl Window2 {
 
             app.activateIgnoringOtherApps_(YES);
 
-            if let Some((width, height)) = win_attribs.min_dimensions {
-                nswindow_set_min_dimensions(window.0, width.into(), height.into());
+            if let Some(dimensions) = win_attribs.min_dimensions {
+                nswindow_set_min_dimensions(window.0, dimensions);
             }
-
-            if let Some((width, height)) = win_attribs.max_dimensions {
-                nswindow_set_max_dimensions(window.0, width.into(), height.into());
+            if let Some(dimensions) = win_attribs.max_dimensions {
+                nswindow_set_max_dimensions(window.0, dimensions);
             }
 
             use cocoa::foundation::NSArray;
@@ -631,7 +649,9 @@ impl Window2 {
                 registerForDraggedTypes:NSArray::arrayWithObject(nil, appkit::NSFilenamesPboardType)];
         }
 
-        let ds = DelegateState {
+        let dpi_factor = unsafe { NSWindow::backingScaleFactor(*window) as f64 };
+
+        let mut delegate_state = DelegateState {
             view: view.clone(),
             window: window.clone(),
             shared,
@@ -640,13 +660,19 @@ impl Window2 {
             save_style_mask: Cell::new(None),
             handle_with_fullscreen: win_attribs.fullscreen.is_some(),
             previous_position: None,
+            previous_dpi_factor: dpi_factor,
         };
-        ds.win_attribs.borrow_mut().fullscreen = None;
+        delegate_state.win_attribs.borrow_mut().fullscreen = None;
+
+        if dpi_factor != 1.0 {
+            WindowDelegate::emit_event(&mut delegate_state, WindowEvent::HiDpiFactorChanged(dpi_factor));
+            WindowDelegate::emit_resize_event(&mut delegate_state);
+        }
 
         let window = Window2 {
             view: view,
             window: window,
-            delegate: WindowDelegate::new(ds),
+            delegate: WindowDelegate::new(delegate_state),
             input_context,
         };
 
@@ -729,8 +755,10 @@ impl Window2 {
             let frame = match screen {
                 Some(screen) => appkit::NSScreen::frame(screen),
                 None => {
-                    let (width, height) = attrs.dimensions.unwrap_or((800, 600));
-                    NSRect::new(NSPoint::new(0., 0.), NSSize::new(width as f64, height as f64))
+                    let (width, height) = attrs.dimensions
+                        .map(|logical| (logical.width, logical.height))
+                        .unwrap_or((800.0, 600.0));
+                    NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(width, height))
                 }
             };
 
@@ -843,15 +871,15 @@ impl Window2 {
         unsafe { NSWindow::orderOut_(*self.window, nil); }
     }
 
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
         let frame_rect = unsafe { NSWindow::frame(*self.window) };
         Some((
-            frame_rect.origin.x as i32,
+            frame_rect.origin.x as f64,
             util::bottom_left_to_top_left(frame_rect),
-        ))
+        ).into())
     }
 
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         let content_rect = unsafe {
             NSWindow::contentRectForFrameRect_(
                 *self.window,
@@ -859,18 +887,18 @@ impl Window2 {
             )
         };
         Some((
-            content_rect.origin.x as i32,
+            content_rect.origin.x as f64,
             util::bottom_left_to_top_left(content_rect),
-        ))
+        ).into())
     }
 
-    pub fn set_position(&self, x: i32, y: i32) {
+    pub fn set_position(&self, position: LogicalPosition) {
         let dummy = NSRect::new(
             NSPoint::new(
-                x as f64,
+                position.x,
                 // While it's true that we're setting the top-left position, it still needs to be
                 // in a bottom-left coordinate system.
-                CGDisplay::main().pixels_high() as f64 - y as f64,
+                CGDisplay::main().pixels_high() as f64 - position.y,
             ),
             NSSize::new(0f64, 0f64),
         );
@@ -880,42 +908,35 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
-        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
-        unsafe {
-            let view_frame = NSView::frame(*self.view);
-            Some(((view_frame.size.width*factor) as u32, (view_frame.size.height*factor) as u32))
-        }
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
+        let view_frame = unsafe { NSView::frame(*self.view) };
+        Some((view_frame.size.width as f64, view_frame.size.height as f64).into())
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
-        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
-        unsafe {
-            let window_frame = NSWindow::frame(*self.window);
-            Some(((window_frame.size.width*factor) as u32, (window_frame.size.height*factor) as u32))
-        }
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
+        let view_frame = unsafe { NSWindow::frame(*self.window) };
+        Some((view_frame.size.width as f64, view_frame.size.height as f64).into())
     }
 
     #[inline]
-    pub fn set_inner_size(&self, width: u32, height: u32) {
-        let factor = self.hidpi_factor() as f64; // API convention is that size is in physical pixels
+    pub fn set_inner_size(&self, size: LogicalSize) {
         unsafe {
-            NSWindow::setContentSize_(*self.window, NSSize::new((width as f64)/factor, (height as f64)/factor));
+            NSWindow::setContentSize_(*self.window, NSSize::new(size.width as CGFloat, size.height as CGFloat));
         }
     }
 
-    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         unsafe {
-            let (width, height) = dimensions.unwrap_or((0, 0));
-            nswindow_set_min_dimensions(self.window.0, width.into(), height.into());
+            let dimensions = dimensions.unwrap_or_else(|| (!0, !0).into());
+            nswindow_set_min_dimensions(self.window.0, dimensions);
         }
     }
 
-    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
         unsafe {
-            let (width, height) = dimensions.unwrap_or((!0, !0));
-            nswindow_set_max_dimensions(self.window.0, width.into(), height.into());
+            let dimensions = dimensions.unwrap_or_else(|| (!0, !0).into());
+            nswindow_set_max_dimensions(self.window.0, dimensions);
         }
     }
 
@@ -932,16 +953,6 @@ impl Window2 {
             }
             unsafe { util::set_style_mask(*self.window, *self.view, mask) };
         } // Otherwise, we don't change the mask until we exit fullscreen.
-    }
-
-    #[inline]
-    pub fn platform_display(&self) -> *mut libc::c_void {
-        unimplemented!()
-    }
-
-    #[inline]
-    pub fn platform_window(&self) -> *mut libc::c_void {
-        *self.window as *mut libc::c_void
     }
 
     pub fn set_cursor(&self, cursor: MouseCursor) {
@@ -1005,24 +1016,24 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         unsafe {
-            NSWindow::backingScaleFactor(*self.window) as f32
+            NSWindow::backingScaleFactor(*self.window) as f64
         }
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
-        let (window_x, window_y) = self.get_position().unwrap_or((0, 0));
-        let (cursor_x, cursor_y) = (window_x + x, window_y + y);
-
-        // TODO: Check for errors.
-        let _ = CGDisplay::warp_mouse_cursor_position(appkit::CGPoint {
-            x: cursor_x as appkit::CGFloat,
-            y: cursor_y as appkit::CGFloat,
-        });
-        let _ = CGDisplay::associate_mouse_and_mouse_cursor_position(true);
-
+    pub fn set_cursor_position(&self, cursor_position: LogicalPosition) -> Result<(), ()> {
+        let window_position = self.get_inner_position()
+            .expect("`get_inner_position` failed");
+        let point = appkit::CGPoint {
+            x: (cursor_position.x + window_position.x) as CGFloat,
+            y: (cursor_position.y + window_position.y) as CGFloat,
+        };
+        CGDisplay::warp_mouse_cursor_position(point)
+            .expect("`CGWarpMouseCursorPosition` failed");
+        CGDisplay::associate_mouse_and_mouse_cursor_position(true)
+            .expect("`CGAssociateMouseAndMouseCursorPosition` failed");
         Ok(())
     }
 
@@ -1131,8 +1142,8 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, x: i32, y: i32) {
-        set_ime_spot(*self.view, *self.input_context, x, y);
+    pub fn set_ime_spot(&self, logical_spot: LogicalPosition) {
+        set_ime_spot(*self.view, *self.input_context, logical_spot.x, logical_spot.y);
     }
 
     #[inline]
@@ -1149,51 +1160,50 @@ pub fn get_window_id(window_cocoa_id: id) -> Id {
     Id(window_cocoa_id as *const objc::runtime::Object as usize)
 }
 
-unsafe fn nswindow_set_min_dimensions<V: NSWindow + Copy>(
-    window: V, min_width: f64, min_height: f64)
-{
+unsafe fn nswindow_set_min_dimensions<V: NSWindow + Copy>(window: V, mut min_size: LogicalSize) {
+    let mut current_rect = NSWindow::frame(window);
+    let content_rect = NSWindow::contentRectForFrameRect_(window, NSWindow::frame(window));
+    // Convert from client area size to window size
+    min_size.width += (current_rect.size.width - content_rect.size.width) as f64; // this tends to be 0
+    min_size.height += (current_rect.size.height - content_rect.size.height) as f64;
     window.setMinSize_(NSSize {
-        width: min_width,
-        height: min_height,
+        width: min_size.width as CGFloat,
+        height: min_size.height as CGFloat,
     });
     // If necessary, resize the window to match constraint
-    let mut current_rect = NSWindow::frame(window);
-    if current_rect.size.width < min_width {
-        current_rect.size.width = min_width;
+    if current_rect.size.width < min_size.width {
+        current_rect.size.width = min_size.width;
         window.setFrame_display_(current_rect, 0)
     }
-    if current_rect.size.height < min_height {
-        // The origin point of a rectangle is at its bottom left in Cocoa. To
-        // ensure the window's top-left point remains the same:
-        current_rect.origin.y +=
-            current_rect.size.height - min_height;
-
-        current_rect.size.height = min_height;
+    if current_rect.size.height < min_size.height {
+        // The origin point of a rectangle is at its bottom left in Cocoa.
+        // To ensure the window's top-left point remains the same:
+        current_rect.origin.y += current_rect.size.height - min_size.height;
+        current_rect.size.height = min_size.height;
         window.setFrame_display_(current_rect, 0)
     }
 }
 
-unsafe fn nswindow_set_max_dimensions<V: NSWindow + Copy>(
-    window: V, max_width: f64, max_height: f64)
-{
+unsafe fn nswindow_set_max_dimensions<V: NSWindow + Copy>(window: V, mut max_size: LogicalSize) {
+    let mut current_rect = NSWindow::frame(window);
+    let content_rect = NSWindow::contentRectForFrameRect_(window, NSWindow::frame(window));
+    // Convert from client area size to window size
+    max_size.width += (current_rect.size.width - content_rect.size.width) as f64; // this tends to be 0
+    max_size.height += (current_rect.size.height - content_rect.size.height) as f64;
     window.setMaxSize_(NSSize {
-        width: max_width,
-        height: max_height,
+        width: max_size.width as CGFloat,
+        height: max_size.height as CGFloat,
     });
     // If necessary, resize the window to match constraint
-    let mut current_rect = NSWindow::frame(window);
-    if current_rect.size.width > max_width {
-        current_rect.size.width = max_width;
+    if current_rect.size.width > max_size.width {
+        current_rect.size.width = max_size.width;
         window.setFrame_display_(current_rect, 0)
     }
-    if current_rect.size.height > max_height {
-        // The origin point of a rectangle is at its bottom left in
-        // Cocoa. To ensure the window's top-left point remains the
-        // same:
-        current_rect.origin.y +=
-            current_rect.size.height - max_height;
-
-        current_rect.size.height = max_height;
+    if current_rect.size.height > max_size.height {
+        // The origin point of a rectangle is at its bottom left in Cocoa.
+        // To ensure the window's top-left point remains the same:
+        current_rect.origin.y += current_rect.size.height - max_size.height;
+        current_rect.size.height = max_size.height;
         window.setFrame_display_(current_rect, 0)
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -929,7 +929,7 @@ impl Window2 {
 
     pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         unsafe {
-            let dimensions = dimensions.unwrap_or_else(|| (!0, !0).into());
+            let dimensions = dimensions.unwrap_or_else(|| (0, 0).into());
             nswindow_set_min_dimensions(self.window.0, dimensions);
         }
     }

--- a/src/platform/windows/dpi.rs
+++ b/src/platform/windows/dpi.rs
@@ -183,7 +183,7 @@ pub unsafe fn get_window_dpi(hwnd: HWND, hdc: HDC) -> u32 {
 
 // Use this when you have both the HWND and HDC on hand (i.e. window methods)
 pub fn get_window_scale_factor(hwnd: HWND, hdc: HDC) -> f64 {
-    unsafe { dpi_to_scale_factor(get_window_dpi(hwnd, hdc)) }
+    dpi_to_scale_factor(unsafe { get_window_dpi(hwnd, hdc) })
 }
 
 // Use this when you only have the HWND (i.e. event handling)

--- a/src/platform/windows/dpi.rs
+++ b/src/platform/windows/dpi.rs
@@ -1,0 +1,196 @@
+#![allow(non_snake_case, unused_unsafe)]
+
+use std::mem;
+use std::os::raw::c_void;
+use std::sync::{Once, ONCE_INIT};
+
+use winapi::shared::minwindef::{BOOL, UINT, FALSE};
+use winapi::shared::windef::{
+    DPI_AWARENESS_CONTEXT,
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE,
+    HDC,
+    HMONITOR,
+    HWND,
+};
+use winapi::shared::winerror::S_OK;
+use winapi::um::libloaderapi::{GetProcAddress, LoadLibraryA};
+use winapi::um::shellscalingapi::{
+    MDT_EFFECTIVE_DPI,
+    MONITOR_DPI_TYPE,
+    PROCESS_DPI_AWARENESS,
+    PROCESS_PER_MONITOR_DPI_AWARE,
+};
+use winapi::um::wingdi::{GetDeviceCaps, LOGPIXELSX};
+use winapi::um::winnt::{HRESULT, LPCSTR};
+use winapi::um::winuser::{self, MONITOR_DEFAULTTONEAREST};
+
+const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT = -4isize as _;
+
+type SetProcessDPIAware = unsafe extern "system" fn () -> BOOL;
+type SetProcessDpiAwareness = unsafe extern "system" fn (
+    value: PROCESS_DPI_AWARENESS,
+) -> HRESULT;
+type SetProcessDpiAwarenessContext = unsafe extern "system" fn (
+    value: DPI_AWARENESS_CONTEXT,
+) -> BOOL;
+type GetDpiForWindow = unsafe extern "system" fn (hwnd: HWND) -> UINT;
+type GetDpiForMonitor = unsafe extern "system" fn (
+    hmonitor: HMONITOR,
+    dpi_type: MONITOR_DPI_TYPE,
+    dpi_x: *mut UINT,
+    dpi_y: *mut UINT,
+) -> HRESULT;
+type EnableNonClientDpiScaling = unsafe extern "system" fn (hwnd: HWND) -> BOOL;
+
+// Helper function to dynamically load function pointer.
+// `library` and `function` must be zero-terminated.
+fn get_function_impl(library: &str, function: &str) -> Option<*const c_void> {
+    assert_eq!(library.chars().last(), Some('\0'));
+    assert_eq!(function.chars().last(), Some('\0'));
+
+    // Library names we will use are ASCII so we can use the A version to avoid string conversion.
+    let module = unsafe { LoadLibraryA(library.as_ptr() as LPCSTR) };
+    if module.is_null() {
+        return None;
+    }
+
+    let function_ptr = unsafe { GetProcAddress(module, function.as_ptr() as LPCSTR) };
+    if function_ptr.is_null() {
+        return None;
+    }
+
+    Some(function_ptr as _)
+}
+
+macro_rules! get_function {
+    ($lib:expr, $func:ident) => {
+        get_function_impl(concat!($lib, '\0'), concat!(stringify!($func), '\0'))
+            .map(|f| unsafe { mem::transmute::<*const _, $func>(f) })
+    }
+}
+
+lazy_static! {
+    static ref GET_DPI_FOR_WINDOW: Option<GetDpiForWindow> = get_function!(
+        "user32.dll",
+        GetDpiForWindow
+    );
+    static ref GET_DPI_FOR_MONITOR: Option<GetDpiForMonitor> = get_function!(
+        "shcore.dll",
+        GetDpiForMonitor
+    );
+    static ref ENABLE_NON_CLIENT_DPI_SCALING: Option<EnableNonClientDpiScaling> = get_function!(
+        "user32.dll",
+        EnableNonClientDpiScaling
+    );
+}
+
+pub fn become_dpi_aware(enable: bool) {
+    if !enable { return; }
+    static ENABLE_DPI_AWARENESS: Once = ONCE_INIT;
+    ENABLE_DPI_AWARENESS.call_once(|| { unsafe {
+        if let Some(SetProcessDpiAwarenessContext) = get_function!(
+            "user32.dll",
+            SetProcessDpiAwarenessContext
+        ) {
+            // We are on Windows 10 Anniversary Update (1607) or later.
+            if SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+            == FALSE {
+                // V2 only works with Windows 10 Creators Update (1703). Try using the older
+                // V1 if we can't set V2.
+                SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+            }
+        } else if let Some(SetProcessDpiAwareness) = get_function!(
+            "shcore.dll",
+            SetProcessDpiAwareness
+        ) {
+            // We are on Windows 8.1 or later.
+            SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+        } else if let Some(SetProcessDPIAware) = get_function!(
+            "user32.dll",
+            SetProcessDPIAware
+        ) {
+            // We are on Vista or later.
+            SetProcessDPIAware();
+        }
+    } });
+}
+
+pub fn enable_non_client_dpi_scaling(hwnd: HWND) {
+    unsafe {
+        if let Some(EnableNonClientDpiScaling) = *ENABLE_NON_CLIENT_DPI_SCALING {
+            EnableNonClientDpiScaling(hwnd);
+        }
+    }
+}
+
+pub fn get_monitor_dpi(hmonitor: HMONITOR) -> Option<u32> {
+    unsafe {
+        if let Some(GetDpiForMonitor) = *GET_DPI_FOR_MONITOR {
+            // We are on Windows 8.1 or later.
+            let mut dpi_x = 0;
+            let mut dpi_y = 0;
+            if GetDpiForMonitor(hmonitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) == S_OK {
+                // MSDN says that "the values of *dpiX and *dpiY are identical. You only need to
+                // record one of the values to determine the DPI and respond appropriately".
+                // https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
+                return Some(dpi_x as u32)
+            }
+        }
+    }
+    None
+}
+
+pub const BASE_DPI: u32 = 96;
+pub fn dpi_to_scale_factor(dpi: u32) -> f64 {
+    dpi as f64 / BASE_DPI as f64
+}
+
+pub unsafe fn get_window_dpi(hwnd: HWND, hdc: HDC) -> u32 {
+    if let Some(GetDpiForWindow) = *GET_DPI_FOR_WINDOW {
+        // We are on Windows 10 Anniversary Update (1607) or later.
+        match GetDpiForWindow(hwnd) {
+            0 => BASE_DPI, // 0 is returned if hwnd is invalid
+            dpi => dpi as u32,
+        }
+    } else if let Some(GetDpiForMonitor) = *GET_DPI_FOR_MONITOR {
+        // We are on Windows 8.1 or later.
+        let monitor = winuser::MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        if monitor.is_null() {
+            return BASE_DPI;
+        }
+
+        let mut dpi_x = 0;
+        let mut dpi_y = 0;
+        if GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) == S_OK {
+            dpi_x as u32
+        } else {
+            BASE_DPI
+        }
+    } else {
+        // We are on Vista or later.
+        if winuser::IsProcessDPIAware() != FALSE {
+            // If the process is DPI aware, then scaling must be handled by the application using
+            // this DPI value.
+            GetDeviceCaps(hdc, LOGPIXELSX) as u32
+        } else {
+            // If the process is DPI unaware, then scaling is performed by the OS; we thus return
+            // 96 (scale factor 1.0) to prevent the window from being re-scaled by both the
+            // application and the WM.
+            BASE_DPI
+        }
+    }
+}
+
+// Use this when you have both the HWND and HDC on hand (i.e. window methods)
+pub fn get_window_scale_factor(hwnd: HWND, hdc: HDC) -> f64 {
+    unsafe { dpi_to_scale_factor(get_window_dpi(hwnd, hdc)) }
+}
+
+// Use this when you only have the HWND (i.e. event handling)
+pub fn get_hwnd_scale_factor(hwnd: HWND) -> f64 {
+    let hdc = unsafe { winuser::GetDC(hwnd) };
+    if hdc.is_null() {
+        panic!("[winit] `GetDC` returned null!");
+    }
+    unsafe { get_window_scale_factor(hwnd, hdc) }
+}

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -44,9 +44,9 @@ use {
     Event,
     EventsLoopClosed,
     KeyboardInput,
-    LogicalCoordinates,
-    LogicalDimensions,
-    PhysicalDimensions,
+    LogicalPosition,
+    LogicalSize,
+    PhysicalSize,
     WindowAttributes,
     WindowEvent,
     WindowId as SuperWindowId,
@@ -462,7 +462,7 @@ pub unsafe extern "system" fn callback(
             let windowpos = lparam as *const winuser::WINDOWPOS;
             if (*windowpos).flags & winuser::SWP_NOMOVE != winuser::SWP_NOMOVE {
                 let dpi_factor = get_hwnd_scale_factor(window);
-                let logical_position = LogicalCoordinates::from_physical(
+                let logical_position = LogicalPosition::from_physical(
                     ((*windowpos).x, (*windowpos).y),
                     dpi_factor,
                 );
@@ -488,7 +488,7 @@ pub unsafe extern "system" fn callback(
                 let cstash = context_stash.as_mut().unwrap();
 
                 let dpi_factor = get_hwnd_scale_factor(window);
-                let logical_size = LogicalDimensions::from_physical((w, h), dpi_factor);
+                let logical_size = LogicalSize::from_physical((w, h), dpi_factor);
                 let event = Event::WindowEvent {
                     window_id: SuperWindowId(WindowId(window)),
                     event: Resized(logical_size),
@@ -1093,7 +1093,7 @@ pub unsafe extern "system" fn callback(
                 // Automatically resize for actual DPI
                 let width = LOWORD(lparam as DWORD) as u32;
                 let height = HIWORD(lparam as DWORD) as u32;
-                let (adjusted_width, adjusted_height): (u32, u32) = PhysicalDimensions::from_logical(
+                let (adjusted_width, adjusted_height): (u32, u32) = PhysicalSize::from_logical(
                     (width, height),
                     scale_factor,
                 ).into();

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -1185,7 +1185,6 @@ pub unsafe extern "system" fn callback(
                     | winuser::SWP_NOZORDER
                     | winuser::SWP_NOACTIVATE,
                 );
-                // TODO: Adjust min+max size
                 0
             } else {
                 winuser::DefWindowProcW(window, msg, wparam, lparam)

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -47,6 +47,7 @@ pub struct WindowId(HWND);
 unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}
 
+mod dpi;
 mod event;
 mod events_loop;
 mod icon;

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -5,8 +5,8 @@ use winapi::um::winuser;
 use std::{mem, ptr};
 use std::collections::VecDeque;
 
-use super::{EventsLoop, util};
 use {PhysicalPosition, PhysicalSize};
+use super::{EventsLoop, util};
 use platform::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 
 /// Win32 implementation of the main `MonitorId` object.

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -6,6 +6,7 @@ use std::{mem, ptr};
 use std::collections::VecDeque;
 
 use super::{EventsLoop, util};
+use {PhysicalPosition, PhysicalSize};
 use platform::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 
 /// Win32 implementation of the main `MonitorId` object.
@@ -128,13 +129,13 @@ impl MonitorId {
     }
 
     #[inline]
-    pub fn get_dimensions(&self) -> (u32, u32) {
-        self.dimensions
+    pub fn get_dimensions(&self) -> PhysicalSize {
+        self.dimensions.into()
     }
 
     #[inline]
-    pub fn get_position(&self) -> (i32, i32) {
-        self.position
+    pub fn get_position(&self) -> PhysicalPosition {
+        self.position.into()
     }
 
     #[inline]

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -1,38 +1,30 @@
-use winapi::ctypes::wchar_t;
-use winapi::shared::minwindef::{DWORD, LPARAM, BOOL, TRUE};
-use winapi::shared::windef::{HMONITOR, HDC, LPRECT, HWND};
+use winapi::shared::minwindef::{BOOL, DWORD, LPARAM, TRUE};
+use winapi::shared::windef::{HDC, HMONITOR, HWND, LPRECT, POINT};
 use winapi::um::winuser;
 
-use std::collections::VecDeque;
 use std::{mem, ptr};
+use std::collections::VecDeque;
 
 use super::{EventsLoop, util};
+use platform::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 
 /// Win32 implementation of the main `MonitorId` object.
 #[derive(Debug, Clone)]
 pub struct MonitorId {
-    /// The system name of the adapter.
-    adapter_name: [wchar_t; 32],
-
     /// Monitor handle.
     hmonitor: HMonitor,
-
     /// The system name of the monitor.
     monitor_name: String,
-
     /// True if this is the primary monitor.
     primary: bool,
-
     /// The position of the monitor in pixels on the desktop.
     ///
     /// A window that is positioned at these coordinates will overlap the monitor.
     position: (i32, i32),
-
     /// The current resolution in pixels on the monitor.
     dimensions: (u32, u32),
-
-    /// DPI scaling factor.
-    hidpi_factor: f32,
+    /// DPI scale factor.
+    hidpi_factor: f64,
 }
 
 // Send is not implemented for HMONITOR, we have to wrap it and implement it manually.
@@ -44,122 +36,109 @@ struct HMonitor(HMONITOR);
 
 unsafe impl Send for HMonitor {}
 
-unsafe extern "system" fn monitor_enum_proc(hmonitor: HMONITOR, _: HDC, place: LPRECT, data: LPARAM) -> BOOL {
+unsafe extern "system" fn monitor_enum_proc(
+    hmonitor: HMONITOR,
+    _hdc: HDC,
+    _place: LPRECT,
+    data: LPARAM,
+) -> BOOL {
     let monitors = data as *mut VecDeque<MonitorId>;
-
-    let place = *place;
-    let position = (place.left as i32, place.top as i32);
-    let dimensions = ((place.right - place.left) as u32, (place.bottom - place.top) as u32);
-
-    let mut monitor_info: winuser::MONITORINFOEXW = mem::zeroed();
-    monitor_info.cbSize = mem::size_of::<winuser::MONITORINFOEXW>() as DWORD;
-    if winuser::GetMonitorInfoW(hmonitor, &mut monitor_info as *mut winuser::MONITORINFOEXW as *mut winuser::MONITORINFO) == 0 {
-        // Some error occurred, just skip this monitor and go on.
-        return TRUE;
-    }
-
-    (*monitors).push_back(MonitorId {
-        adapter_name: monitor_info.szDevice,
-        hmonitor: HMonitor(hmonitor),
-        monitor_name: util::wchar_to_string(&monitor_info.szDevice),
-        primary: monitor_info.dwFlags & winuser::MONITORINFOF_PRIMARY != 0,
-        position,
-        dimensions,
-        hidpi_factor: 1.0,
-    });
-
-    // TRUE means continue enumeration.
-    TRUE
+    (*monitors).push_back(MonitorId::from_hmonitor(hmonitor));
+    TRUE // continue enumeration
 }
 
 impl EventsLoop {
+    // TODO: Investigate opportunities for caching
     pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
+        let mut monitors: VecDeque<MonitorId> = VecDeque::new();
         unsafe {
-            let mut result: VecDeque<MonitorId> = VecDeque::new();
-            winuser::EnumDisplayMonitors(ptr::null_mut(), ptr::null_mut(), Some(monitor_enum_proc), &mut result as *mut _ as LPARAM);
-            result
+            winuser::EnumDisplayMonitors(
+                ptr::null_mut(),
+                ptr::null_mut(),
+                Some(monitor_enum_proc),
+                &mut monitors as *mut _ as LPARAM,
+            );
         }
+        monitors
     }
 
-    pub fn get_current_monitor(handle: HWND) -> MonitorId {
-        unsafe {
-            let mut monitor_info: winuser::MONITORINFOEXW = mem::zeroed();
-            monitor_info.cbSize = mem::size_of::<winuser::MONITORINFOEXW>() as DWORD;
-
-            let hmonitor = winuser::MonitorFromWindow(handle, winuser::MONITOR_DEFAULTTONEAREST);
-
-            winuser::GetMonitorInfoW(
-                hmonitor,
-                &mut monitor_info as *mut winuser::MONITORINFOEXW as *mut winuser::MONITORINFO,
-            );
-
-            let place = monitor_info.rcMonitor;
-            let position = (place.left as i32, place.top as i32);
-            let dimensions = (
-                (place.right - place.left) as u32,
-                (place.bottom - place.top) as u32,
-            );
-
-            MonitorId {
-                adapter_name: monitor_info.szDevice,
-                hmonitor: super::monitor::HMonitor(hmonitor),
-                monitor_name: util::wchar_to_string(&monitor_info.szDevice),
-                primary: monitor_info.dwFlags & winuser::MONITORINFOF_PRIMARY != 0,
-                position,
-                dimensions,
-                hidpi_factor: 1.0,
-            }
-        }
+    pub fn get_current_monitor(hwnd: HWND) -> MonitorId {
+        let hmonitor = unsafe {
+            winuser::MonitorFromWindow(hwnd, winuser::MONITOR_DEFAULTTONEAREST)
+        };
+        MonitorId::from_hmonitor(hmonitor)
     }
 
     pub fn get_primary_monitor(&self) -> MonitorId {
-        // we simply get all available monitors and return the one with the `MONITORINFOF_PRIMARY` flag
-        // TODO: it is possible to query the win32 API for the primary monitor, this should be done
-        //  instead
-        for monitor in self.get_available_monitors().into_iter() {
-            if monitor.primary {
-                return monitor;
-            }
-        }
+        const ORIGIN: POINT = POINT { x: 0, y: 0 };
+        let hmonitor = unsafe {
+            winuser::MonitorFromPoint(ORIGIN, winuser::MONITOR_DEFAULTTOPRIMARY)
+        };
+        MonitorId::from_hmonitor(hmonitor)
+    }
+}
 
-        panic!("Failed to find the primary monitor")
+fn get_monitor_info(hmonitor: HMONITOR) -> Result<winuser::MONITORINFOEXW, util::WinError> {
+    let mut monitor_info: winuser::MONITORINFOEXW = unsafe { mem::uninitialized() };
+    monitor_info.cbSize = mem::size_of::<winuser::MONITORINFOEXW>() as DWORD;
+    let status = unsafe {
+        winuser::GetMonitorInfoW(
+            hmonitor,
+            &mut monitor_info as *mut winuser::MONITORINFOEXW as *mut winuser::MONITORINFO,
+        )
+    };
+    if status == 0 {
+        Err(util::WinError::from_last_error())
+    } else {
+        Ok(monitor_info)
     }
 }
 
 impl MonitorId {
-    /// See the docs if the crate root file.
+    pub(crate) fn from_hmonitor(hmonitor: HMONITOR) -> Self {
+        let monitor_info = get_monitor_info(hmonitor).expect("`GetMonitorInfoW` failed");
+        let place = monitor_info.rcMonitor;
+        let dimensions = (
+            (place.right - place.left) as u32,
+            (place.bottom - place.top) as u32,
+        );
+        MonitorId {
+            hmonitor: HMonitor(hmonitor),
+            monitor_name: util::wchar_ptr_to_string(monitor_info.szDevice.as_ptr()),
+            primary: util::has_flag(monitor_info.dwFlags, winuser::MONITORINFOF_PRIMARY),
+            position: (place.left as i32, place.top as i32),
+            dimensions,
+            hidpi_factor: dpi_to_scale_factor(get_monitor_dpi(hmonitor).unwrap_or(96)),
+        }
+    }
+
     #[inline]
     pub fn get_name(&self) -> Option<String> {
         Some(self.monitor_name.clone())
     }
 
-    /// See the docs of the crate root file.
     #[inline]
     pub fn get_native_identifier(&self) -> String {
         self.monitor_name.clone()
     }
 
-    /// See the docs of the crate root file.
     #[inline]
     pub fn get_hmonitor(&self) -> HMONITOR {
         self.hmonitor.0
     }
 
-    /// See the docs of the crate root file.
     #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
-        // TODO: retrieve the dimensions every time this is called
         self.dimensions
     }
 
-    /// A window that is positioned at these coordinates will overlap the monitor.
     #[inline]
     pub fn get_position(&self) -> (i32, i32) {
         self.position
     }
 
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         self.hidpi_factor
     }
 }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -26,7 +26,6 @@ use {
     PhysicalSize,
     WindowAttributes,
 };
-
 use platform::platform::{Cursor, EventsLoop, PlatformSpecificWindowBuilderAttributes, WindowId};
 use platform::platform::dpi::{BASE_DPI, dpi_to_scale_factor, get_window_dpi, get_window_scale_factor};
 use platform::platform::events_loop::{self, DESTROY_MSG_ID, INITIAL_DPI_MSG_ID};

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -975,9 +975,9 @@ unsafe fn init(
 
     let window_state = {
         let max_size = attributes.max_dimensions
-            .map(|logical_size| PhysicalSize::from_logical(logical_size, 1.0));
+            .map(|logical_size| PhysicalSize::from_logical(logical_size, dpi_factor));
         let min_size = attributes.min_dimensions
-            .map(|logical_size| PhysicalSize::from_logical(logical_size, 1.0));
+            .map(|logical_size| PhysicalSize::from_logical(logical_size, dpi_factor));
         let mut window_state = events_loop::WindowState {
             cursor: Cursor(winuser::IDC_ARROW), // use arrow by default
             cursor_state: CursorState::Normal,
@@ -987,8 +987,6 @@ unsafe fn init(
             saved_window_info: None,
             dpi_factor,
         };
-        // Adjust min/max dimensions for DPI.
-        window_state.update_min_max(1.0, dpi_factor);
         // Creating a mutex to track the current window state
         Arc::new(Mutex::new(window_state))
     };

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -911,7 +911,7 @@ unsafe fn init(
             style | winuser::WS_VISIBLE
         };
 
-        if !window.resizable {
+        if !attributes.resizable {
             style &= !winuser::WS_SIZEBOX;
         }
 

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -19,8 +19,8 @@ use {
     CreationError,
     CursorState,
     Icon,
-    LogicalCoordinates,
-    LogicalDimensions,
+    LogicalPosition,
+    LogicalSize,
     MonitorId as RootMonitorId,
     MouseCursor,
     WindowAttributes,
@@ -120,11 +120,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
         self.get_position_physical()
             .map(|physical_position| {
                 let dpi_factor = self.get_hidpi_factor();
-                LogicalCoordinates::from_physical(physical_position, dpi_factor)
+                LogicalPosition::from_physical(physical_position, dpi_factor)
             })
     }
 
@@ -137,11 +137,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         self.get_inner_position_physical()
             .map(|physical_position| {
                 let dpi_factor = self.get_hidpi_factor();
-                LogicalCoordinates::from_physical(physical_position, dpi_factor)
+                LogicalPosition::from_physical(physical_position, dpi_factor)
             })
     }
 
@@ -161,7 +161,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_position(&self, logical_position: LogicalCoordinates) {
+    pub fn set_position(&self, logical_position: LogicalPosition) {
         let dpi_factor = self.get_hidpi_factor();
         let (x, y) = logical_position.to_physical(dpi_factor).into();
         self.set_position_physical(x, y);
@@ -179,11 +179,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
         self.get_inner_size_physical()
             .map(|physical_size| {
                 let dpi_factor = self.get_hidpi_factor();
-                LogicalDimensions::from_physical(physical_size, dpi_factor)
+                LogicalSize::from_physical(physical_size, dpi_factor)
             })
     }
 
@@ -196,11 +196,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         self.get_outer_size_physical()
             .map(|physical_size| {
                 let dpi_factor = self.get_hidpi_factor();
-                LogicalDimensions::from_physical(physical_size, dpi_factor)
+                LogicalSize::from_physical(physical_size, dpi_factor)
             })
     }
 
@@ -236,7 +236,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_inner_size(&self, logical_size: LogicalDimensions) {
+    pub fn set_inner_size(&self, logical_size: LogicalSize) {
         let dpi_factor = self.get_hidpi_factor();
         let (width, height) = logical_size.to_physical(dpi_factor).into();
         self.set_inner_size_physical(width, height);
@@ -279,7 +279,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_min_dimensions(&self, logical_size: Option<LogicalDimensions>) {
+    pub fn set_min_dimensions(&self, logical_size: Option<LogicalSize>) {
         let physical_size = logical_size.map(|logical_size| {
             let dpi_factor = self.get_hidpi_factor();
             logical_size.to_physical(dpi_factor).into()
@@ -324,7 +324,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_max_dimensions(&self, logical_size: Option<LogicalDimensions>) {
+    pub fn set_max_dimensions(&self, logical_size: Option<LogicalSize>) {
         let physical_size = logical_size.map(|logical_size| {
             let dpi_factor = self.get_hidpi_factor();
             logical_size.to_physical(dpi_factor).into()
@@ -513,7 +513,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, logical_position: LogicalCoordinates) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, logical_position: LogicalPosition) -> Result<(), ()> {
         let dpi_factor = self.get_hidpi_factor();
         let (x, y) = logical_position.to_physical(dpi_factor).into();
         self.set_cursor_position_physical(x, y)
@@ -834,7 +834,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_spot(&self, _logical_spot: LogicalCoordinates) {
+    pub fn set_ime_spot(&self, _logical_spot: LogicalPosition) {
         unimplemented!();
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -310,13 +310,6 @@ impl Window {
         self.window.set_resizable(resizable)
     }
 
-    /// Modifies the mouse cursor of the window.
-    /// Has no effect on Android.
-    #[inline]
-    pub fn set_cursor(&self, cursor: MouseCursor) {
-        self.window.set_cursor(cursor);
-    }
-
     /// Returns the ratio between the backing framebuffer resolution and the
     /// window size in screen pixels. This is typically one for a normal display
     /// and two for a retina display.
@@ -327,6 +320,13 @@ impl Window {
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {
         self.window.get_hidpi_factor()
+    }
+
+    /// Modifies the mouse cursor of the window.
+    /// Has no effect on Android.
+    #[inline]
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+        self.window.set_cursor(cursor);
     }
 
     /// Changes the position of the cursor in window coordinates.

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,8 +5,8 @@ use {
     CursorState,
     EventsLoop,
     Icon,
-    LogicalCoordinates,
-    LogicalDimensions,
+    LogicalPosition,
+    LogicalSize,
     MouseCursor,
     platform,
     Window,
@@ -222,7 +222,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_position(&self) -> Option<LogicalPosition> {
         self.window.get_position()
     }
 
@@ -231,7 +231,7 @@ impl Window {
     ///
     /// The same conditions that apply to `get_position` apply to this method.
     #[inline]
-    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
         self.window.get_inner_position()
     }
 
@@ -241,7 +241,7 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_position(&self, position: LogicalCoordinates) {
+    pub fn set_position(&self, position: LogicalPosition) {
         self.window.set_position(position)
     }
 
@@ -252,7 +252,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
         self.window.get_inner_size()
     }
 
@@ -263,7 +263,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
         self.window.get_outer_size()
     }
 
@@ -273,7 +273,7 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalDimensions) {
+    pub fn set_inner_size(&self, size: LogicalSize) {
         self.window.set_inner_size(size)
     }
 
@@ -281,7 +281,7 @@ impl Window {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<LogicalDimensions>) {
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         self.window.set_min_dimensions(dimensions)
     }
 
@@ -289,7 +289,7 @@ impl Window {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<LogicalDimensions>) {
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
         self.window.set_max_dimensions(dimensions)
     }
 
@@ -329,7 +329,7 @@ impl Window {
 
     /// Changes the position of the cursor in window coordinates.
     #[inline]
-    pub fn set_cursor_position(&self, position: LogicalCoordinates) -> Result<(), ()> {
+    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ()> {
         self.window.set_cursor_position(position)
     }
 
@@ -380,7 +380,7 @@ impl Window {
 
     /// Sets location of IME candidate box in client area coordinates relative to the top left.
     #[inline]
-    pub fn set_ime_spot(&self, position: LogicalCoordinates) {
+    pub fn set_ime_spot(&self, position: LogicalPosition) {
         self.window.set_ime_spot(position)
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,7 +1,5 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 
-use libc;
-
 use {
     CreationError,
     CursorState,
@@ -148,6 +146,7 @@ impl WindowBuilder {
     ///
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     /// out of memory, etc.
+    #[inline]
     pub fn build(mut self, events_loop: &EventsLoop) -> Result<Window, CreationError> {
         self.window.dimensions = Some(self.window.dimensions.unwrap_or_else(|| {
             if let Some(ref monitor) = self.window.fullscreen {
@@ -309,26 +308,9 @@ impl Window {
         self.window.set_resizable(resizable)
     }
 
-    /// DEPRECATED. Gets the native platform specific display for this window.
-    /// This is typically only required when integrating with
-    /// other libraries that need this information.
-    #[deprecated]
-    #[inline]
-    pub unsafe fn platform_display(&self) -> *mut libc::c_void {
-        self.window.platform_display()
-    }
-
-    /// DEPRECATED. Gets the native platform specific window handle. This is
-    /// typically only required when integrating with other libraries
-    /// that need this information.
-    #[deprecated]
-    #[inline]
-    pub unsafe fn platform_window(&self) -> *mut libc::c_void {
-        self.window.platform_window()
-    }
-
     /// Modifies the mouse cursor of the window.
     /// Has no effect on Android.
+    #[inline]
     pub fn set_cursor(&self, cursor: MouseCursor) {
         self.window.set_cursor(cursor);
     }
@@ -403,6 +385,7 @@ impl Window {
     }
 
     /// Returns the monitor on which the window currently resides
+    #[inline]
     pub fn get_current_monitor(&self) -> MonitorId {
         self.window.get_current_monitor()
     }
@@ -468,7 +451,7 @@ impl MonitorId {
     /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
     /// variable.
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f32 {
+    pub fn get_hidpi_factor(&self) -> f64 {
         self.inner.get_hidpi_factor()
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -27,8 +27,6 @@ impl WindowBuilder {
     }
 
     /// Requests the window to be of specific dimensions.
-    ///
-    /// Width and height are in pixels.
     #[inline]
     pub fn with_dimensions(mut self, size: LogicalSize) -> WindowBuilder {
         self.window.dimensions = Some(size);
@@ -36,8 +34,6 @@ impl WindowBuilder {
     }
 
     /// Sets a minimum dimension size for the window
-    ///
-    /// Width and height are in pixels.
     #[inline]
     pub fn with_min_dimensions(mut self, min_size: LogicalSize) -> WindowBuilder {
         self.window.min_dimensions = Some(min_size);
@@ -45,8 +41,6 @@ impl WindowBuilder {
     }
 
     /// Sets a maximum dimension size for the window
-    ///
-    /// Width and height are in pixels.
     #[inline]
     pub fn with_max_dimensions(mut self, max_size: LogicalSize) -> WindowBuilder {
         self.window.max_dimensions = Some(max_size);
@@ -247,10 +241,11 @@ impl Window {
         self.window.set_position(position)
     }
 
-    /// Returns the size in pixels of the client area of the window.
+    /// Returns the logical size of the window's client area.
     ///
     /// The client area is the content of the window, excluding the title bar and borders.
-    /// These are the dimensions that need to be supplied to `glViewport`.
+    ///
+    /// Converting the returned `LogicalSize` to `PhysicalSize` produces the size your framebuffer should be.
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
@@ -258,10 +253,10 @@ impl Window {
         self.window.get_inner_size()
     }
 
-    /// Returns the size in pixels of the window.
+    /// Returns the logical size of the entire window.
     ///
-    /// These dimensions include title bar and borders. If you don't want these, you should use
-    ///  use `get_inner_size` instead.
+    /// These dimensions include the title bar and borders. If you don't want that (and you usually don't),
+    /// use `get_inner_size` instead.
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
@@ -280,16 +275,12 @@ impl Window {
     }
 
     /// Sets a minimum dimension size for the window.
-    ///
-    /// Width and height are in pixels.
     #[inline]
     pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
         self.window.set_min_dimensions(dimensions)
     }
 
     /// Sets a maximum dimension size for the window.
-    ///
-    /// Width and height are in pixels.
     #[inline]
     pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
         self.window.set_max_dimensions(dimensions)
@@ -310,13 +301,14 @@ impl Window {
         self.window.set_resizable(resizable)
     }
 
-    /// Returns the ratio between the backing framebuffer resolution and the
-    /// window size in screen pixels. This is typically one for a normal display
-    /// and two for a retina display.
+    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    ///
+    /// See the [`dpi`](dpi/index.html) module for more information.
     ///
     /// ## Platform-specific
-    /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
-    /// variable.
+    ///
+    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **Android:** Always returns 1.0.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {
         self.window.get_hidpi_factor()
@@ -434,7 +426,7 @@ impl MonitorId {
         self.inner.get_name()
     }
 
-    /// Returns the number of pixels currently displayed on the monitor.
+    /// Returns the monitor's resolution.
     #[inline]
     pub fn get_dimensions(&self) -> PhysicalSize {
         self.inner.get_dimensions()
@@ -447,11 +439,14 @@ impl MonitorId {
         self.inner.get_position()
     }
 
-    /// Returns the ratio between the monitor's physical pixels and logical pixels.
+    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    ///
+    /// See the [`dpi`](dpi/index.html) module for more information.
     ///
     /// ## Platform-specific
-    /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
-    /// variable.
+    ///
+    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **Android:** Always returns 1.0.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {
         self.inner.get_hidpi_factor()

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,6 +8,8 @@ use {
     LogicalPosition,
     LogicalSize,
     MouseCursor,
+    PhysicalPosition,
+    PhysicalSize,
     platform,
     Window,
     WindowBuilder,
@@ -28,8 +30,8 @@ impl WindowBuilder {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn with_dimensions(mut self, width: u32, height: u32) -> WindowBuilder {
-        self.window.dimensions = Some((width, height));
+    pub fn with_dimensions(mut self, size: LogicalSize) -> WindowBuilder {
+        self.window.dimensions = Some(size);
         self
     }
 
@@ -37,8 +39,8 @@ impl WindowBuilder {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn with_min_dimensions(mut self, width: u32, height: u32) -> WindowBuilder {
-        self.window.min_dimensions = Some((width, height));
+    pub fn with_min_dimensions(mut self, min_size: LogicalSize) -> WindowBuilder {
+        self.window.min_dimensions = Some(min_size);
         self
     }
 
@@ -46,8 +48,8 @@ impl WindowBuilder {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn with_max_dimensions(mut self, width: u32, height: u32) -> WindowBuilder {
-        self.window.max_dimensions = Some((width, height));
+    pub fn with_max_dimensions(mut self, max_size: LogicalSize) -> WindowBuilder {
+        self.window.max_dimensions = Some(max_size);
         self
     }
 
@@ -151,10 +153,10 @@ impl WindowBuilder {
         self.window.dimensions = Some(self.window.dimensions.unwrap_or_else(|| {
             if let Some(ref monitor) = self.window.fullscreen {
                 // resizing the window to the dimensions of the monitor when fullscreen
-                monitor.get_dimensions()
+                LogicalSize::from_physical(monitor.get_dimensions(), 1.0)
             } else {
                 // default dimensions
-                (1024, 768)
+                (1024, 768).into()
             }
         }));
 
@@ -434,14 +436,14 @@ impl MonitorId {
 
     /// Returns the number of pixels currently displayed on the monitor.
     #[inline]
-    pub fn get_dimensions(&self) -> (u32, u32) {
+    pub fn get_dimensions(&self) -> PhysicalSize {
         self.inner.get_dimensions()
     }
 
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
     #[inline]
-    pub fn get_position(&self) -> (i32, i32) {
+    pub fn get_position(&self) -> PhysicalPosition {
         self.inner.get_position()
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,16 +1,20 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 
-use CreationError;
-use CursorState;
-use EventsLoop;
-use Icon;
-use MouseCursor;
-use Window;
-use WindowBuilder;
-use WindowId;
-
 use libc;
-use platform;
+
+use {
+    CreationError,
+    CursorState,
+    EventsLoop,
+    Icon,
+    LogicalCoordinates,
+    LogicalDimensions,
+    MouseCursor,
+    platform,
+    Window,
+    WindowBuilder,
+    WindowId,
+};
 
 impl WindowBuilder {
     /// Initializes a new `WindowBuilder` with default values.
@@ -219,7 +223,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_position(&self) -> Option<(i32, i32)> {
+    pub fn get_position(&self) -> Option<LogicalCoordinates> {
         self.window.get_position()
     }
 
@@ -228,7 +232,7 @@ impl Window {
     ///
     /// The same conditions that apply to `get_position` apply to this method.
     #[inline]
-    pub fn get_inner_position(&self) -> Option<(i32, i32)> {
+    pub fn get_inner_position(&self) -> Option<LogicalCoordinates> {
         self.window.get_inner_position()
     }
 
@@ -238,8 +242,8 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_position(&self, x: i32, y: i32) {
-        self.window.set_position(x, y)
+    pub fn set_position(&self, position: LogicalCoordinates) {
+        self.window.set_position(position)
     }
 
     /// Returns the size in pixels of the client area of the window.
@@ -249,39 +253,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
-        self.window.get_inner_size()
-    }
-
-    /// Returns the size in points of the client area of the window.
-    ///
-    /// The client area is the content of the window, excluding the title bar and borders.
-    /// To get the dimensions of the frame buffer when calling `glViewport`, multiply with hidpi factor.
-    ///
-    /// Returns `None` if the window no longer exists.
-    ///
-    /// DEPRECATED
-    #[inline]
-    #[deprecated]
-    pub fn get_inner_size_points(&self) -> Option<(u32, u32)> {
-        self.window.get_inner_size().map(|(x, y)| {
-            let hidpi = self.hidpi_factor();
-            ((x as f32 / hidpi) as u32, (y as f32 / hidpi) as u32)
-        })
-    }
-
-    /// Returns the size in pixels of the client area of the window.
-    ///
-    /// The client area is the content of the window, excluding the title bar and borders.
-    /// These are the dimensions of the frame buffer, and the dimensions that you should use
-    ///  when you call `glViewport`.
-    ///
-    /// Returns `None` if the window no longer exists.
-    ///
-    /// DEPRECATED
-    #[inline]
-    #[deprecated]
-    pub fn get_inner_size_pixels(&self) -> Option<(u32, u32)> {
+    pub fn get_inner_size(&self) -> Option<LogicalDimensions> {
         self.window.get_inner_size()
     }
 
@@ -292,7 +264,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(u32, u32)> {
+    pub fn get_outer_size(&self) -> Option<LogicalDimensions> {
         self.window.get_outer_size()
     }
 
@@ -302,15 +274,15 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_inner_size(&self, x: u32, y: u32) {
-        self.window.set_inner_size(x, y)
+    pub fn set_inner_size(&self, size: LogicalDimensions) {
+        self.window.set_inner_size(size)
     }
 
     /// Sets a minimum dimension size for the window.
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalDimensions>) {
         self.window.set_min_dimensions(dimensions)
     }
 
@@ -318,7 +290,7 @@ impl Window {
     ///
     /// Width and height are in pixels.
     #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalDimensions>) {
         self.window.set_max_dimensions(dimensions)
     }
 
@@ -369,14 +341,14 @@ impl Window {
     /// On X11 the DPI factor can be overridden using the `WINIT_HIDPI_FACTOR` environment
     /// variable.
     #[inline]
-    pub fn hidpi_factor(&self) -> f32 {
-        self.window.hidpi_factor()
+    pub fn get_hidpi_factor(&self) -> f64 {
+        self.window.get_hidpi_factor()
     }
 
     /// Changes the position of the cursor in window coordinates.
     #[inline]
-    pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
-        self.window.set_cursor_position(x, y)
+    pub fn set_cursor_position(&self, position: LogicalCoordinates) -> Result<(), ()> {
+        self.window.set_cursor_position(position)
     }
 
     /// Sets how winit handles the cursor. See the documentation of `CursorState` for details.
@@ -426,8 +398,8 @@ impl Window {
 
     /// Sets location of IME candidate box in client area coordinates relative to the top left.
     #[inline]
-    pub fn set_ime_spot(&self, x: i32, y: i32) {
-        self.window.set_ime_spot(x, y)
+    pub fn set_ime_spot(&self, position: LogicalCoordinates) {
+        self.window.set_ime_spot(position)
     }
 
     /// Returns the monitor on which the window currently resides


### PR DESCRIPTION
Fixes #62
Fixes #105
Fixes #169 
Fixes #315
Fixes #332 (big thanks to @kryptan for the initial work on Windows!)
Fixes #337
Fixes #469
Fixes tomaka/glutin#1025

Alright, it was quite the undertaking, but I believe I've finished this on X11, Windows, macOS, iOS, Android, and Emscripten.

Some caveats:
- The Intel OpenGL driver on Windows still has some problems in mixed-DPI environments. It doesn't happen with DirectX or Vulkan (and OpenGL with Nvidia works fine), and it will only affect people who either A) have multiple monitors of differing scale factors, or B) change the scale factor after login. The issue itself is just that there's a small black/background-colored gap below the titlebar; this doesn't happen without DPI awareness, but I think this is an acceptable trade-off. Besides, if users disagree, it's still possible to disable DPI awareness using `EventsLoopExt`.
- Android still returns a DPI factor of 1.0. As far as I can tell, getting the real value won't be possible until tomaka/android-rs-glue#116 is sorted out. However, once that's filled in the code I've added here should do all the right conversions.
- I couldn't really test Emscripten, since I was unable to get anything to actually run in my browser.
- iOS was an adventure, and I ended up reworking glutin's iOS backend (it's apparently been broken for quite some time). I still never got anything to render, but I can at least say that it reported the correct sizes and DPI factor. I've unfortunately introduced a small amount of GL-specific code to the iOS backend here; I plan on doing some restructuring and fixing that before this makes it into a release, but I didn't want to make this PR any more huge and monolithic than it is already.
- My solution for Wayland was just to comment things out in `src/platform/linux/mod.rs` and say "@vberger will figure this out later"

That said, this PR is functionally complete. The only reason I've labeled it WIP is because it's still completely undocumented! I just wanted an opportunity for feedback before I start fussing over doc comments. (I also noticed that I left a `// TODO: Adjust min+max size` in the Windows backend, whoops)

I won't reiterate what I wrote in `CHANGELOG.md`. Besides there, the other files I recommend looking at are `src/dpi.rs`and `src/window.rs`. You can obviously also test this, and I've provided some partial migrations of various things to help with that:
- [glutin](https://github.com/francesca64/glutin/tree/super-dpi) - everything should work except for the examples, and note that `GlWindow::resize` doesn't yet explicitly take `PhysicalSize`.
- [gfx pre-ll](https://github.com/francesca64/gfx/tree/super-dpi) - everything should work except for the examples.
- [alacritty](https://github.com/francesca64/alacritty/tree/super-dpi) - it seems fine on macOS, though on X11 it seems to "double upscale" on HiDPI displays. This is almost certainly a result of the math in the auto-resize Alacritty does after creation, but I couldn't find where it does that.

Migrating can be tedious, but isn't hard, and the more explicit API resulted in me fixing some bugs in my own applications. Overall, I'm pretty satisfied, but if anyone has objections, I'm in no rush to merge this. I want to release a 0.15.1 with various regression fixes before introducing any breaking changes like this.