### PR TITLE
Change Travis badge to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Docs.rs](https://docs.rs/winit/badge.svg)](https://docs.rs/winit)
 
-[![Build Status](https://travis-ci.org/tomaka/winit.png?branch=master)](https://travis-ci.org/tomaka/winit)
+[![Build Status](https://travis-ci.org/tomaka/winit.svg?branch=master)](https://travis-ci.org/tomaka/winit)
 [![Build status](https://ci.appveyor.com/api/projects/status/5h87hj0g4q2xe3j9/branch/master?svg=true)](https://ci.appveyor.com/project/tomaka/winit/branch/master)
 
 ```toml


### PR DESCRIPTION
When using PNG for the Travis badge, GitHub fails to render it well on HiDPI screens.