### PR TITLE
iOS: Fix the `longjmp`/`setjmp` ffi

### DIFF
--- a/src/platform/ios/ffi.rs
+++ b/src/platform/ios/ffi.rs
@@ -64,10 +64,20 @@ extern {
 
 extern {
     pub fn setjmp(env: *mut c_void) -> c_int;
-    pub fn longjmp(env: *mut c_void, val: c_int);
+    pub fn longjmp(env: *mut c_void, val: c_int) -> !;
 }
 
-pub type JmpBuf = [c_int; 27];
+// values taken from "setjmp.h" header in xcode iPhoneOS/iPhoneSimulator SDK
+#[cfg(any(target_arch = "x86_64"))]
+pub const JBLEN: usize = ((9 * 2) + 3 + 16);
+#[cfg(any(target_arch = "x86"))]
+pub const JBLEN: usize = (18);
+#[cfg(target_arch = "arm")]
+pub const JBLEN: usize = (10 + 16 + 2);
+#[cfg(target_arch = "aarch64")]
+pub const JBLEN: usize = ((14 + 8 + 2) * 2);
+
+pub type JmpBuf = [c_int; JBLEN];
 
 pub trait NSString: Sized {
     unsafe fn alloc(_: Self) -> id {

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -92,6 +92,7 @@ use self::ffi::{
     CGPoint,
     CGRect,
     id,
+    JBLEN,
     JmpBuf,
     kCFRunLoopDefaultMode,
     kCFRunLoopRunHandledSource,
@@ -209,7 +210,7 @@ impl EventsLoop {
     pub fn new() -> EventsLoop {
         unsafe {
             if !msg_send![class!(NSThread), isMainThread] {
-                panic!("`Window` can only be created on the main thread on iOS");
+                panic!("`EventsLoop` can only be created on the main thread on iOS");
             }
         }
         EventsLoop { events_queue: Default::default() }
@@ -315,7 +316,7 @@ impl Window {
     ) -> Result<Window, CreationError> {
         unsafe {
             debug_assert!(mem::size_of_val(&JMPBUF) == mem::size_of::<Box<JmpBuf>>());
-            assert!(mem::replace(&mut JMPBUF, Some(Box::new([0; 27]))).is_none(), "Only one `Window` is supported on iOS");
+            assert!(mem::replace(&mut JMPBUF, Some(Box::new([0; JBLEN]))).is_none(), "Only one `Window` is supported on iOS");
         }
 
         unsafe {


### PR DESCRIPTION
- [x] Tested on all platforms changed

- The length of the `JmpBuf` was incorrectly set to `27` `c_int`'s. In reality the length is architecture dependent and larger than `27` on most platforms.
- The longjmp function now returns `!`
- Tweaked a `panic!` message.

Before this change, sometimes there would be random crashes every few launches with unhelpful stack traces:

```
malloc: *** error for object 0x1d00ceb60: Invalid pointer dequeued from free list
*** set a breakpoint in malloc_error_break to debug
```

After this change, I am unable to reproduce the crash.