### PR TITLE
set the UIViewController's view to the one that was just created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On iOS, the view is now set correctly. This makes it possible to render things (instead of being stuck on a black screen), and touch events work again.
+
 # Version 0.16.2 (2018-07-07)
 
 - On Windows, non-resizable windows now have the maximization button disabled. This is consistent with behavior on macOS and popular X11 WMs.

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -489,7 +489,7 @@ fn create_delegate_class() {
             let view: id = msg_send![view_class, alloc];
             let view: id = msg_send![view, initForGl:&bounds];
 
-            msg_send![view_controller, setView: view];
+            let _: () = msg_send![view_controller, setView:view];
 
             let _: () = msg_send![window, setRootViewController:view_controller];
             let _: () = msg_send![window, makeKeyAndVisible];

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -489,6 +489,8 @@ fn create_delegate_class() {
             let view: id = msg_send![view_class, alloc];
             let view: id = msg_send![view, initForGl:&bounds];
 
+            msg_send![view_controller, setView: view];
+
             let _: () = msg_send![window, setRootViewController:view_controller];
             let _: () = msg_send![window, makeKeyAndVisible];
 


### PR DESCRIPTION
This, plus a bunch of other unrelated changes, let me get a triangle on screen on iOS with vulkano. I suspect this will fix a lot issues dependencies like glium have on iOS.

Let me know if you need more information from me.