### PR TITLE
Remove resize block on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Unreleased
+- On Windows, fix freezes when performing certain actions after a window resize has been triggered.
 
 # Version 0.17.2 (2018-08-19)
 
 - On macOS, fix `<C-Tab>` so applications receive the event.
 - On macOS, fix `<Cmd-{key}>` so applications receive the event.
 - On Wayland, key press events will now be repeated.
-- On Windows, fix freezes when performing certain actions after a window resize has been triggered.
 
 # Version 0.17.1 (2018-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- On Windows, fix freezes when performing certain actions after a window resize has been triggered.
+
+- On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On macOS, fix `<C-Tab>` so applications receive the event.
 - On macOS, fix `<Cmd-{key}>` so applications receive the event.
 - On Wayland, key press events will now be repeated.
+- On Windows, fix freezes when performing certain actions after a window resize has been triggered.
 
 # Version 0.17.1 (2018-08-05)
 


### PR DESCRIPTION
Reintroduces some visual bugs when resizing, but fixes the freezes in #574, #617, and #633.