### PR TITLE
Release winit 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Version 0.15.1 (2018-06-13)
+
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
 - `WindowBuilder::with_resizable` implemented for Windows, X11, Wayland, and macOS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["The winit contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]


### PR DESCRIPTION
The good thing about this release is that it fixes various bugs that people weren't fond of.

The bad thing thing about this release is that I'll no longer be able to procrastinate on writing documentation for #548...

Though, this won't merge until after @vberger fills in Wayland support for `with_resizable`/`set_resizable`, so that still gives me some time for doing nothing.