### PR TITLE
Put badges next to each other instead of below eachother

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # winit - Cross-platform window creation and management in Rust
 
 [![](http://meritbadge.herokuapp.com/winit)](https://crates.io/crates/winit)
-
 [![Docs.rs](https://docs.rs/winit/badge.svg)](https://docs.rs/winit)
-
 [![Build Status](https://travis-ci.org/tomaka/winit.svg?branch=master)](https://travis-ci.org/tomaka/winit)
 [![Build status](https://ci.appveyor.com/api/projects/status/5h87hj0g4q2xe3j9/branch/master?svg=true)](https://ci.appveyor.com/project/tomaka/winit/branch/master)
 


### PR DESCRIPTION
This makes it look more like other projects have it. I always thought the way winit had it looked odd.
However, I see a certain logic in which you have arranged them so just close this if you want to keep it like you have it.