### PR TITLE
Windows: Fix transparency

### DIFF
--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -14,6 +14,7 @@ use winapi::um::{combaseapi, dwmapi, libloaderapi, winuser};
 use winapi::um::objbase::COINIT_MULTITHREADED;
 use winapi::um::shobjidl_core::{CLSID_TaskbarList, ITaskbarList2};
 use winapi::um::winnt::{LONG, LPCWSTR};
+use winapi::um::wingdi::CreateRectRgn;
 
 use {
     CreationError,
@@ -894,7 +895,7 @@ unsafe fn init(
             }
         )
     } else {
-        (winuser::WS_EX_APPWINDOW | winuser::WS_EX_WINDOWEDGE,
+        (winuser::WS_EX_APPWINDOW | winuser::WS_EX_WINDOWEDGE | winuser::WS_EX_LAYERED,
             winuser::WS_OVERLAPPEDWINDOW | winuser::WS_CLIPSIBLINGS | winuser::WS_CLIPCHILDREN)
     };
 
@@ -1019,13 +1020,22 @@ unsafe fn init(
     // making the window transparent
     if attributes.transparent && !pl_attribs.no_redirection_bitmap {
         let bb = dwmapi::DWM_BLURBEHIND {
-            dwFlags: 0x1, // FIXME: DWM_BB_ENABLE;
+            dwFlags: dwmapi::DWM_BB_ENABLE | dwmapi::DWM_BB_BLURREGION,
             fEnable: 1,
-            hRgnBlur: ptr::null_mut(),
+            hRgnBlur: CreateRectRgn(0, 0, -1, -1), // makes the window transparent
             fTransitionOnMaximized: 0,
         };
 
         dwmapi::DwmEnableBlurBehindWindow(real_window.0, &bb);
+
+        if attributes.decorations {
+            // HACK: When opaque (opacity 255), there is a trail whenever
+            // the transparent window is moved. By reducing it to 254,
+            // the window is rendered properly.
+            let opacity = 254;
+
+            winuser::SetLayeredWindowAttributes(real_window.0, 0x0030c100, opacity, winuser::LWA_ALPHA);
+        }
     }
 
     let win = Window {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -895,7 +895,7 @@ unsafe fn init(
             }
         )
     } else {
-        (winuser::WS_EX_APPWINDOW | winuser::WS_EX_WINDOWEDGE | winuser::WS_EX_LAYERED,
+        (winuser::WS_EX_APPWINDOW | winuser::WS_EX_WINDOWEDGE,
             winuser::WS_OVERLAPPEDWINDOW | winuser::WS_CLIPSIBLINGS | winuser::WS_CLIPCHILDREN)
     };
 
@@ -904,6 +904,9 @@ unsafe fn init(
     }
     if pl_attribs.no_redirection_bitmap {
         ex_style |= winuser::WS_EX_NOREDIRECTIONBITMAP;
+    }
+    if attributes.transparent && attributes.decorations {
+        ex_style |= winuser::WS_EX_LAYERED;
     }
 
     // adjusting the window coordinates using the style


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Fixed transparency in Windows 10 (#260). It also works with window decorations, by using `WS_EX_LAYERED`. Tested with the transparency example on my Windows 10 machine.