### PR TITLE
[NOMERGE] Adds a way to create windows and events pools from a subset of their raw parts.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.20.10", features = [ "dlopen", "egl", "cursor"] }
+wayland-client = { version = "0.20.12", features = [ "dlopen", "egl", "cursor"] }
 smithay-client-toolkit = "0.3.0"
 x11-dl = "2.18.3"
 parking_lot = "0.6"

--- a/examples/raw_window.rs
+++ b/examples/raw_window.rs
@@ -1,7 +1,5 @@
 extern crate winit;
 
-use std::sync::Mutex;
-
 fn main() {
     let mut evlp = winit::EventsLoop::new();
     let win = winit::WindowBuilder::new()
@@ -15,7 +13,7 @@ fn main() {
     // Replace the code above with some *other* magical way to make your raw parts.
     // I.e. some C library.
 
-    let mut evlp_raw = unsafe {
+    let evlp_raw = unsafe {
         winit::EventsLoop::new_from_raw_parts(&evlp_raw)
     };
 
@@ -23,9 +21,10 @@ fn main() {
         winit::Window::new_from_raw_parts(&evlp_raw, &win_raw).unwrap()
     };
 
-    let running = Mutex::new(true);
-    while *running.lock().unwrap() {
-        let event_handler = |event| {
+    let mut running = true;
+    while running {
+        evlp.poll_events(|event| {
+            println!("Evlp {:?}", event);
             if let winit::Event::WindowEvent { event, .. } = event {
                 match event {
                     winit::WindowEvent::KeyboardInput {
@@ -36,19 +35,10 @@ fn main() {
                             },
                         ..
                     }
-                    | winit::WindowEvent::CloseRequested => *running.lock().unwrap() = false,
+                    | winit::WindowEvent::CloseRequested => running = false,
                     _ => (),
                 }
             }
-        };
-
-        evlp.poll_events(|event| {
-            println!("Evlp {:?}", event);
-            event_handler(event)
-        });
-        evlp_raw.poll_events(|event| {
-            println!("Raw Evlp {:?}", event);
-            event_handler(event)
         });
     }
 }

--- a/examples/raw_window.rs
+++ b/examples/raw_window.rs
@@ -1,0 +1,54 @@
+extern crate winit;
+
+use std::sync::Mutex;
+
+fn main() {
+    let mut evlp = winit::EventsLoop::new();
+    let win = winit::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&evlp)
+        .unwrap();
+
+    let evlp_raw = evlp.get_raw_parts();
+    let win_raw = win.get_raw_parts();
+
+    // Replace the code above with some *other* magical way to make your raw parts.
+    // I.e. some C library.
+
+    let mut evlp_raw = unsafe {
+        winit::EventsLoop::new_from_raw_parts(&evlp_raw)
+    };
+
+    let _win_raw = unsafe {
+        winit::Window::new_from_raw_parts(&evlp_raw, &win_raw).unwrap()
+    };
+
+    let running = Mutex::new(true);
+    while *running.lock().unwrap() {
+        let event_handler = |event| {
+            if let winit::Event::WindowEvent { event, .. } = event {
+                match event {
+                    winit::WindowEvent::KeyboardInput {
+                        input:
+                            winit::KeyboardInput {
+                                virtual_keycode: Some(winit::VirtualKeyCode::Escape),
+                                ..
+                            },
+                        ..
+                    }
+                    | winit::WindowEvent::CloseRequested => *running.lock().unwrap() = false,
+                    _ => (),
+                }
+            }
+        };
+
+        evlp.poll_events(|event| {
+            println!("Evlp {:?}", event);
+            event_handler(event)
+        });
+        evlp_raw.poll_events(|event| {
+            println!("Raw Evlp {:?}", event);
+            event_handler(event)
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub use platform::raw_parts::*;
 pub mod dpi;
 mod events;
 mod icon;
-mod platform;
+pub mod platform;
 mod window;
 
 pub mod os;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ pub(crate) use dpi::*; // TODO: Actually change the imports throughout the codeb
 pub use events::*;
 pub use window::{AvailableMonitorsIter, MonitorId};
 pub use icon::*;
+pub use platform::raw_parts::*;
 
 pub mod dpi;
 mod events;
@@ -202,11 +203,32 @@ impl EventsLoop {
     /// using an environment variable `WINIT_UNIX_BACKEND`. Legal values are `x11` and `wayland`.
     /// If it is not set, winit will try to connect to a wayland connection, and if it fails will
     /// fallback on x11. If this variable is set with any other value, winit will panic.
+    #[inline]
     pub fn new() -> EventsLoop {
         EventsLoop {
             events_loop: platform::EventsLoop::new(),
             _marker: ::std::marker::PhantomData,
         }
+    }
+
+    /// Builds a new events loop from it's raw parts. Useful for interfacing with C
+    /// libraries.
+    ///
+    /// We don't take "ownership" over the window, as in, some functions might,
+    /// possibly silently, fail, while others might return invalid results. Some
+    /// may even result in unsafe behaviour!
+    #[inline]
+    pub unsafe fn new_from_raw_parts(relp: &RawEventsLoopParts) -> EventsLoop {
+        EventsLoop {
+            events_loop: platform::EventsLoop::new_from_raw_parts(relp),
+            _marker: ::std::marker::PhantomData,
+        }
+    }
+
+    /// Returns an events loop's raw parts. Useful for interfacing with C
+    #[inline]
+    pub fn get_raw_parts(&self) -> RawEventsLoopParts {
+        self.events_loop.get_raw_parts()
     }
 
     /// Returns the list of all the monitors available on the system.

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -197,7 +197,7 @@ impl WindowExt for Window {
     #[inline]
     fn get_wayland_display(&self) -> Option<*mut raw::c_void> {
         match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.get_display().c_ptr() as *mut _),
+            LinuxWindow::Wayland(ref w) => Some(w.get_display() as *mut _),
             _ => None
         }
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -7,7 +7,7 @@ use std::os::raw::*;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use sctk::reexports::client::ConnectError;
+pub use sctk::reexports::client::ConnectError;
 
 use {
     CreationError,
@@ -19,7 +19,7 @@ use {
 };
 use dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
 use window::MonitorId as RootMonitorId;
-use self::x11::{XConnection, XError};
+pub use self::x11::{XConnection, XError};
 use self::x11::ffi::XVisualInfo;
 pub use self::x11::XNotSupported;
 

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -1,8 +1,8 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
            target_os = "netbsd", target_os = "openbsd"))]
 
-pub use self::window::Window;
-pub use self::event_loop::{EventsLoop, EventsLoopProxy, EventsLoopSink, MonitorId};
+pub use self::window::{Window, RawWindowParts};
+pub use self::event_loop::{EventsLoop, EventsLoopProxy, EventsLoopSink, MonitorId, RawEventsLoopParts};
 
 use sctk::reexports::client::protocol::wl_surface;
 use sctk::reexports::client::Proxy;

--- a/src/platform/linux/x11/xdisplay.rs
+++ b/src/platform/linux/x11/xdisplay.rs
@@ -28,14 +28,7 @@ pub type XErrorHandler = Option<unsafe extern fn(*mut ffi::Display, *mut ffi::XE
 
 impl XConnection {
     pub fn new(error_handler: XErrorHandler) -> Result<XConnection, XNotSupported> {
-        // opening the libraries
         let xlib = ffi::Xlib::open()?;
-        let xcursor = ffi::Xcursor::open()?;
-        let xrandr = ffi::Xrandr_2_2_0::open()?;
-        let xrandr_1_5 = ffi::Xrandr::open().ok();
-        let xinput2 = ffi::XInput2::open()?;
-        let xlib_xcb = ffi::Xlib_xcb::open()?;
-
         unsafe { (xlib.XInitThreads)() };
         unsafe { (xlib.XSetErrorHandler)(error_handler) };
 
@@ -47,6 +40,17 @@ impl XConnection {
             }
             display
         };
+
+        Self::new_from_display(xlib, display)
+    }
+
+    pub fn new_from_display(xlib: ffi::Xlib, display: *mut ffi::Display) -> Result<XConnection, XNotSupported> {
+        // opening the libraries
+        let xcursor = ffi::Xcursor::open()?;
+        let xrandr = ffi::Xrandr_2_2_0::open()?;
+        let xrandr_1_5 = ffi::Xrandr::open().ok();
+        let xinput2 = ffi::XInput2::open()?;
+        let xlib_xcb = ffi::Xlib_xcb::open()?;
 
         Ok(XConnection {
             xlib,

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -62,6 +62,8 @@ use platform::platform::icon::WinIcon;
 use platform::platform::raw_input::{get_raw_input_data, get_raw_mouse_button_state};
 use platform::platform::window::adjust_size;
 
+pub struct RawEventsLoopParts;
+
 /// Contains saved window info for switching between fullscreen
 #[derive(Clone)]
 pub struct SavedWindowInfo {
@@ -244,6 +246,18 @@ impl EventsLoop {
                 ControlFlow::Break => break,
             }
         }
+    }
+
+    #[inline]
+    pub unsafe fn new_from_raw_parts(
+        _relp: &RawEventsLoopParts,
+    ) -> EventsLoop {
+        Self::new()
+    }
+
+    #[inline]
+    pub fn get_raw_parts(&self) -> RawEventsLoopParts {
+        RawEventsLoopParts
     }
 
     pub fn create_proxy(&self) -> EventsLoopProxy {

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -7,6 +7,14 @@ pub use self::events_loop::{EventsLoop, EventsLoopProxy};
 pub use self::monitor::MonitorId;
 pub use self::window::Window;
 
+pub mod raw_parts {
+    pub use super::{RawEventsLoopParts, RawWindowParts};
+    pub use winapi::shared::windef::HWND;
+}
+
+pub use self::events_loop::RawEventsLoopParts;
+pub use self::window::RawWindowParts;
+
 #[derive(Clone, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub parent: Option<HWND>,

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -444,7 +444,12 @@ impl Window {
 
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {
-        self.window_state.as_ref().unwrap().lock().unwrap().dpi_factor
+        if let Some(ref ws) = self.window_state {
+            ws.lock().unwrap().dpi_factor
+        } else {
+            let dpi = unsafe { get_hwnd_dpi(self.window.0) };
+            dpi_to_scale_factor(dpi)
+        }
     }
 
     fn set_cursor_position_physical(&self, x: i32, y: i32) -> Result<(), String> {

--- a/src/window.rs
+++ b/src/window.rs
@@ -175,6 +175,24 @@ impl Window {
         builder.build(events_loop)
     }
 
+    /// Builds a new window from it's raw parts. Useful for interfacing with C
+    /// libraries.
+    ///
+    /// We don't take "ownership" over the window, as in, some functions might,
+    /// possibly silently, fail, while others might return invalid results. Some
+    /// may even result in unsafe behaviour!
+    #[inline]
+    pub unsafe fn new_from_raw_parts(el: &EventsLoop, rwp: &platform::RawWindowParts) -> Result<Window, CreationError> {
+        platform::Window::new_from_raw_parts(&el.events_loop, rwp)
+            .map(|window| Window { window })
+    }
+
+    /// Returns a window's raw parts. Useful for interfacing with C
+    #[inline]
+    pub fn get_raw_parts(&self) -> platform::RawWindowParts {
+        self.window.get_raw_parts()
+    }
+
     /// Modifies the title of the window.
     ///
     /// This is a no-op if the window has already been closed.


### PR DESCRIPTION
Adds a way to create windows and events pools from a subset of their raw parts.

A new API which allows us to make windows and events pools from a subset of their raw parts. Should be useful when interfacing with C libraries. 

~Currently the raw parts we require just so happen to match the ones we receive from gfx-rs/portability in its `Vk*SurfaceCreateInfo` structs, as my use case for this api will be constructing `Window`s and `EventsPool`s from that data (and that will just make my life easier :D).~ We now also require the dims of the surface for the wayland backend.

I currently only plan to implement this functionality on linux and windows. Currently untested.

Implemented:
 - [x] Linux - X11
 - [x] Linux - Wayland
 - [x] Windows

Tested:
 - [x] Linux - X11
 - [ ] Linux - Wayland
 - [ ] Windows

Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
