### PR TITLE
Don't include NUL byte in _NET_WM_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed graphical glitches when resizing on Wayland.
 - On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.
 - Updated window manager hints under X11 to v1.5 of [Extended Window Manager Hints](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm140200472629520).
+- Fixed UTF8 handling bug in X11 `set_title` function
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -583,7 +583,7 @@ impl UnownedWindow {
                 wm_name_atom,
                 utf8_atom,
                 util::PropMode::Replace,
-                title.as_bytes_with_nul(),
+                title.as_bytes(),
             )
         }
     }


### PR DESCRIPTION
> The contents of the property are not required to be null-terminated;
> any terminating null should not be included in text_prop.nitems.

https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XmbTextPropertyToTextList.html

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] n/a <strike>Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior</strike>
- [ ] n/a <strike>Created an example program if it would help users understand this functionality</strike>
