### PR TITLE
macOS: fix modifiers during key repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed UTF8 handling bug in X11 `set_title` function.
 - On Windows, `Window::set_cursor` now applies immediately instead of requiring specific events to occur first.
 - On Windows, fix window.set_maximized().
+- on macOS, fix modifiers during key repeat.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -5,7 +5,6 @@ use std::os::raw::c_void;
 use std::sync::Weak;
 use std::sync::atomic::{Ordering, AtomicBool};
 
-use cocoa;
 use cocoa::appkit::{
     self,
     CGFloat,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~[ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- ~[ ] Created an example program if it would help users understand this functionality~
