### PR TITLE
Make `parking_lot` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ features = ["icon_loading"]
 
 [features]
 icon_loading = ["image"]
+parking_lot_mutex = ["parking_lot"]
 
 [dependencies]
 lazy_static = "1"
@@ -57,5 +58,5 @@ features = [
 wayland-client = { version = "0.20.10", features = [ "dlopen", "egl", "cursor"] }
 smithay-client-toolkit = "0.3.0"
 x11-dl = "2.18.3"
-parking_lot = "0.6"
 percent-encoding = "1.0"
+parking_lot = { version = "0.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ extern crate core_foundation;
 extern crate core_graphics;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 extern crate x11_dl;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(all(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"), feature="parking_lot_mutex"))]
 extern crate parking_lot;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 extern crate percent_encoding;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -27,6 +27,17 @@ use self::x11::{XConnection, XError};
 use self::x11::ffi::XVisualInfo;
 pub use self::x11::XNotSupported;
 
+macro_rules! lock_mutex {
+    ($mutex:expr) => ({
+        #[cfg(feature = "parking_lot_mutex")] {
+            ($mutex.lock())
+        }
+        #[cfg(not(feature = "parking_lot_mutex"))] {
+            ($mutex.lock().unwrap())
+        }
+    })
+}
+
 mod dlopen;
 pub mod wayland;
 pub mod x11;
@@ -366,7 +377,7 @@ unsafe extern "C" fn x_error_callback(
     display: *mut x11::ffi::Display,
     event: *mut x11::ffi::XErrorEvent,
 ) -> c_int {
-    let xconn_lock = X11_BACKEND.lock();
+    let xconn_lock = lock_mutex!(X11_BACKEND);
     if let Ok(ref xconn) = *xconn_lock {
         let mut buf: [c_char; 1024] = mem::uninitialized();
         (xconn.xlib.XGetErrorText)(
@@ -386,7 +397,7 @@ unsafe extern "C" fn x_error_callback(
 
         eprintln!("[winit X11 error] {:#?}", error);
 
-        *xconn.latest_error.lock() = Some(error);
+        *lock_mutex!(xconn.latest_error) = Some(error);
     }
     // Fun fact: this return value is completely ignored.
     0
@@ -449,8 +460,7 @@ r#"Failed to initialize any backend!
     }
 
     pub fn new_x11() -> Result<EventsLoop, XNotSupported> {
-        X11_BACKEND
-            .lock()
+        lock_mutex!(X11_BACKEND)
             .as_ref()
             .map(Arc::clone)
             .map(x11::EventsLoop::new)

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -6,7 +6,11 @@ use std::ffi::CStr;
 use std::os::raw::*;
 use std::sync::Arc;
 
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
+
 use sctk::reexports::client::ConnectError;
 
 use {

--- a/src/platform/linux/x11/ime/input_method.rs
+++ b/src/platform/linux/x11/ime/input_method.rs
@@ -20,7 +20,7 @@ unsafe fn open_im(
     xconn: &Arc<XConnection>,
     locale_modifiers: &CStr,
 ) -> Option<ffi::XIM> {
-    let _lock = GLOBAL_LOCK.lock();
+    let _lock = lock_mutex!(GLOBAL_LOCK);
 
     // XSetLocaleModifiers returns...
     // * The current locale modifiers if it's given a NULL pointer.

--- a/src/platform/linux/x11/ime/input_method.rs
+++ b/src/platform/linux/x11/ime/input_method.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::os::raw::c_char;
 use std::ffi::{CStr, CString, IntoStringError};
 
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use super::{ffi, util, XConnection, XError};
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -413,7 +413,7 @@ impl EventsLoop {
                     let new_inner_position = (xev.x as i32, xev.y as i32);
 
                     let monitor = window.get_current_monitor(); // This must be done *before* locking!
-                    let mut shared_state_lock = window.shared_state.lock();
+                    let mut shared_state_lock = lock_mutex!(window.shared_state);
 
                     let (resized, moved) = {
                         let resized = util::maybe_change(&mut shared_state_lock.size, new_inner_size);
@@ -754,7 +754,7 @@ impl EventsLoop {
                         let modifiers = ModifiersState::from(xev.mods);
 
                         let cursor_moved = self.with_window(xev.event, |window| {
-                            let mut shared_state_lock = window.shared_state.lock();
+                            let mut shared_state_lock = lock_mutex!(window.shared_state);
                             util::maybe_change(&mut shared_state_lock.cursor_pos, new_cursor_pos)
                         });
                         if cursor_moved == Some(true) {

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -1,6 +1,9 @@
 use std::os::raw::*;
 
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use {PhysicalPosition, PhysicalSize};
 use super::{util, XConnection, XError};

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -27,7 +27,7 @@ lazy_static! {
 }
 
 fn version_is_at_least(major: c_int, minor: c_int) -> bool {
-    if let Some((avail_major, avail_minor)) = *XRANDR_VERSION.lock() {
+    if let Some((avail_major, avail_minor)) = *lock_mutex!(XRANDR_VERSION) {
         if avail_major == major {
             avail_minor >= minor
         } else {
@@ -40,7 +40,7 @@ fn version_is_at_least(major: c_int, minor: c_int) -> bool {
 
 pub fn invalidate_cached_monitor_list() -> Option<Vec<MonitorId>> {
     // We update this lazily.
-    (*MONITORS.lock()).take()
+    (*lock_mutex!(MONITORS)).take()
 }
 
 #[derive(Debug, Clone)]
@@ -205,7 +205,7 @@ impl XConnection {
     }
 
     pub fn get_available_monitors(&self) -> Vec<MonitorId> {
-        let mut monitors_lock = MONITORS.lock();
+        let mut monitors_lock = lock_mutex!(MONITORS);
         (*monitors_lock)
             .as_ref()
             .cloned()
@@ -229,7 +229,7 @@ impl XConnection {
 
     pub fn select_xrandr_input(&self, root: Window) -> Result<c_int, XError> {
         {
-            let mut version_lock = XRANDR_VERSION.lock();
+            let mut version_lock = lock_mutex!(XRANDR_VERSION);
             if version_lock.is_none() {
                 let mut major = 0;
                 let mut minor = 0;

--- a/src/platform/linux/x11/util/atom.rs
+++ b/src/platform/linux/x11/util/atom.rs
@@ -19,7 +19,7 @@ lazy_static! {
 impl XConnection {
     pub fn get_atom<T: AsRef<CStr> + Debug>(&self, name: T) -> ffi::Atom {
         let name = name.as_ref();
-        let mut atom_cache_lock = ATOM_CACHE.lock();
+        let mut atom_cache_lock = lock_mutex!(ATOM_CACHE);
         let cached_atom = (*atom_cache_lock).get(name).cloned();
         if let Some(atom) = cached_atom {
             atom

--- a/src/platform/linux/x11/util/atom.rs
+++ b/src/platform/linux/x11/util/atom.rs
@@ -3,7 +3,10 @@ use std::ffi::{CStr, CString};
 use std::fmt::Debug;
 use std::os::raw::*;
 
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use super::*;
 

--- a/src/platform/linux/x11/util/wm.rs
+++ b/src/platform/linux/x11/util/wm.rs
@@ -12,11 +12,11 @@ lazy_static! {
 }
 
 pub fn hint_is_supported(hint: ffi::Atom) -> bool {
-    (*SUPPORTED_HINTS.lock()).contains(&hint)
+    (*lock_mutex!(SUPPORTED_HINTS)).contains(&hint)
 }
 
 pub fn wm_name_is_one_of(names: &[&str]) -> bool {
-    if let Some(ref name) = *WM_NAME.lock() {
+    if let Some(ref name) = *lock_mutex!(WM_NAME) {
         names.contains(&name.as_str())
     } else {
         false
@@ -25,8 +25,8 @@ pub fn wm_name_is_one_of(names: &[&str]) -> bool {
 
 impl XConnection {
     pub fn update_cached_wm_info(&self, root: ffi::Window) {
-        *SUPPORTED_HINTS.lock() = self.get_supported_hints(root);
-        *WM_NAME.lock() = self.get_wm_name(root);
+        *lock_mutex!(SUPPORTED_HINTS) = self.get_supported_hints(root);
+        *lock_mutex!(WM_NAME) = self.get_wm_name(root);
     }
 
     fn get_supported_hints(&self, root: ffi::Window) -> Vec<ffi::Atom> {

--- a/src/platform/linux/x11/util/wm.rs
+++ b/src/platform/linux/x11/util/wm.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use super::*;
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -286,7 +286,7 @@ impl UnownedWindow {
                         max_dimensions = Some(dimensions.into());
                         min_dimensions = Some(dimensions.into());
 
-                        let mut shared_state_lock = window.shared_state.lock();
+                        let mut shared_state_lock = lock_mutex!(window.shared_state);
                         shared_state_lock.min_dimensions = window_attrs.min_dimensions;
                         shared_state_lock.max_dimensions = window_attrs.max_dimensions;
                     }
@@ -501,14 +501,14 @@ impl UnownedWindow {
         match monitor {
             None => {
                 let flusher = self.set_fullscreen_hint(false);
-                if let Some(position) = self.shared_state.lock().restore_position.take() {
+                if let Some(position) = lock_mutex!(self.shared_state).restore_position.take() {
                     self.set_position_inner(position.0, position.1).queue();
                 }
                 flusher
             },
             Some(RootMonitorId { inner: PlatformMonitorId::X(monitor) }) => {
                 let window_position = self.get_position_physical();
-                self.shared_state.lock().restore_position = window_position;
+                lock_mutex!(self.shared_state).restore_position = window_position;
                 let monitor_origin: (i32, i32) = monitor.get_position().into();
                 self.set_position_inner(monitor_origin.0, monitor_origin.1).queue();
                 self.set_fullscreen_hint(true)
@@ -536,15 +536,14 @@ impl UnownedWindow {
 
     #[inline]
     pub fn get_current_monitor(&self) -> X11MonitorId {
-        let monitor = self.shared_state
-            .lock()
+        let monitor = lock_mutex!(self.shared_state)
             .last_monitor
             .as_ref()
             .cloned();
         monitor
             .unwrap_or_else(|| {
                 let monitor = self.xconn.get_monitor_for_window(self.get_rect()).to_owned();
-                self.shared_state.lock().last_monitor = Some(monitor.clone());
+                lock_mutex!(self.shared_state).last_monitor = Some(monitor.clone());
                 monitor
             })
     }
@@ -687,15 +686,15 @@ impl UnownedWindow {
 
     fn update_cached_frame_extents(&self) {
         let extents = self.xconn.get_frame_extents_heuristic(self.xwindow, self.root);
-        (*self.shared_state.lock()).frame_extents = Some(extents);
+        (*lock_mutex!(self.shared_state)).frame_extents = Some(extents);
     }
 
     pub(crate) fn invalidate_cached_frame_extents(&self) {
-        (*self.shared_state.lock()).frame_extents.take();
+        (*lock_mutex!(self.shared_state)).frame_extents.take();
     }
 
     pub(crate) fn get_position_physical(&self) -> Option<(i32, i32)> {
-        let extents = (*self.shared_state.lock()).frame_extents.clone();
+        let extents = (*lock_mutex!(self.shared_state)).frame_extents.clone();
         if let Some(extents) = extents {
             self.get_inner_position_physical()
                 .map(|(x, y)| extents.inner_pos_to_outer(x, y))
@@ -707,7 +706,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn get_position(&self) -> Option<LogicalPosition> {
-        let extents = (*self.shared_state.lock()).frame_extents.clone();
+        let extents = (*lock_mutex!(self.shared_state)).frame_extents.clone();
         if let Some(extents) = extents {
             self.get_inner_position()
                 .map(|logical| extents.inner_pos_to_outer_logical(logical, self.get_hidpi_factor()))
@@ -733,7 +732,7 @@ impl UnownedWindow {
         // There are a few WMs that set client area position rather than window position, so
         // we'll translate for consistency.
         if util::wm_name_is_one_of(&["Enlightenment", "FVWM"]) {
-            let extents = (*self.shared_state.lock()).frame_extents.clone();
+            let extents = (*lock_mutex!(self.shared_state)).frame_extents.clone();
             if let Some(extents) = extents {
                 x += extents.frame_extents.left as i32;
                 y += extents.frame_extents.top as i32;
@@ -778,7 +777,7 @@ impl UnownedWindow {
     }
 
     pub(crate) fn get_outer_size_physical(&self) -> Option<(u32, u32)> {
-        let extents = self.shared_state.lock().frame_extents.clone();
+        let extents = lock_mutex!(self.shared_state).frame_extents.clone();
         if let Some(extents) = extents {
             self.get_inner_size_physical()
                 .map(|(w, h)| extents.inner_size_to_outer(w, h))
@@ -790,7 +789,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn get_outer_size(&self) -> Option<LogicalSize> {
-        let extents = self.shared_state.lock().frame_extents.clone();
+        let extents = lock_mutex!(self.shared_state).frame_extents.clone();
         if let Some(extents) = extents {
             self.get_inner_size()
                 .map(|logical| extents.inner_size_to_outer_logical(logical, self.get_hidpi_factor()))
@@ -834,7 +833,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_min_dimensions(&self, logical_dimensions: Option<LogicalSize>) {
-        self.shared_state.lock().min_dimensions = logical_dimensions;
+        lock_mutex!(self.shared_state).min_dimensions = logical_dimensions;
         let physical_dimensions = logical_dimensions.map(|logical_dimensions| {
             logical_dimensions.to_physical(self.get_hidpi_factor()).into()
         });
@@ -848,7 +847,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_max_dimensions(&self, logical_dimensions: Option<LogicalSize>) {
-        self.shared_state.lock().max_dimensions = logical_dimensions;
+        lock_mutex!(self.shared_state).max_dimensions = logical_dimensions;
         let physical_dimensions = logical_dimensions.map(|logical_dimensions| {
             logical_dimensions.to_physical(self.get_hidpi_factor()).into()
         });
@@ -901,7 +900,7 @@ impl UnownedWindow {
         }
 
         let (logical_min, logical_max) = if resizable {
-            let shared_state_lock = self.shared_state.lock();
+            let shared_state_lock = lock_mutex!(self.shared_state);
             (shared_state_lock.min_dimensions, shared_state_lock.max_dimensions)
         } else {
             let window_size = self.get_inner_size();
@@ -1038,8 +1037,8 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_cursor(&self, cursor: MouseCursor) {
-        *self.cursor.lock() = cursor;
-        if !*self.cursor_hidden.lock() {
+        *lock_mutex!(self.cursor) = cursor;
+        if !*lock_mutex!(self.cursor_hidden) {
             self.update_cursor(self.get_cursor(cursor));
         }
     }
@@ -1084,7 +1083,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn grab_cursor(&self, grab: bool) -> Result<(), String> {
-        let mut grabbed_lock = self.cursor_grabbed.lock();
+        let mut grabbed_lock = lock_mutex!(self.cursor_grabbed);
         if grab == *grabbed_lock { return Ok(()); }
         unsafe {
             // We ungrab before grabbing to prevent passive grabs from causing `AlreadyGrabbed`.
@@ -1140,12 +1139,12 @@ impl UnownedWindow {
 
     #[inline]
     pub fn hide_cursor(&self, hide: bool) {
-        let mut hidden_lock = self.cursor_hidden.lock();
+        let mut hidden_lock = lock_mutex!(self.cursor_hidden);
         if hide == *hidden_lock {return; }
         let cursor = if hide {
             self.create_empty_cursor().expect("Failed to create empty cursor")
         } else {
-            self.get_cursor(*self.cursor.lock())
+            self.get_cursor(*lock_mutex!(self.cursor))
         };
         *hidden_lock = hide;
         drop(hidden_lock);
@@ -1181,8 +1180,7 @@ impl UnownedWindow {
     }
 
     pub(crate) fn set_ime_spot_physical(&self, x: i32, y: i32) {
-        let _ = self.ime_sender
-            .lock()
+        let _ = lock_mutex!(self.ime_sender)
             .send((self.xwindow, x as i16, y as i16));
     }
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -5,7 +5,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use libc;
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use {Icon, MouseCursor, WindowAttributes};
 use CreationError::{self, OsError};

--- a/src/platform/linux/x11/xdisplay.rs
+++ b/src/platform/linux/x11/xdisplay.rs
@@ -3,7 +3,11 @@ use std::fmt;
 use std::error::Error;
 
 use libc;
+
+#[cfg(feature = "parking_lot_mutex")]
 use parking_lot::Mutex;
+#[cfg(not(feature = "parking_lot_mutex"))]
+use std::sync::Mutex;
 
 use super::ffi;
 

--- a/src/platform/linux/x11/xdisplay.rs
+++ b/src/platform/linux/x11/xdisplay.rs
@@ -67,7 +67,7 @@ impl XConnection {
     /// Checks whether an error has been triggered by the previous function calls.
     #[inline]
     pub fn check_errors(&self) -> Result<(), XError> {
-        let error = self.latest_error.lock().take();
+        let error = lock_mutex!(self.latest_error).take();
         if let Some(error) = error {
             Err(error)
         } else {
@@ -78,7 +78,7 @@ impl XConnection {
     /// Ignores any previous error.
     #[inline]
     pub fn ignore_error(&self) {
-        *self.latest_error.lock() = None;
+        *lock_mutex!(self.latest_error) = None;
     }
 }
 


### PR DESCRIPTION
Fixes #650 - `parking_lot` is now an optional dependency, replacing `parking_lot::Mutex` by `std::sync::Mutex` if the feature `parking_lot_mutex` is disabled.

TODO:

- [ ] Windows / Mac should not need to download `parking_lot` if the feature is enabled
- [ ] Make `parking_lot` the default implementation for Linux (opt-out instead of opt-in)
- [ ] Document change in `CHANGELOG.md`