### PR TITLE
X11: Check if `XRRGetOutputInfo` returned `NULL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, fixed panic caused by dropping the window before running the event loop.
+- On X11, fixed a segfault when using virtual monitors with XRandR.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -381,7 +381,7 @@ unsafe extern "C" fn x_error_callback(
             minor_code: (*event).minor_code,
         };
 
-        eprintln!("[winit X11 error] {:#?}", error);
+        error!("X11 error: {:#?}", error);
 
         *xconn.latest_error.lock() = Some(error);
     }


### PR DESCRIPTION
Fixes #693

This just skips any output that returns `NULL` when passed to `XRRGetOutputInfo`, which seems to sometimes be the case with virtual monitors.

This also changes the X11 error `eprintln!` to use `error!` from `log` instead.