### PR TITLE
Upgrade to smithay-client-toolkit 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- On Wayland, titles will now be displayed in the window header decoration
+- On Wayland, key repetition is now ended when keyboard loses focus
+- On Wayland, windows will now use more stylish and modern client side decorations.
 - On Wayland, windows will use server-side decorations when available.
 - Added support for F16-F24 keys.
 - Fixed graphical glitches when resizing on Wayland.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.20.10", features = [ "dlopen", "egl", "cursor"] }
-smithay-client-toolkit = "0.3.0"
+wayland-client = { version = "0.21", features = [ "dlopen", "egl", "cursor"] }
+smithay-client-toolkit = "0.4"
 x11-dl = "2.18.3"
 parking_lot = "0.6"
 percent-encoding = "1.0"

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -10,7 +10,6 @@ use super::window::WindowStore;
 use super::WindowId;
 
 use sctk::output::OutputMgr;
-use sctk::reexports::client::commons::Implementation;
 use sctk::reexports::client::protocol::{
     wl_keyboard, wl_output, wl_pointer, wl_registry, wl_seat, wl_touch,
 };
@@ -93,7 +92,7 @@ impl EventsLoopProxy {
                 // Update the `EventsLoop`'s `pending_wakeup` flag.
                 wakeup.store(true, Ordering::Relaxed);
                 // Cause the `EventsLoop` to break from `dispatch` if it is currently blocked.
-                let _ = display.sync();
+                let _ = display.sync(|callback| {callback.implement(|_, _| {}, ())});
                 display.flush().map_err(|_| EventsLoopClosed)?;
                 Ok(())
             }
