### PR TITLE
fix assertion failed: validate_hidpi_factor(dpi_factor) (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On iOS, the `UIApplication` is not started until `Window::new` is called.
 - Fixed thread unsafety with cursor hiding on macOS.
 - On iOS, fixed the size of the `JmpBuf` type used for `setjmp`/`longjmp` calls. Previously this was a buffer overflow on most architectures.
+- On Windows, use cached window DPI instead of repeatedly querying the system. This fixes sporadic crashes on Windows 7.
 
 # Version 0.16.2 (2018-07-07)
 


### PR DESCRIPTION
use cached window dpi to fix panic on win 7

- [X] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
