### PR TITLE
X11: implement with_resizable (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
-- `WindowBuilder::with_resizable` implemented for Windows.
+- `WindowBuilder::with_resizable` implemented for Windows & X11.
 - On X11, if the monitor's width or height in millimeters is reported as 0, the DPI is now 1.0 instead of +inf.
 - On X11, the environment variable `WINIT_HIDPI_FACTOR` has been added for overriding DPI factor.
 - On X11, enabling transparency no longer causes the window contents to flicker when resizing.

--- a/examples/no_resize.rs
+++ b/examples/no_resize.rs
@@ -11,8 +11,6 @@ fn main() {
         .unwrap();
 
     events_loop.run_forever(|event| {
-        println!("{:?}", event);
-
         match event {
             winit::Event::WindowEvent {
                 event: winit::WindowEvent::CloseRequested,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub max_dimensions: Option<(u32, u32)>,
 
-    /// [Windows only] Whether the window is resizable or not
+    /// [Windows & X11 only] Whether the window is resizable or not
     ///
     /// The default is `true`.
     pub resizable: bool,

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -216,16 +216,23 @@ impl UnownedWindow {
 
             // set size hints
             {
+                let mut min_dimensions = window_attrs.min_dimensions;
+                let mut max_dimensions = window_attrs.max_dimensions;
+                if !window_attrs.resizable {
+                    max_dimensions = Some(dimensions);
+                    min_dimensions = Some(dimensions);
+                }
+
                 let mut size_hints = xconn.alloc_size_hints();
                 (*size_hints).flags = ffi::PSize;
                 (*size_hints).width = dimensions.0 as c_int;
                 (*size_hints).height = dimensions.1 as c_int;
-                if let Some((min_width, min_height)) = window_attrs.min_dimensions {
+                if let Some((min_width, min_height)) = min_dimensions {
                     (*size_hints).flags |= ffi::PMinSize;
                     (*size_hints).min_width = min_width as c_int;
                     (*size_hints).min_height = min_height as c_int;
                 }
-                if let Some((max_width, max_height)) = window_attrs.max_dimensions {
+                if let Some((max_width, max_height)) = max_dimensions {
                     (*size_hints).flags |= ffi::PMaxSize;
                     (*size_hints).max_width = max_width as c_int;
                     (*size_hints).max_height = max_height as c_int;

--- a/src/window.rs
+++ b/src/window.rs
@@ -53,7 +53,7 @@ impl WindowBuilder {
     ///
     /// ## Platform-specific
     ///
-    /// This only has an effect on Windows.
+    /// This only has an effect on Windows & X11.
     #[inline]
     pub fn with_resizable(mut self, resizable: bool) -> WindowBuilder {
         self.window.resizable = resizable;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality

Setting the min/max to the same value creates a non-resizable window with X11.

regarding #540 