@@ -112,17 +111,24 @@ impl EventsLoop {
         let store = Arc::new(Mutex::new(WindowStore::new()));
         let seats = Arc::new(Mutex::new(Vec::new()));
 
-        let env = Environment::from_registry_with_cb(
-            display.get_registry().unwrap(),
+        let my_display = display.clone();
+        let my_sink = sink.clone();
+        let my_store = store.clone();
+        let my_seats = seats.clone();
+        let my_pending_wakeup = pending_wakeup.clone();
+        let env = Environment::from_display_with_cb(
+            &display,
             &mut event_queue,
-            SeatManager {
-                sink: sink.clone(),
-                store: store.clone(),
-                seats: seats.clone(),
-                events_loop_proxy: EventsLoopProxy {
-                    display: Arc::downgrade(&display),
-                    pending_wakeup: Arc::downgrade(&pending_wakeup),
-                },
+            move |event, registry| { 
+                SeatManager {
+                    sink: my_sink.clone(),
+                    store: my_store.clone(),
+                    seats: my_seats.clone(),
+                    events_loop_proxy: EventsLoopProxy {
+                        display: Arc::downgrade(&my_display),
+                        pending_wakeup: Arc::downgrade(&my_pending_wakeup),
+                    },
+                }.receive(event, registry)
             },
         ).unwrap();
 
@@ -280,7 +286,7 @@ struct SeatManager {
     events_loop_proxy: EventsLoopProxy,
 }
 
-impl Implementation<Proxy<wl_registry::WlRegistry>, GlobalEvent> for SeatManager {
+impl SeatManager {
     fn receive(&mut self, evt: GlobalEvent, registry: Proxy<wl_registry::WlRegistry>) {
         use self::wl_registry::RequestsTrait as RegistryRequests;
         use self::wl_seat::RequestsTrait as SeatRequests;
@@ -292,17 +298,22 @@ impl Implementation<Proxy<wl_registry::WlRegistry>, GlobalEvent> for SeatManager
             } if interface == "wl_seat" =>
             {
                 use std::cmp::min;
+
+                let seat_data = Arc::new(Mutex::new(SeatData {
+                    sink: self.sink.clone(),
+                    store: self.store.clone(),
+                    pointer: None,
+                    keyboard: None,
+                    touch: None,
+                    events_loop_proxy: self.events_loop_proxy.clone(),
+                }));
                 let seat = registry
-                    .bind::<wl_seat::WlSeat>(min(version, 5), id)
-                    .unwrap()
-                    .implement(SeatData {
-                        sink: self.sink.clone(),
-                        store: self.store.clone(),
-                        pointer: None,
-                        keyboard: None,
-                        touch: None,
-                        events_loop_proxy: self.events_loop_proxy.clone(),
-                    });
+                    .bind(min(version, 5), id, move |seat| {
+                        seat.implement(move |event, seat| {
+                            seat_data.lock().unwrap().receive(event, seat)
+                        }, ())
+                    })
+                    .unwrap();
                 self.store.lock().unwrap().new_seat(&seat);
                 self.seats.lock().unwrap().push((id, seat));
             }
@@ -329,16 +340,15 @@ struct SeatData {
     events_loop_proxy: EventsLoopProxy,
 }
 
-impl Implementation<Proxy<wl_seat::WlSeat>, wl_seat::Event> for SeatData {
+impl SeatData {
     fn receive(&mut self, evt: wl_seat::Event, seat: Proxy<wl_seat::WlSeat>) {
-        use self::wl_seat::RequestsTrait as SeatRequests;
         match evt {
             wl_seat::Event::Name { .. } => (),
             wl_seat::Event::Capabilities { capabilities } => {
                 // create pointer if applicable
                 if capabilities.contains(wl_seat::Capability::Pointer) && self.pointer.is_none() {
                     self.pointer = Some(super::pointer::implement_pointer(
-                        seat.get_pointer().unwrap(),
+                        &seat,
                         self.sink.clone(),
                         self.store.clone(),
                     ))
@@ -355,7 +365,7 @@ impl Implementation<Proxy<wl_seat::WlSeat>, wl_seat::Event> for SeatData {
                 // create keyboard if applicable
                 if capabilities.contains(wl_seat::Capability::Keyboard) && self.keyboard.is_none() {
                     self.keyboard = Some(super::keyboard::init_keyboard(
-                        seat.get_keyboard().unwrap(),
+                        &seat,
                         self.sink.clone(),
                         self.events_loop_proxy.clone(),
                     ))
@@ -372,7 +382,7 @@ impl Implementation<Proxy<wl_seat::WlSeat>, wl_seat::Event> for SeatData {
                 // create touch if applicable
                 if capabilities.contains(wl_seat::Capability::Touch) && self.touch.is_none() {
                     self.touch = Some(super::touch::implement_touch(
-                        seat.get_touch().unwrap(),
+                        &seat,
                         self.sink.clone(),
                         self.store.clone(),
                     ))

--- a/src/platform/linux/wayland/pointer.rs
+++ b/src/platform/linux/wayland/pointer.rs
@@ -7,11 +7,13 @@ use super::DeviceId;
 use super::event_loop::EventsLoopSink;
 use super::window::WindowStore;
 
-use sctk::reexports::client::{NewProxy, Proxy};
+use sctk::reexports::client::Proxy;
 use sctk::reexports::client::protocol::wl_pointer::{self, Event as PtrEvent, WlPointer};
+use sctk::reexports::client::protocol::wl_seat;
+use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
 
 pub fn implement_pointer(
-    pointer: NewProxy<WlPointer>,
+    seat: &Proxy<wl_seat::WlSeat>,
     sink: Arc<Mutex<EventsLoopSink>>,
     store: Arc<Mutex<WindowStore>>,
 ) -> Proxy<WlPointer> {
@@ -20,146 +22,30 @@ pub fn implement_pointer(
     let mut axis_discrete_buffer = None;
     let mut axis_state = TouchPhase::Ended;
 
-    pointer.implement(move |evt, pointer: Proxy<_>| {
-        let mut sink = sink.lock().unwrap();
-        let store = store.lock().unwrap();
-        match evt {
-            PtrEvent::Enter {
-                surface,
-                surface_x,
-                surface_y,
-                ..
-            } => {
-                let wid = store.find_wid(&surface);
-                if let Some(wid) = wid {
-                    mouse_focus = Some(wid);
-                    sink.send_event(
-                        WindowEvent::CursorEntered {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                        },
-                        wid,
-                    );
-                    sink.send_event(
-                        WindowEvent::CursorMoved {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            position: (surface_x, surface_y).into(),
-                            // TODO: replace dummy value with actual modifier state
-                            modifiers: ModifiersState::default(),
-                        },
-                        wid,
-                    );
-                }
-            }
-            PtrEvent::Leave { surface, .. } => {
-                mouse_focus = None;
-                let wid = store.find_wid(&surface);
-                if let Some(wid) = wid {
-                    sink.send_event(
-                        WindowEvent::CursorLeft {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                        },
-                        wid,
-                    );
-                }
-            }
-            PtrEvent::Motion {
-                surface_x,
-                surface_y,
-                ..
-            } => {
-                if let Some(wid) = mouse_focus {
-                    sink.send_event(
-                        WindowEvent::CursorMoved {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            position: (surface_x, surface_y).into(),
-                            // TODO: replace dummy value with actual modifier state
-                            modifiers: ModifiersState::default(),
-                        },
-                        wid,
-                    );
-                }
-            }
-            PtrEvent::Button { button, state, .. } => {
-                if let Some(wid) = mouse_focus {
-                    let state = match state {
-                        wl_pointer::ButtonState::Pressed => ElementState::Pressed,
-                        wl_pointer::ButtonState::Released => ElementState::Released,
-                    };
-                    let button = match button {
-                        0x110 => MouseButton::Left,
-                        0x111 => MouseButton::Right,
-                        0x112 => MouseButton::Middle,
-                        // TODO figure out the translation ?
-                        _ => return,
-                    };
-                    sink.send_event(
-                        WindowEvent::MouseInput {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            state: state,
-                            button: button,
-                            // TODO: replace dummy value with actual modifier state
-                            modifiers: ModifiersState::default(),
-                        },
-                        wid,
-                    );
-                }
-            }
-            PtrEvent::Axis { axis, value, .. } => {
-                if let Some(wid) = mouse_focus {
-                    if pointer.version() < 5 {
-                        let (mut x, mut y) = (0.0, 0.0);
-                        // old seat compatibility
-                        match axis {
-                            // wayland vertical sign convention is the inverse of winit
-                            wl_pointer::Axis::VerticalScroll => y -= value as f32,
-                            wl_pointer::Axis::HorizontalScroll => x += value as f32,
-                        }
+    seat.get_pointer(|pointer| {
+        pointer.implement(move |evt, pointer| {
+            let mut sink = sink.lock().unwrap();
+            let store = store.lock().unwrap();
+            match evt {
+                PtrEvent::Enter {
+                    surface,
+                    surface_x,
+                    surface_y,
+                    ..
+                } => {
+                    let wid = store.find_wid(&surface);
+                    if let Some(wid) = wid {
+                        mouse_focus = Some(wid);
                         sink.send_event(
-                            WindowEvent::MouseWheel {
+                            WindowEvent::CursorEntered {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
-                                phase: TouchPhase::Moved,
-                                // TODO: replace dummy value with actual modifier state
-                                modifiers: ModifiersState::default(),
                             },
                             wid,
                         );
-                    } else {
-                        let (mut x, mut y) = axis_buffer.unwrap_or((0.0, 0.0));
-                        match axis {
-                            // wayland vertical sign convention is the inverse of winit
-                            wl_pointer::Axis::VerticalScroll => y -= value as f32,
-                            wl_pointer::Axis::HorizontalScroll => x += value as f32,
-                        }
-                        axis_buffer = Some((x, y));
-                        axis_state = match axis_state {
-                            TouchPhase::Started | TouchPhase::Moved => TouchPhase::Moved,
-                            _ => TouchPhase::Started,
-                        }
-                    }
-                }
-            }
-            PtrEvent::Frame => {
-                let axis_buffer = axis_buffer.take();
-                let axis_discrete_buffer = axis_discrete_buffer.take();
-                if let Some(wid) = mouse_focus {
-                    if let Some((x, y)) = axis_discrete_buffer {
                         sink.send_event(
-                            WindowEvent::MouseWheel {
+                            WindowEvent::CursorMoved {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                delta: MouseScrollDelta::LineDelta(x as f32, y as f32),
-                                phase: axis_state,
-                                // TODO: replace dummy value with actual modifier state
-                                modifiers: ModifiersState::default(),
-                            },
-                            wid,
-                        );
-                    } else if let Some((x, y)) = axis_buffer {
-                        sink.send_event(
-                            WindowEvent::MouseWheel {
-                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                                delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
-                                phase: axis_state,
+                                position: (surface_x, surface_y).into(),
                                 // TODO: replace dummy value with actual modifier state
                                 modifiers: ModifiersState::default(),
                             },
@@ -167,24 +53,142 @@ pub fn implement_pointer(
                         );
                     }
                 }
-            }
-            PtrEvent::AxisSource { .. } => (),
-            PtrEvent::AxisStop { .. } => {
-                axis_state = TouchPhase::Ended;
-            }
-            PtrEvent::AxisDiscrete { axis, discrete } => {
-                let (mut x, mut y) = axis_discrete_buffer.unwrap_or((0, 0));
-                match axis {
-                    // wayland vertical sign convention is the inverse of winit
-                    wl_pointer::Axis::VerticalScroll => y -= discrete,
-                    wl_pointer::Axis::HorizontalScroll => x += discrete,
+                PtrEvent::Leave { surface, .. } => {
+                    mouse_focus = None;
+                    let wid = store.find_wid(&surface);
+                    if let Some(wid) = wid {
+                        sink.send_event(
+                            WindowEvent::CursorLeft {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                            },
+                            wid,
+                        );
+                    }
                 }
-                axis_discrete_buffer = Some((x, y));
-                axis_state = match axis_state {
-                    TouchPhase::Started | TouchPhase::Moved => TouchPhase::Moved,
-                    _ => TouchPhase::Started,
+                PtrEvent::Motion {
+                    surface_x,
+                    surface_y,
+                    ..
+                } => {
+                    if let Some(wid) = mouse_focus {
+                        sink.send_event(
+                            WindowEvent::CursorMoved {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                position: (surface_x, surface_y).into(),
+                                // TODO: replace dummy value with actual modifier state
+                                modifiers: ModifiersState::default(),
+                            },
+                            wid,
+                        );
+                    }
+                }
+                PtrEvent::Button { button, state, .. } => {
+                    if let Some(wid) = mouse_focus {
+                        let state = match state {
+                            wl_pointer::ButtonState::Pressed => ElementState::Pressed,
+                            wl_pointer::ButtonState::Released => ElementState::Released,
+                        };
+                        let button = match button {
+                            0x110 => MouseButton::Left,
+                            0x111 => MouseButton::Right,
+                            0x112 => MouseButton::Middle,
+                            // TODO figure out the translation ?
+                            _ => return,
+                        };
+                        sink.send_event(
+                            WindowEvent::MouseInput {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                state: state,
+                                button: button,
+                                // TODO: replace dummy value with actual modifier state
+                                modifiers: ModifiersState::default(),
+                            },
+                            wid,
+                        );
+                    }
+                }
+                PtrEvent::Axis { axis, value, .. } => {
+                    if let Some(wid) = mouse_focus {
+                        if pointer.version() < 5 {
+                            let (mut x, mut y) = (0.0, 0.0);
+                            // old seat compatibility
+                            match axis {
+                                // wayland vertical sign convention is the inverse of winit
+                                wl_pointer::Axis::VerticalScroll => y -= value as f32,
+                                wl_pointer::Axis::HorizontalScroll => x += value as f32,
+                            }
+                            sink.send_event(
+                                WindowEvent::MouseWheel {
+                                    device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                    delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
+                                    phase: TouchPhase::Moved,
+                                    // TODO: replace dummy value with actual modifier state
+                                    modifiers: ModifiersState::default(),
+                                },
+                                wid,
+                            );
+                        } else {
+                            let (mut x, mut y) = axis_buffer.unwrap_or((0.0, 0.0));
+                            match axis {
+                                // wayland vertical sign convention is the inverse of winit
+                                wl_pointer::Axis::VerticalScroll => y -= value as f32,
+                                wl_pointer::Axis::HorizontalScroll => x += value as f32,
+                            }
+                            axis_buffer = Some((x, y));
+                            axis_state = match axis_state {
+                                TouchPhase::Started | TouchPhase::Moved => TouchPhase::Moved,
+                                _ => TouchPhase::Started,
+                            }
+                        }
+                    }
+                }
+                PtrEvent::Frame => {
+                    let axis_buffer = axis_buffer.take();
+                    let axis_discrete_buffer = axis_discrete_buffer.take();
+                    if let Some(wid) = mouse_focus {
+                        if let Some((x, y)) = axis_discrete_buffer {
+                            sink.send_event(
+                                WindowEvent::MouseWheel {
+                                    device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                    delta: MouseScrollDelta::LineDelta(x as f32, y as f32),
+                                    phase: axis_state,
+                                    // TODO: replace dummy value with actual modifier state
+                                    modifiers: ModifiersState::default(),
+                                },
+                                wid,
+                            );
+                        } else if let Some((x, y)) = axis_buffer {
+                            sink.send_event(
+                                WindowEvent::MouseWheel {
+                                    device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                    delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
+                                    phase: axis_state,
+                                    // TODO: replace dummy value with actual modifier state
+                                    modifiers: ModifiersState::default(),
+                                },
+                                wid,
+                            );
+                        }
+                    }
+                }
+                PtrEvent::AxisSource { .. } => (),
+                PtrEvent::AxisStop { .. } => {
+                    axis_state = TouchPhase::Ended;
+                }
+                PtrEvent::AxisDiscrete { axis, discrete } => {
+                    let (mut x, mut y) = axis_discrete_buffer.unwrap_or((0, 0));
+                    match axis {
+                        // wayland vertical sign convention is the inverse of winit
+                        wl_pointer::Axis::VerticalScroll => y -= discrete,
+                        wl_pointer::Axis::HorizontalScroll => x += discrete,
+                    }
+                    axis_discrete_buffer = Some((x, y));
+                    axis_state = match axis_state {
+                        TouchPhase::Started | TouchPhase::Moved => TouchPhase::Moved,
+                        _ => TouchPhase::Started,
+                    }
                 }
             }
-        }
-    })
+        }, ())
+    }).unwrap()
 }

--- a/src/platform/linux/wayland/touch.rs
+++ b/src/platform/linux/wayland/touch.rs
@@ -6,8 +6,10 @@ use super::{DeviceId, WindowId};
 use super::event_loop::EventsLoopSink;
 use super::window::WindowStore;
 
-use sctk::reexports::client::{NewProxy, Proxy};
+use sctk::reexports::client::Proxy;
 use sctk::reexports::client::protocol::wl_touch::{Event as TouchEvent, WlTouch};
+use sctk::reexports::client::protocol::wl_seat;
+use sctk::reexports::client::protocol::wl_seat::RequestsTrait as SeatRequests;
 
 struct TouchPoint {
     wid: WindowId,
@@ -16,78 +18,80 @@ struct TouchPoint {
 }
 
 pub(crate) fn implement_touch(
-    touch: NewProxy<WlTouch>,
+    seat: &Proxy<wl_seat::WlSeat>,
     sink: Arc<Mutex<EventsLoopSink>>,
     store: Arc<Mutex<WindowStore>>,
 ) -> Proxy<WlTouch> {
     let mut pending_ids = Vec::new();
-    touch.implement(move |evt, _| {
-        let mut sink = sink.lock().unwrap();
-        let store = store.lock().unwrap();
-        match evt {
-            TouchEvent::Down {
-                surface, id, x, y, ..
-            } => {
-                let wid = store.find_wid(&surface);
-                if let Some(wid) = wid {
-                    sink.send_event(
-                        WindowEvent::Touch(::Touch {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            phase: TouchPhase::Started,
-                            location: (x, y).into(),
-                            id: id as u64,
-                        }),
-                        wid,
-                    );
-                    pending_ids.push(TouchPoint {
-                        wid: wid,
-                        location: (x, y),
-                        id: id,
-                    });
+    seat.get_touch(|touch| {
+        touch.implement(move |evt, _| {
+            let mut sink = sink.lock().unwrap();
+            let store = store.lock().unwrap();
+            match evt {
+                TouchEvent::Down {
+                    surface, id, x, y, ..
+                } => {
+                    let wid = store.find_wid(&surface);
+                    if let Some(wid) = wid {
+                        sink.send_event(
+                            WindowEvent::Touch(::Touch {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                phase: TouchPhase::Started,
+                                location: (x, y).into(),
+                                id: id as u64,
+                            }),
+                            wid,
+                        );
+                        pending_ids.push(TouchPoint {
+                            wid: wid,
+                            location: (x, y),
+                            id: id,
+                        });
+                    }
                 }
-            }
-            TouchEvent::Up { id, .. } => {
-                let idx = pending_ids.iter().position(|p| p.id == id);
-                if let Some(idx) = idx {
-                    let pt = pending_ids.remove(idx);
+                TouchEvent::Up { id, .. } => {
+                    let idx = pending_ids.iter().position(|p| p.id == id);
+                    if let Some(idx) = idx {
+                        let pt = pending_ids.remove(idx);
+                        sink.send_event(
+                            WindowEvent::Touch(::Touch {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                phase: TouchPhase::Ended,
+                                location: pt.location.into(),
+                                id: id as u64,
+                            }),
+                            pt.wid,
+                        );
+                    }
+                }
+                TouchEvent::Motion { id, x, y, .. } => {
+                    let pt = pending_ids.iter_mut().find(|p| p.id == id);
+                    if let Some(pt) = pt {
+                        pt.location = (x, y);
+                        sink.send_event(
+                            WindowEvent::Touch(::Touch {
+                                device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
+                                phase: TouchPhase::Moved,
+                                location: (x, y).into(),
+                                id: id as u64,
+                            }),
+                            pt.wid,
+                        );
+                    }
+                }
+                TouchEvent::Frame => (),
+                TouchEvent::Cancel => for pt in pending_ids.drain(..) {
                     sink.send_event(
                         WindowEvent::Touch(::Touch {
                             device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            phase: TouchPhase::Ended,
+                            phase: TouchPhase::Cancelled,
                             location: pt.location.into(),
-                            id: id as u64,
+                            id: pt.id as u64,
                         }),
                         pt.wid,
                     );
-                }
+                },
             }
-            TouchEvent::Motion { id, x, y, .. } => {
-                let pt = pending_ids.iter_mut().find(|p| p.id == id);
-                if let Some(pt) = pt {
-                    pt.location = (x, y);
-                    sink.send_event(
-                        WindowEvent::Touch(::Touch {
-                            device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                            phase: TouchPhase::Moved,
-                            location: (x, y).into(),
-                            id: id as u64,
-                        }),
-                        pt.wid,
-                    );
-                }
-            }
-            TouchEvent::Frame => (),
-            TouchEvent::Cancel => for pt in pending_ids.drain(..) {
-                sink.send_event(
-                    WindowEvent::Touch(::Touch {
-                        device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
-                        phase: TouchPhase::Cancelled,
-                        location: pt.location.into(),
-                        id: pt.id as u64,
-                    }),
-                    pt.wid,
-                );
-            },
-        }
-    })
+        }, ())
+    }).unwrap()
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users (Just about the decorations change)

Upgrades to smithay-client-toolkit to version 4.0, biggest changes are

* Now uses wayland 0.21 (doesn't use pure rust implementation because of c lib dependency that can hopefully be removed in the future)

* Better 'ConceptFrame' for decorations which looks more visual appealing then 'BasicFrame'

* Window titles will now be displayed in the header of the window

* Fix wayland key repetition when keyboard loses focus

Fixes https://github.com/tomaka/winit/issues/657