### PR TITLE
Wayland: Fix window creation dimensions

### DIFF
--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -129,9 +129,8 @@ impl Window {
         frame.set_decorate(attributes.decorations);
 
         // min-max dimensions
-        // TODO: Update for new DPI API
-        //frame.set_min_size(attributes.min_dimensions);
-        //frame.set_max_size(attributes.max_dimensions);
+        frame.set_min_size(attributes.min_dimensions.map(Into::into));
+        frame.set_max_size(attributes.max_dimensions.map(Into::into));
 
         let kill_switch = Arc::new(Mutex::new(false));
         let need_frame_refresh = Arc::new(Mutex::new(true));

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -29,9 +29,7 @@ pub struct Window {
 
 impl Window {
     pub fn new(evlp: &EventsLoop, attributes: WindowAttributes) -> Result<Window, CreationError> {
-        // TODO: Update for new DPI API
-        //let (width, height) = attributes.dimensions.unwrap_or((800, 600));
-        let (width, height) = (64, 64);
+        let (width, height) = attributes.dimensions.map(Into::into).unwrap_or((800, 600));
         // Create the window
         let size = Arc::new(Mutex::new((width, height)));
 


### PR DESCRIPTION
In retrospect, I was actually the one who put in this dummy code (https://github.com/francesca64/winit/commit/2dbe28e30079b3532cbca9aedea4f08f0a18d1ab#diff-7d4b937dfd8134b6a46e1cfc22ca80faR27). This explains a lot, since 64 is clearly a cheeky reference to @francesca64.

Sorry @vberger!


