### PR TITLE
wayland: implement set_resizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - On X11, the `Moved` event is no longer sent when the window is resized without changing position.
 - `MouseCursor` and `CursorState` now implement `Default`.
-- `WindowBuilder::with_resizable` implemented for Windows, X11, and macOS.
-- `Window::set_resizable` implemented for Windows, X11, and macOS.
+- `WindowBuilder::with_resizable` implemented for Windows, X11, Wayland, and macOS.
+- `Window::set_resizable` implemented for Windows, X11, Wayland, and macOS.
 - On X11, if the monitor's width or height in millimeters is reported as 0, the DPI is now 1.0 instead of +inf.
 - On X11, the environment variable `WINIT_HIDPI_FACTOR` has been added for overriding DPI factor.
 - On X11, enabling transparency no longer causes the window contents to flicker when resizing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 wayland-client = { version = "0.20.6", features = [ "dlopen", "egl", "cursor"] }
-smithay-client-toolkit = "0.2.1"
+smithay-client-toolkit = "0.2.2"
 x11-dl = "2.17.5"
 parking_lot = "0.5"
 percent-encoding = "1.0"

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -237,7 +237,7 @@ impl Window {
     pub fn set_resizable(&self, resizable: bool) {
         match self {
             &Window::X(ref w) => w.set_resizable(resizable),
-            &Window::Wayland(ref _w) => unimplemented!(),
+            &Window::Wayland(ref w) => w.set_resizable(resizable),
         }
     }
 

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -101,6 +101,8 @@ impl Window {
             frame.set_maximized();
         }
 
+        frame.set_resizable(attributes.resizable);
+
         // set decorations
         frame.set_decorate(attributes.decorations);
 
@@ -196,6 +198,11 @@ impl Window {
     #[inline]
     pub fn set_max_dimensions(&self, dimensions: Option<(u32, u32)>) {
         self.frame.lock().unwrap().set_max_size(dimensions);
+    }
+
+    #[inline]
+    pub fn set_resizable(&self, resizable: bool) {
+        self.frame.lock().unwrap().set_resizable(resizable);
     }
 
     #[inline]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality

I believe this should be pretty trivial to review. :)

I tested it on weston, based on the glutin examples.