### PR TITLE
Handle removed wl_outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On X11, fixed a segfault when using virtual monitors with XRandR.
 - Derive `Ord` and `PartialOrd` for `VirtualKeyCode` enum.
 - On Windows, fix issue where hovering or dropping a non file item would create a panic.
+- On Wayland, fix disappearing wl_outputs that do not notify surfaces using enter/leave.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - On X11, fixed a segfault when using virtual monitors with XRandR.
 - Derive `Ord` and `PartialOrd` for `VirtualKeyCode` enum.
 - On Windows, fix issue where hovering or dropping a non file item would create a panic.
-- On Wayland, fix disappearing wl_outputs that do not notify surfaces using enter/leave.
+- On Wayland, fix resizing and DPI calculation when a `wl_output` is removed without sending a `leave` event to the `wl_surface`, such as disconnecting a monitor from a laptop.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -123,6 +123,8 @@ impl EventsLoop {
             },
         };
 
+        let cb_store = store.clone();
+
         let env = Environment::from_display_with_cb(
             &display,
             &mut event_queue,
@@ -136,6 +138,8 @@ impl EventsLoop {
                     GlobalEvent::Removed { id, ref interface } => {
                         if interface == "wl_seat" {
                             seat_manager.remove_seat(id)
+                        } else if interface == "wl_output" {
+                            cb_store.lock().unwrap().remove_output(id);
                         }
                     },
                 }


### PR DESCRIPTION
I'm trying to use Alacritty on Wayland+Gnome in a mixed DPI environment. I run a laptop with a HiDPI screen attached to a regular DPI external screen. Being a laptop, I regularly disconnect the external screen, and Alacritty goes haywire when I switch between screens, as stated in https://github.com/jwilm/alacritty/issues/1801.

I traced this to the fact that Gnome does not send `wl_surface enter/leave` events to all surfaces when a `wl_output` is removed, only a `wl_output removed` is sent. The changes now listens for `wl_output removed` events, and handles them accordingly.

It's not the prettiest change, but there was no clean way to do this without a major refactoring.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
