### PR TITLE
Unit testing: Panic messages should not contain control characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Implemented the `Debug` trait for `Window`, `EventsLoop`, `EventsLoopProxy` and `WindowBuilder`.
 - On X11, now a `Resized` event will always be generated after a DPI change to ensure the window's logical size is consistent with the new DPI.
 - Added further clarifications to the DPI docs.
+- On Linux, if neither X11 nor Wayland manage to initialize, the corresponding panic now consists of a single line only.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -430,10 +430,7 @@ impl EventsLoop {
         };
 
         let err_string = format!(
-r#"Failed to initialize any backend!
-    Wayland status: {:#?}
-    X11 status: {:#?}
-"#,
+            "Failed to initialize any backend! Wayland status: {:?} X11 status: {:?}",
             wayland_err,
             x11_err,
         );


### PR DESCRIPTION
This PR refers to issue #678 .

The relevant panic message should primarily appear on linux systems without either Wayland or X11. This is true for example on the Windows Subsystem for Linux, on which I tested the changes. Please let me know if I should test on additional platforms.

The binary used to trigger the panic is the example `window`. After the change, the panic message looks as follows:

```bash
$ cargo run --example window
thread 'main' panicked at 'Failed to initialize any backend! Wayland status: XdgRuntimeDirNotSet X11 status: XOpenDisplayFailed', src/platform/linux/mod.rs:437:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior (not applicable)
- [ ] Created an example program if it would help users understand this functionality (not applicable)
