### PR TITLE
macOS: Fix cursor hiding thread unsafety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added NetBSD support.
 - **Breaking:** On iOS, `UIView` is now the default root view. `WindowBuilderExt::with_root_view_class` can be used to set the root view objective-c class to `GLKView` (OpenGLES) or `MTKView` (Metal/MoltenVK).
 - On iOS, the `UIApplication` is not started until `Window::new` is called.
+- Fixed thread unsafety with cursor hiding on macOS.
 
 # Version 0.16.2 (2018-07-07)
 


### PR DESCRIPTION
There's stil future work with `DelegateState` that needs to be done, which I noticed when working on DPI support... `windowDidChangeBackingProperties` can be called before `windowDidChangeScreen` finishes, for instance.

All I've addressed here is unsoundness when hiding the cursor, since it's both easy to encounter and easy for me to fix.