### PR TITLE
Introduce WindowBuilderExt::with_app_id for wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
+- Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -225,6 +225,13 @@ pub trait WindowBuilderExt {
     fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
     /// Build window with base size hint. Only implemented on X11.
     fn with_base_size(self, base_size: LogicalSize) -> WindowBuilder;
+
+    /// Build window with a given application ID. It should match the `.desktop` file distributed with
+    /// your program. Only relevant on Wayland.
+    ///
+    /// For details about application ID conventions, see the
+    /// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
+    fn with_app_id(self, app_id: String) -> WindowBuilder;
 }
 
 impl WindowBuilderExt for WindowBuilder {
@@ -275,6 +282,12 @@ impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_gtk_theme_variant(mut self, variant: String) -> WindowBuilder {
         self.platform_specific.gtk_theme_variant = Some(variant);
+        self
+    }
+
+    #[inline]
+    fn with_app_id(mut self, app_id: String) -> WindowBuilder {
+        self.platform_specific.app_id = Some(app_id);
         self
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -46,6 +46,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub override_redirect: bool,
     pub x11_window_type: x11::util::WindowType,
     pub gtk_theme_variant: Option<String>,
+    pub app_id: Option<String>
 }
 
 lazy_static!(
@@ -128,7 +129,7 @@ impl Window {
     ) -> Result<Self, CreationError> {
         match *events_loop {
             EventsLoop::Wayland(ref events_loop) => {
-                wayland::Window::new(events_loop, attribs).map(Window::Wayland)
+                wayland::Window::new(events_loop, attribs, pl_attribs).map(Window::Wayland)
             },
             EventsLoop::X(ref events_loop) => {
                 x11::Window::new(events_loop, attribs, pl_attribs).map(Window::X)

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, Weak};
 
 use {CreationError, MouseCursor, WindowAttributes};
 use dpi::{LogicalPosition, LogicalSize};
-use platform::MonitorId as PlatformMonitorId;
+use platform::{MonitorId as PlatformMonitorId, PlatformSpecificWindowBuilderAttributes as PlAttributes};
 use window::MonitorId as RootMonitorId;
 
 use sctk::window::{ConceptFrame, Event as WEvent, Window as SWindow};
@@ -28,7 +28,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn new(evlp: &EventsLoop, attributes: WindowAttributes) -> Result<Window, CreationError> {
+    pub fn new(evlp: &EventsLoop, attributes: WindowAttributes, pl_attribs: PlAttributes) -> Result<Window, CreationError> {
         let (width, height) = attributes.dimensions.map(Into::into).unwrap_or((800, 600));
         // Create the window
         let size = Arc::new(Mutex::new((width, height)));
@@ -105,6 +105,10 @@ impl Window {
                 }
             },
         ).unwrap();
+
+        if let Some(app_id) = pl_attribs.app_id {
+            frame.set_app_id(app_id);
+        }
 
         for &(_, ref seat) in evlp.seats.lock().unwrap().iter() {
             frame.new_seat(seat);


### PR DESCRIPTION
This was discussed some time ago, and allows applications to specify an application id that the wayland compositor will use to find the matching `.desktop` file.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
