### PR TITLE
macOS: Resizable without decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
-- `WindowBuilder::with_resizable` implemented for Windows & X11.
+- `WindowBuilder::with_resizable` implemented for Windows, X11, and macOS.
 - On X11, if the monitor's width or height in millimeters is reported as 0, the DPI is now 1.0 instead of +inf.
 - On X11, the environment variable `WINIT_HIDPI_FACTOR` has been added for overriding DPI factor.
 - On X11, enabling transparency no longer causes the window contents to flicker when resizing.
 - On X11, `with_override_redirect` now actually enables override redirect.
 - macOS now generates `VirtualKeyCode::LAlt` and `VirtualKeyCode::RAlt` instead of `None` for both.
 - On macOS, `VirtualKeyCode::RWin` and `VirtualKeyCode::LWin` are no longer switched.
+- On macOS, windows without decorations can once again be resized.
 
 # Version 0.15.0 (2018-05-22)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -53,7 +53,7 @@ impl WindowBuilder {
     ///
     /// ## Platform-specific
     ///
-    /// This only has an effect on Windows & X11.
+    /// This only has an effect on Windows, X11, and macOS.
     #[inline]
     pub fn with_resizable(mut self, resizable: bool) -> WindowBuilder {
         self.window.resizable = resizable;


### PR DESCRIPTION
Fixes jwilm/alacritty#1345

As a bonus, I threw in an implementation for `with_resizable` for #540 (and `set_resizable`, though it isn't exposed yet).