### PR TITLE
Test against 1.26.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           packages: *i686_packages
     - env: TARGET=i686-unknown-linux-gnu
       os: linux
-      rust: 1.24.1
+      rust: 1.26.2
       addons:
         apt:
           packages: *i686_packages
@@ -35,7 +35,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-unknown-linux-gnu
       os: linux
-      rust: 1.24.1
+      rust: 1.26.2
 
     # macOS
     - env: TARGET=x86_64-apple-darwin
@@ -46,7 +46,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-apple-darwin
       os: osx
-      rust: 1.24.1
+      rust: 1.26.2
 
     # iOS
     - env: TARGET=x86_64-apple-ios
@@ -57,7 +57,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-apple-ios
       os: osx
-      rust: 1.24.1
+      rust: 1.26.2
 
 install:
   - rustup self update

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc
-    CHANNEL: 1.24.1
+    CHANNEL: 1.26.2
   - TARGET: i686-pc-windows-msvc
     CHANNEL: nightly
   - TARGET: i686-pc-windows-gnu


### PR DESCRIPTION
Bumps minimum tested version to `1.26.2`. Fixes #645.

Should this have a changelog entry? I haven't put on in here since there don't seem to be any for previous version bumps, but I can add it in if necessary.