### PR TITLE
Wayland: use `init_from_env()` to create windows and allow server-sid…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- On Wayland, windows will use server-side decorations when appropriate.
 - Added support for F16-F24 keys.
 - Fixed graphical glitches when resizing on Wayland.
 - On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- On Wayland, windows will use server-side decorations when appropriate.
+- On Wayland, windows will use server-side decorations when available.
 - Added support for F16-F24 keys.
 - Fixed graphical glitches when resizing on Wayland.
 - On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -69,13 +69,10 @@ impl Window {
 
         let window_store = evlp.store.clone();
         let my_surface = surface.clone();
-        let mut frame = SWindow::<BasicFrame>::init(
+        let mut frame = SWindow::<BasicFrame>::init_from_env(
+            &evlp.env,
             surface.clone(),
             (width, height),
-            &evlp.env.compositor,
-            &evlp.env.subcompositor,
-            &evlp.env.shm,
-            &evlp.env.shell,
             move |event, ()| match event {
                 WEvent::Configure { new_size, .. } => {
                     let mut store = window_store.lock().unwrap();


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

`init_from_env()` allows the creation of windows with server-side decorations when appropriate (when the compositor allows and supports it). Some compositors will never support server-side decorations on wayland like gnome's mutter however other compositors like kde's kwin actively support and encourage its usage.