### PR TITLE
Remove From<NSApplicationActivationPolicy> impl from ActivationPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add optional `serde` feature with implementations of `Serialize`/`Deserialize` for DPI types and various event types.
 - Add `PartialEq`, `Eq`, and `Hash` implementations on public types that could have them but were missing them.
 - On X11, drag-and-drop receiving an unsupported drop type can no longer cause the WM to freeze.
+- **Breaking:** Removed `From<NSApplicationActivationPolicy>` impl from `ActivationPolicy` on MacOS.
 
 # Version 0.17.2 (2018-08-19)
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,8 +1,6 @@
 #![cfg(target_os = "macos")]
 
-use std::convert::From;
 use std::os::raw::c_void;
-use cocoa::appkit::NSApplicationActivationPolicy;
 use {LogicalSize, MonitorId, Window, WindowBuilder};
 
 /// Additional methods on `Window` that are specific to MacOS.
@@ -44,19 +42,6 @@ pub enum ActivationPolicy {
 impl Default for ActivationPolicy {
     fn default() -> Self {
         ActivationPolicy::Regular
-    }
-}
-
-impl From<ActivationPolicy> for NSApplicationActivationPolicy {
-    fn from(activation_policy: ActivationPolicy) -> Self {
-        match activation_policy {
-            ActivationPolicy::Regular =>
-                NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular,
-            ActivationPolicy::Accessory =>
-                NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory,
-            ActivationPolicy::Prohibited =>
-                NSApplicationActivationPolicy::NSApplicationActivationPolicyProhibited,
-        }
     }
 }
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -15,6 +15,7 @@ use cocoa::appkit::{
     NSWindow,
     NSWindowButton,
     NSWindowStyleMask,
+    NSApplicationActivationPolicy,
 };
 use cocoa::base::{id, nil};
 use cocoa::foundation::{NSAutoreleasePool, NSDictionary, NSPoint, NSRect, NSSize, NSString};
@@ -717,7 +718,15 @@ impl Window2 {
             if app == nil {
                 None
             } else {
-                app.setActivationPolicy_(activation_policy.into());
+                let ns_activation_policy = match activation_policy {
+                    ActivationPolicy::Regular =>
+                        NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular,
+                    ActivationPolicy::Accessory =>
+                        NSApplicationActivationPolicy::NSApplicationActivationPolicyAccessory,
+                    ActivationPolicy::Prohibited =>
+                        NSApplicationActivationPolicy::NSApplicationActivationPolicyProhibited,
+                };
+                app.setActivationPolicy_(ns_activation_policy);
                 app.finishLaunching();
                 Some(app)
             }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] ~~Created an example program if it would help users understand this functionality~~

This is blocking `0.18` and a PR didn't seem to be coming, so I threw this together. With cross-compilation Rust compiles it fine, but since I don't have convenient access to a MacOS machine it's untested.

cc #680 
