### PR TITLE
macOS: Fix doubled key repeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - HiDPI support for Wayland.
 - `EventsLoop::get_available_monitors` and `EventsLoop::get_primary_monitor` now have identical counterparts on `Window`, so this information can be acquired without an `EventsLoop` borrow.
 - `AvailableMonitorsIter` now implements `Debug`.
+- Fixed quirk on macOS where certain keys would generate characters at twice the normal rate when held down.
 
 # Version 0.15.1 (2018-06-13)
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -399,10 +399,10 @@ impl EventsLoop {
                 // If the mouse movement was on one of our windows, use it.
                 // Otherwise, if one of our windows is the key window (receiving input), use it.
                 // Otherwise, return `None`.
-                let window = match maybe_window.or_else(maybe_key_window) {
-                    Some(window) => window,
+                match maybe_window.or_else(maybe_key_window) {
+                    Some(_window) => (),
                     None => return None,
-                };
+                }
 
                 let mut events = std::collections::VecDeque::with_capacity(3);
 

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -396,11 +396,14 @@ extern fn key_down(this: &Object, _sel: Sel, event: id) {
                         .unwrap()
                         .push_back(window_event);
                 }
+            } else {
+                // Some keys (and only *some*, with no known reason) don't trigger `insertText`, while others do...
+                // So, we don't give repeats the opportunity to trigger that, since otherwise our hack will cause some
+                // keys to generate twice as many characters.
+                let array: id = msg_send![class("NSArray"), arrayWithObject:event];
+                let (): _ = msg_send![this, interpretKeyEvents:array];
             }
         }
-
-        let array: id = msg_send![class("NSArray"), arrayWithObject:event];
-        let (): _ = msg_send![this, interpretKeyEvents:array];
     }
 }
 


### PR DESCRIPTION
Fixes jwilm/alacritty#1375

For reasons unknown, some keys trigger `insertText` when held, and others don't. While I'd love to know why that happens, I just did the easy thing here by preventing key repeats from *ever* being processed further.