### PR TITLE
Make views explicitly layer-backed on macOS Mojave.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add optional `serde` feature with implementations of `Serialize`/`Deserialize` for DPI types and various event types.
 - Add `PartialEq`, `Eq`, and `Hash` implementations on public types that could have them but were missing them.
 - On X11, drag-and-drop receiving an unsupported drop type can no longer cause the WM to freeze.
+- Fix issue whereby the OpenGL context would not appear at startup on macOS Mojave (#1069).
 
 # Version 0.17.2 (2018-08-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ objc = "0.2.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.3"
-cocoa = "0.17"
+cocoa = "0.18.4"
 core-foundation = "0.6"
-core-graphics = "0.16"
+core-graphics = "0.17.3"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.6"

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -1,5 +1,6 @@
 use std;
 use std::cell::{Cell, RefCell};
+use std::f64;
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::sync::Weak;
@@ -850,6 +851,16 @@ impl Window2 {
             let view = new_view(window, shared);
             view.non_nil().map(|view| {
                 view.setWantsBestResolutionOpenGLSurface_(YES);
+
+                // On Mojave, views automatically become layer-backed shortly after being added to
+                // a window. Changing the layer-backedness of a view breaks the association between
+                // the view and its associated OpenGL context. To work around this, on Mojave we
+                // explicitly make the view layer-backed up front so that AppKit doesn't do it
+                // itself and break the association with its context.
+                if f64::floor(appkit::NSAppKitVersionNumber) > appkit::NSAppKitVersionNumber10_12 {
+                    view.setWantsLayer(YES);
+                }
+
                 window.setContentView_(*view);
                 window.makeFirstResponder_(*view);
                 view


### PR DESCRIPTION
This is an alternate fix for tomaka/glutin#1069.

On Mojave, views automatically become layer-backed shortly after being added to a window. Changing the layer-backedness of a view breaks the association between the view and its associated OpenGL context. To work around this, on Mojave we explicitly make the view layer-backed up front so that AppKit doesn't do it itself and break the association with its context.

This was breaking the `window` example in `glutin`.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
