### PR TITLE
Add ordering traits to VirtualKeyCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On Windows, fix issue where resizing or moving window combined with grabbing the cursor would freeze program.
 - On Windows, fix issue where resizing or moving window would eat `Awakened` events.
 - On X11, fixed a segfault when using virtual monitors with XRandR.
+- Derive `Ord` and `PartialOrd` for `VirtualKeyCode` enum.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -253,7 +253,7 @@ pub enum MouseScrollDelta {
 }
 
 /// Symbolic name for a keyboard key.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum VirtualKeyCode {


### PR DESCRIPTION
Motivation:
This allows VirtualKeyCode variants to be stored in a BTreeSet.
Unlike HashSets, BTreeSets implement Ord and Hash, allowing them to be
keys in a {Hash|BTree}Map. This is nice, e.g. when implementing
keyboard shortcuts functionality, which maps a set of pressed keys to
some action.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
