### PR TITLE
Windows: Fix window.set_maximized()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `WindowBuilderExt::with_gtk_theme_variant` to X11-specific `WindowBuilder` functions.
 - Fixed UTF8 handling bug in X11 `set_title` function.
 - On Windows, `Window::set_cursor` now applies immediately instead of requiring specific events to occur first.
+- On Windows, fix window.set_maximized().
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -453,9 +453,9 @@ impl Window {
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let mut window_state = self.window_state.lock().unwrap();
-        window_state.maximized = true;
+        window_state.maximized = maximized;
         // We only maximize if we're not in fullscreen.
-        if window_state.fullscreen.is_none() {
+        if window_state.fullscreen.is_some() {
             return;
         }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Should fix issue #670
Tested on my Windows 10 machine, using the fullscreen example.
Restores the correct window.set_maxmized functionality, that appears to have been broken in PR #601  