### PR TITLE
X11: Fix panic when dropping window before running event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On X11, fixed panic caused by dropping the window before running the event loop.
+
 # Version 0.18.0 (2018-11-07)
 
 - **Breaking:** `image` crate upgraded to 0.20. This is exposed as part of the `icon_loading` API.


### PR DESCRIPTION
Fixes #691

Dropping a window before running the `EventsLoop` results in events still being queued when `XDestroyWindow` is called, so events like `XI_Enter` (the culprit in this case) will still be processed. Simply checking that the window still exists before calling `query_pointer` was enough to solve the problem.