### PR TITLE
iOS Abstract Out the UIView type from winit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **Breaking:** On iOS, `UIView` is now the default root view. `WindowBuilderExt::with_root_view_class` can be used to set the root view objective-c class to `GLKView` (OpenGLES) or `MTKView` (Metal/MoltenVK).
+- On iOS, the `UIApplication` is not started until `Window::new` is called.
 - On iOS, the view is now set correctly. This makes it possible to render things (instead of being stuck on a black screen), and touch events work again.
 - Added NetBSD support.
 

--- a/src/os/ios.rs
+++ b/src/os/ios.rs
@@ -40,7 +40,7 @@ pub trait WindowBuilderExt {
 impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_root_view_class(mut self, root_view_class: *const c_void) -> WindowBuilder {
-        self.platform_specific.root_view_class = Some(unsafe {&*(root_view_class as *const _) });
+        self.platform_specific.root_view_class = unsafe {&*(root_view_class as *const _) };
         self
     }
 }

--- a/src/os/ios.rs
+++ b/src/os/ios.rs
@@ -2,7 +2,7 @@
 
 use std::os::raw::c_void;
 
-use {MonitorId, Window};
+use {MonitorId, Window, WindowBuilder};
 
 /// Additional methods on `Window` that are specific to iOS.
 pub trait WindowExt {
@@ -26,6 +26,22 @@ impl WindowExt for Window {
     #[inline]
     fn get_uiview(&self) -> *mut c_void {
         self.window.get_uiview() as _
+    }
+}
+
+/// Additional methods on `WindowBuilder` that are specific to iOS.
+pub trait WindowBuilderExt {
+    /// Sets the root view class used by the `Window`, otherwise a barebones `UIView` is provided.
+    /// 
+    /// The class will be initialized by calling `[root_view initWithFrame:CGRect]`
+    fn with_root_view_class(self, root_view_class: *const c_void) -> WindowBuilder;
+}
+
+impl WindowBuilderExt for WindowBuilder {
+    #[inline]
+    fn with_root_view_class(mut self, root_view_class: *const c_void) -> WindowBuilder {
+        self.platform_specific.root_view_class = Some(unsafe {&*(root_view_class as *const _) });
+        self
     }
 }
 

--- a/src/os/ios.rs
+++ b/src/os/ios.rs
@@ -32,7 +32,7 @@ impl WindowExt for Window {
 /// Additional methods on `WindowBuilder` that are specific to iOS.
 pub trait WindowBuilderExt {
     /// Sets the root view class used by the `Window`, otherwise a barebones `UIView` is provided.
-    /// 
+    ///
     /// The class will be initialized by calling `[root_view initWithFrame:CGRect]`
     fn with_root_view_class(self, root_view_class: *const c_void) -> WindowBuilder;
 }
@@ -40,7 +40,7 @@ pub trait WindowBuilderExt {
 impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_root_view_class(mut self, root_view_class: *const c_void) -> WindowBuilder {
-        self.platform_specific.root_view_class = unsafe {&*(root_view_class as *const _) };
+        self.platform_specific.root_view_class = unsafe { &*(root_view_class as *const _) };
         self
     }
 }

--- a/src/platform/ios/ffi.rs
+++ b/src/platform/ios/ffi.rs
@@ -15,18 +15,10 @@ pub type Boolean = u32;
 
 pub const kCFRunLoopRunHandledSource: i32 = 4;
 
-pub const UIViewAutoresizingFlexibleWidth: NSUInteger = 1 << 1;
-pub const UIViewAutoresizingFlexibleHeight: NSUInteger = 1 << 4;
-
 #[cfg(target_pointer_width = "32")]
 pub type CGFloat = f32;
 #[cfg(target_pointer_width = "64")]
 pub type CGFloat = f64;
-
-#[cfg(target_pointer_width = "32")]
-pub type NSUInteger = u32;
-#[cfg(target_pointer_width = "64")]
-pub type NSUInteger = u64;
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -75,6 +67,8 @@ extern {
     pub fn setjmp(env: *mut c_void) -> c_int;
     pub fn longjmp(env: *mut c_void, val: c_int);
 }
+
+pub type JmpBuf = [c_int; 27];
 
 pub trait NSString: Sized {
     unsafe fn alloc(_: Self) -> id {

--- a/src/platform/ios/ffi.rs
+++ b/src/platform/ios/ffi.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
 use std::ffi::CString;
-use std::mem;
 use std::os::raw::*;
 
 use objc::runtime::Object;

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -212,7 +212,7 @@ impl EventsLoop {
                 panic!("`Window` can only be created on the main thread on iOS");
             }
         }
-        EventsLoop { events_queue: Arc::new(RefCell::new(VecDeque::new())) }
+        EventsLoop { events_queue: Default::default() }
     }
 
     #[inline]
@@ -311,7 +311,7 @@ impl Window {
     pub fn new(
         ev: &EventsLoop,
         _attributes: WindowAttributes,
-        pl_alltributes: PlatformSpecificWindowBuilderAttributes,
+        pl_attributes: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, CreationError> {
         unsafe {
             debug_assert!(mem::size_of_val(&JMPBUF) == mem::size_of::<Box<JmpBuf>>());
@@ -332,7 +332,7 @@ impl Window {
                 let rect: CGRect = msg_send![MonitorId.get_uiscreen(), bounds];
 
                 let uiview_class = class!(UIView);
-                let root_view_class = pl_alltributes.root_view_class;
+                let root_view_class = pl_attributes.root_view_class;
                 let is_uiview: BOOL = msg_send![root_view_class, isSubclassOfClass:uiview_class];
                 assert!(is_uiview == YES, "`root_view_class` must inherit from `UIView`");
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

There are a lot of changes to iOS in this pull request.
- The `UIApplication` `setjmp` hacks now happen in `Window::new`. This allows `PlatformSpecificWindowBuilderAttributes` to customize the specific `UIView` class.
- The biggest breaking change here is that `winit` no longer sets up a `GLKView`. Putting responsibility on other libraries like `glutin` and `vulkano-win` to specify the exact `UIView` subclass.
- `EventsLoop` now explicitly checks that it's created on the main thread. AFAICT this was required before, but it was just UB to create it anywhere else.
- Only one `Window` can ever be created.
- `EventsLoop` cannot be polled until a `Window` has been created - in order for the `CFRunLoopRunInMode` calls to work.

I have been testing it with `glutin`. https://github.com/mtak-/glutin/commit/1a3066f8582ee2881890c7e7297419c8badb2fb3

Let me know what needs to be changed/etc.