### PR TITLE
Implement `Debug` trait on exported opaque types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed UTF8 handling bug in X11 `set_title` function.
 - On Windows, `Window::set_cursor` now applies immediately instead of requiring specific events to occur first.
 - On Windows, fix window.set_maximized().
+- Implemented the `Debug` trait for `Window`, `EventsLoop`, `EventsLoopProxy` and `WindowBuilder`.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,12 @@ pub struct Window {
     window: platform::Window,
 }
 
+impl std::fmt::Debug for Window {
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmtr.pad("Window { .. }")
+    }
+}
+
 /// Identifier of a window. Unique for each window.
 ///
 /// Can be obtained with `window.id()`.
@@ -182,6 +188,12 @@ pub struct DeviceId(platform::DeviceId);
 pub struct EventsLoop {
     events_loop: platform::EventsLoop,
     _marker: ::std::marker::PhantomData<*mut ()> // Not Send nor Sync
+}
+
+impl std::fmt::Debug for EventsLoop {
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmtr.pad("EventsLoop { .. }")
+    }
 }
 
 /// Returned by the user callback given to the `EventsLoop::run_forever` method.
@@ -263,6 +275,12 @@ pub struct EventsLoopProxy {
     events_loop_proxy: platform::EventsLoopProxy,
 }
 
+impl std::fmt::Debug for EventsLoopProxy {
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmtr.pad("EventsLoopProxy { ... }")
+    }
+}
+
 impl EventsLoopProxy {
     /// Wake up the `EventsLoop` from which this proxy was created.
     ///
@@ -299,6 +317,14 @@ pub struct WindowBuilder {
 
     // Platform-specific configuration. Private.
     platform_specific: platform::PlatformSpecificWindowBuilderAttributes,
+}
+
+impl std::fmt::Debug for WindowBuilder {
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmtr.debug_struct("WindowBuilder")
+            .field("window", &self.window)
+            .finish()
+    }
 }
 
 /// Error that can happen while creating a window or a headless renderer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ pub struct EventsLoopProxy {
 
 impl std::fmt::Debug for EventsLoopProxy {
     fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmtr.pad("EventsLoopProxy { ... }")
+        fmtr.pad("EventsLoopProxy { .. }")
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior-~~
- [ ] ~~Created an example program if it would help users understand this functionality~~

This change adds opaque debug impls, similar to how [`std::sync::Once`](https://doc.rust-lang.org/src/std/sync/once.rs.html#395) has `Debug` implemented on it.

I don't believe this change requires more documentation changes, but please tell me if I'm missing something.