### PR TITLE
Fix key state on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On MacOS, the key state for modifiers key events is now properly set.
 - On iOS, the view is now set correctly. This makes it possible to render things (instead of being stuck on a black screen), and touch events work again.
 - Added NetBSD support.
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -674,11 +674,15 @@ pub fn event_mods(event: cocoa::base::id) -> ModifiersState {
 unsafe fn modifier_event(
     ns_event: cocoa::base::id,
     keymask: NSEventModifierFlags,
-    key_pressed: bool,
+    was_key_pressed: bool,
 ) -> Option<WindowEvent> {
-    if !key_pressed && NSEvent::modifierFlags(ns_event).contains(keymask)
-    || key_pressed && !NSEvent::modifierFlags(ns_event).contains(keymask) {
-        let state = ElementState::Released;
+    if !was_key_pressed && NSEvent::modifierFlags(ns_event).contains(keymask)
+    || was_key_pressed && !NSEvent::modifierFlags(ns_event).contains(keymask) {
+        let state = if was_key_pressed {
+            ElementState::Released
+        } else {
+            ElementState::Pressed
+        };
         let keycode = NSEvent::keyCode(ns_event);
         let scancode = keycode as u32;
         let virtual_keycode = to_virtual_key_code(keycode);


### PR DESCRIPTION
To reproduce the issue:
- on Mac, `cargo run --example window`
- press the `Cmd` key
- See that we get two consecutive `state:Release` `KeyboardInput` events

We should get `Pressed` then `Release`.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality