### PR TITLE
Windows: Fix set_cursor delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed graphical glitches when resizing on Wayland.
 - On Windows, fix freezes when performing certain actions after a window resize has been triggered. Reintroduces some visual artifacts when resizing.
 - Updated window manager hints under X11 to v1.5 of [Extended Window Manager Hints](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm140200472629520).
+- On Windows, `Window::set_cursor` now applies immediately instead of requiring specific events to occur first.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -18,7 +18,7 @@ unsafe impl Send for PlatformSpecificWindowBuilderAttributes {}
 unsafe impl Sync for PlatformSpecificWindowBuilderAttributes {}
 
 // Cursor name in UTF-16. Used to set cursor in `WM_SETCURSOR`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Cursor(pub *const winapi::ctypes::wchar_t);
 unsafe impl Send for Cursor {}
 unsafe impl Sync for Cursor {}


### PR DESCRIPTION
Fixes #656

This PR simply sets the cursor directly in `set_cursor`, in addition to updating the cursor the old way (`WM_SETCURSOR`). As a result, cursor changes are visible immediately, rather than only appearing after a mouse movement/etc.