### PR TITLE
Add X11-specific with_gtk_theme_variant option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed graphical glitches when resizing on Wayland.
 - On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.
 - Updated window manager hints under X11 to v1.5 of [Extended Window Manager Hints](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm140200472629520).
+- Added `WindowBuilderExt::with_gtk_theme_variant` to X11-specific `WindowBuilder` functions.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -219,6 +219,8 @@ pub trait WindowBuilderExt {
     fn with_override_redirect(self, override_redirect: bool) -> WindowBuilder;
     /// Build window with `_NET_WM_WINDOW_TYPE` hint; defaults to `Normal`. Only relevant on X11.
     fn with_x11_window_type(self, x11_window_type: XWindowType) -> WindowBuilder;
+    /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
+    fn with_gtk_theme_variant(self, variant: String) -> WindowBuilder;
     /// Build window with resize increment hint. Only implemented on X11.
     fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
     /// Build window with base size hint. Only implemented on X11.
@@ -267,6 +269,12 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_base_size(mut self, base_size: LogicalSize) -> WindowBuilder {
         self.platform_specific.base_size = Some(base_size.into());
+        self
+    }
+
+    #[inline]
+    fn with_gtk_theme_variant(mut self, variant: String) -> WindowBuilder {
+        self.platform_specific.gtk_theme_variant = Some(variant);
         self
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -45,6 +45,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub class: Option<(String, String)>,
     pub override_redirect: bool,
     pub x11_window_type: x11::util::WindowType,
+    pub gtk_theme_variant: Option<String>,
 }
 
 lazy_static!(

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -272,6 +272,10 @@ impl UnownedWindow {
                 window.set_window_type(pl_attribs.x11_window_type).queue();
             }
 
+            if let Some(variant) = pl_attribs.gtk_theme_variant {
+                window.set_gtk_theme_variant(variant).queue();
+            }
+
             // set size hints
             {
                 let mut min_dimensions = window_attrs.min_dimensions;
@@ -454,6 +458,19 @@ impl UnownedWindow {
             ffi::XA_ATOM,
             util::PropMode::Replace,
             &[window_type_atom],
+        )
+    }
+
+    fn set_gtk_theme_variant(&self, variant: String) -> util::Flusher {
+        let hint_atom = unsafe { self.xconn.get_atom_unchecked(b"_GTK_THEME_VARIANT\0") };
+        let utf8_atom = unsafe { self.xconn.get_atom_unchecked(b"UTF8_STRING\0") };
+        let variant = CString::new(variant).expect("`_GTK_THEME_VARIANT` contained null byte");
+        self.xconn.change_property(
+            self.xwindow,
+            hint_atom,
+            utf8_atom,
+            util::PropMode::Replace,
+            variant.as_bytes(),
         )
     }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality

This change provides applications that use winit with the ability to set the `_GTK_THEME_VARIANT` property for X11 windows. [Alacritty](https://github.com/jwilm/alacritty) for example could make use of this feature to let users enable dark window decorations specifically for Alacritty without affecting other GNOME apps. The stock GNOME terminal already provides this functionality.

If my understanding of winit's current Wayland support is accurate, implementing this feature for native Wayland isn't yet possible. I'd very happily be corrected on that and amend my changes accordingly.

Since I'm making these changes specifically to enable the above-mentioned feature in Alacritty, I've only tested them on top of the 0.15.1 release that Alacritty depends on — getting it to build with winit 0.17.2 seemed nontrivial at first glance.