### PR TITLE
X11: Fix DND freezing the WM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - On X11, now a `Resized` event will always be generated after a DPI change to ensure the window's logical size is consistent with the new DPI.
 - Added further clarifications to the DPI docs.
 - On Linux, if neither X11 nor Wayland manage to initialize, the corresponding panic now consists of a single line only.
+- On X11, drag-and-drop receiving an unsupported drop type can no longer cause the WM to freeze.
 
 # Version 0.17.2 (2018-08-19)
 


### PR DESCRIPTION
Fixes #687

`XdndFinished` isn't supposed to be sent when rejecting a `XdndPosition`; it should only be
sent in response to `XdndDrop`.

https://freedesktop.org/wiki/Specifications/XDND/