### PR TITLE
On Windows, catch window callback panics and forward them to the calling thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- On Windows, catch panics in event loop child thread and forward them to the parent thread.
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
 - Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
 - Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.
-<<<<<<< HEAD
 - On Windows, catch panics in event loop child thread and forward them to the parent thread. This prevents an invocation of undefined behavior due to unwinding into foreign code.
-=======
 - On Windows, fix issue where resizing or moving window combined with grabbing the cursor would freeze program.
 - On Windows, fix issue where resizing or moving window would eat `Awakened` events.
->>>>>>> master
 
 # Version 0.18.0 (2018-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
-- On Windows, catch panics in event loop child thread and forward them to the parent thread.
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
 - Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.
+- On Windows, catch panics in event loop child thread and forward them to the parent thread.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
 - Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.
-- On Windows, catch panics in event loop child thread and forward them to the parent thread.
+- On Windows, catch panics in event loop child thread and forward them to the parent thread. This prevents an invocation of undefined behavior due to unwinding into foreign code.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ cocoa = "0.18.4"
 core-foundation = "0.6"
 core-graphics = "0.17.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+backtrace = "0.3"
+
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.6"
 features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ extern crate serde;
 
 #[cfg(target_os = "windows")]
 extern crate winapi;
+#[cfg(target_os = "windows")]
+extern crate backtrace;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[macro_use]
 extern crate objc;

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::os::windows::io::AsRawHandle;
 use std::sync::{Arc, Barrier, mpsc, Mutex};
 
+use backtrace::Backtrace;
 use winapi::ctypes::c_int;
 use winapi::shared::minwindef::{
     BOOL,
@@ -236,7 +237,7 @@ impl EventsLoop {
             let event = match self.receiver.try_recv() {
                 Ok(EventsLoopEvent::WinitEvent(e)) => e,
                 Ok(EventsLoopEvent::Panic(panic)) => {
-                    eprintln!("resume child thread unwind at {:?}", backtrace::Backtrace::new());
+                    eprintln!("resume child thread unwind at {:?}", Backtrace::new());
                     panic::resume_unwind(panic)
                 },
                 Err(_) => break
@@ -253,7 +254,7 @@ impl EventsLoop {
             let event = match self.receiver.recv() {
                 Ok(EventsLoopEvent::WinitEvent(e)) => e,
                 Ok(EventsLoopEvent::Panic(panic)) => {
-                    eprintln!("resume child thread unwind at {:?}", backtrace::Backtrace::new());
+                    eprintln!("resume child thread unwind at {:?}", Backtrace::new());
                     panic::resume_unwind(panic)
                 },
                 Err(_) => break


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [x] ~~Created an example program if it would help users understand this functionality~~

Fixes #699. 