### PR TITLE
Wayland: commit frame surface on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed graphical glitches when resizing on Wayland
+
 # Version 0.17.2 (2018-08-19)
 
 - On macOS, fix `<C-Tab>` so applications receive the event.

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -18,6 +18,7 @@ use sctk::reexports::client::{ConnectError, Display, EventQueue, GlobalEvent, Pr
 use sctk::Environment;
 
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
+use sctk::reexports::client::protocol::wl_surface::RequestsTrait;
 
 pub struct EventsLoopSink {
     buffer: VecDeque<::Event>,
@@ -249,6 +250,9 @@ impl EventsLoop {
                         *size = (w, h);
                     } else if frame_refresh {
                         frame.refresh();
+                        if !refresh {
+                            frame.surface().commit()
+                        }
                     }
                 }
                 if let Some(dpi) = new_dpi {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

This PR commits the surface of the wayland window frame on resize  as suggested by @vberger.
This is required by https://github.com/Smithay/client-toolkit/commit/acdfde234e0afa3513b276493696811986aa2322