### PR TITLE
Provide current modifiers state with pointer events on wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Wayland, pointer events will now provide the current modifiers state
 - On Wayland, titles will now be displayed in the window header decoration
 - On Wayland, key repetition is now ended when keyboard loses focus
 - On Wayland, windows will now use more stylish and modern client side decorations.

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -19,6 +19,8 @@ use sctk::Environment;
 use sctk::reexports::client::protocol::wl_display::RequestsTrait as DisplayRequests;
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait;
 
+use ModifiersState;
+
 pub struct EventsLoopSink {
     buffer: VecDeque<::Event>,
 }
@@ -303,6 +305,7 @@ impl SeatManager {
                     keyboard: None,
                     touch: None,
                     events_loop_proxy: self.events_loop_proxy.clone(),
+                    modifiers_tracker: Arc::new(Mutex::new(ModifiersState::default())),
                 };
                 let seat = registry
                     .bind(min(version, 5), id, move |seat| {
@@ -335,6 +338,7 @@ struct SeatData {
     keyboard: Option<Proxy<wl_keyboard::WlKeyboard>>,
     touch: Option<Proxy<wl_touch::WlTouch>>,
     events_loop_proxy: EventsLoopProxy,
+    modifiers_tracker: Arc<Mutex<ModifiersState>>,
 }
 
 impl SeatData {
@@ -348,6 +352,7 @@ impl SeatData {
                         &seat,
                         self.sink.clone(),
                         self.store.clone(),
+                        self.modifiers_tracker.clone(),
                     ))
                 }
                 // destroy pointer if applicable
@@ -365,6 +370,7 @@ impl SeatData {
                         &seat,
                         self.sink.clone(),
                         self.events_loop_proxy.clone(),
+                        self.modifiers_tracker.clone(),
                     ))
                 }
                 // destroy keyboard if applicable

--- a/src/platform/linux/wayland/keyboard.rs
+++ b/src/platform/linux/wayland/keyboard.rs
@@ -15,14 +15,14 @@ pub fn init_keyboard(
     seat: &Proxy<wl_seat::WlSeat>,
     sink: Arc<Mutex<EventsLoopSink>>,
     events_loop_proxy: EventsLoopProxy,
+    modifiers_tracker: Arc<Mutex<ModifiersState>>,
 ) -> Proxy<wl_keyboard::WlKeyboard> {
     // { variables to be captured by the closures
     let target = Arc::new(Mutex::new(None));
     let my_sink = sink.clone();
     let repeat_sink = sink.clone();
     let repeat_target = target.clone();
-    let modifiers = Arc::new(Mutex::new(ModifiersState::default()));
-    let my_modifiers = modifiers.clone();
+    let my_modifiers = modifiers_tracker.clone();
     // }
     let ret = map_keyboard_auto_with_repeat(
         seat,
@@ -65,7 +65,7 @@ pub fn init_keyboard(
                                 state: state,
                                 scancode: rawkey,
                                 virtual_keycode: vkcode,
-                                modifiers: modifiers.lock().unwrap().clone(),
+                                modifiers: modifiers_tracker.lock().unwrap().clone(),
                             },
                         },
                         wid,
@@ -83,7 +83,7 @@ pub fn init_keyboard(
             }
             KbEvent::RepeatInfo { .. } => { /* Handled by smithay client toolkit */ }
             KbEvent::Modifiers { modifiers: event_modifiers } => {
-                *modifiers.lock().unwrap() = event_modifiers.into()
+                *modifiers_tracker.lock().unwrap() = event_modifiers.into()
             }
         },
         move |repeat_event: KeyRepeatEvent, _| {

--- a/src/platform/linux/wayland/pointer.rs
+++ b/src/platform/linux/wayland/pointer.rs
@@ -16,6 +16,7 @@ pub fn implement_pointer(
     seat: &Proxy<wl_seat::WlSeat>,
     sink: Arc<Mutex<EventsLoopSink>>,
     store: Arc<Mutex<WindowStore>>,
+    modifiers_tracker: Arc<Mutex<ModifiersState>>,
 ) -> Proxy<WlPointer> {
     let mut mouse_focus = None;
     let mut axis_buffer = None;
@@ -46,8 +47,7 @@ pub fn implement_pointer(
                             WindowEvent::CursorMoved {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                 position: (surface_x, surface_y).into(),
-                                // TODO: replace dummy value with actual modifier state
-                                modifiers: ModifiersState::default(),
+                                modifiers: modifiers_tracker.lock().unwrap().clone(),
                             },
                             wid,
                         );
@@ -75,8 +75,7 @@ pub fn implement_pointer(
                             WindowEvent::CursorMoved {
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                 position: (surface_x, surface_y).into(),
-                                // TODO: replace dummy value with actual modifier state
-                                modifiers: ModifiersState::default(),
+                                modifiers: modifiers_tracker.lock().unwrap().clone(),
                             },
                             wid,
                         );
@@ -100,8 +99,7 @@ pub fn implement_pointer(
                                 device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                 state: state,
                                 button: button,
-                                // TODO: replace dummy value with actual modifier state
-                                modifiers: ModifiersState::default(),
+                                modifiers: modifiers_tracker.lock().unwrap().clone(),
                             },
                             wid,
                         );
@@ -122,8 +120,7 @@ pub fn implement_pointer(
                                     device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                     delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
                                     phase: TouchPhase::Moved,
-                                    // TODO: replace dummy value with actual modifier state
-                                    modifiers: ModifiersState::default(),
+                                    modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
                             );
@@ -152,8 +149,7 @@ pub fn implement_pointer(
                                     device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                     delta: MouseScrollDelta::LineDelta(x as f32, y as f32),
                                     phase: axis_state,
-                                    // TODO: replace dummy value with actual modifier state
-                                    modifiers: ModifiersState::default(),
+                                    modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
                             );
@@ -163,8 +159,7 @@ pub fn implement_pointer(
                                     device_id: ::DeviceId(::platform::DeviceId::Wayland(DeviceId)),
                                     delta: MouseScrollDelta::PixelDelta((x as f64, y as f64).into()),
                                     phase: axis_state,
-                                    // TODO: replace dummy value with actual modifier state
-                                    modifiers: ModifiersState::default(),
+                                    modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
                             );


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Tracks modifiers state from keyboards and then uses that to provide the modifiers state for pointer events

Fixes https://github.com/tomaka/winit/issues/653