### PR TITLE
On Windows, fix window shrinking when leaving fullscreen in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Introduce `WindowBuilderExt::with_app_id` to allow setting the application ID on Wayland.
 - On Windows, fix issue where resizing or moving window combined with grabbing the cursor would freeze program.
 - On Windows, fix issue where resizing or moving window would eat `Awakened` events.
+- On Windows, exiting fullscreen after entering fullscreen with disabled decorations no longer shrinks window.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut decorations = true;
 
     events_loop.run_forever(|event| {
-        println!("{:?}", event);
+        // println!("{:?}", event);
 
         match event {
             Event::WindowEvent { event, .. } => match event {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut decorations = true;
 
     events_loop.run_forever(|event| {
-        // println!("{:?}", event);
+        println!("{:?}", event);
 
         match event {
             Event::WindowEvent { event, .. } => match event {

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -70,7 +70,7 @@ pub struct SavedWindowInfo {
     /// Window ex-style
     pub ex_style: LONG,
     /// Window position and size
-    pub rect: RECT,
+    pub client_rect: RECT,
     // Since a window can be fullscreened to a different monitor, a DPI change can be triggered. This could result in
     // the window being automitcally resized to smaller/larger than it was supposed to be restored to, so we thus must
     // check if the post-fullscreen DPI matches the pre-fullscreen DPI.

--- a/src/platform/windows/util.rs
+++ b/src/platform/windows/util.rs
@@ -55,6 +55,19 @@ pub fn get_window_rect(hwnd: HWND) -> Option<RECT> {
     unsafe { status_map(|rect| winuser::GetWindowRect(hwnd, rect)) }
 }
 
+pub fn get_client_rect(hwnd: HWND) -> Option<RECT> {
+    unsafe { status_map(|rect| {
+        let mut top_left = mem::zeroed();
+        if 0 == winuser::ClientToScreen(hwnd, &mut top_left) {return 0;};
+        if 0 == winuser::GetClientRect(hwnd, rect) {return 0};
+        rect.left += top_left.x;
+        rect.top += top_left.y;
+        rect.right += top_left.x;
+        rect.bottom += top_left.y;
+        1
+    }) }
+}
+
 // This won't be needed anymore if we just add a derive to winapi.
 pub fn rect_eq(a: &RECT, b: &RECT) -> bool {
     let left_eq = a.left == b.left;

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -455,7 +455,7 @@ impl Window {
 
     unsafe fn set_fullscreen_style(&self, window_state: &mut WindowState) -> (LONG, LONG) {
         if window_state.fullscreen.is_none() || window_state.saved_window_info.is_none() {
-            let client_rect = util::get_client_rect(self.window.0).expect("`GetWindowRect` failed");
+            let client_rect = util::get_client_rect(self.window.0).expect("client rect retrieval failed");
             let dpi_factor = Some(window_state.dpi_factor);
             window_state.saved_window_info = Some(events_loop::SavedWindowInfo {
                 style: winuser::GetWindowLongW(self.window.0, winuser::GWL_STYLE),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Fixes #715. This seems to have been caused by the window style getting improperly set when leaving fullscreen mode.

The Windows fullscreen window restore code is a bit convoluted in general so I'd like to take some time to refactor and simplify that a bit, but this can be fixed without doing that.