### PR TITLE
X11: WindowBuilder min/max size accounts for DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Derive `Ord` and `PartialOrd` for `VirtualKeyCode` enum.
 - On Windows, fix issue where hovering or dropping a non file item would create a panic.
 - On Wayland, fix resizing and DPI calculation when a `wl_output` is removed without sending a `leave` event to the `wl_surface`, such as disconnecting a monitor from a laptop.
+- On X11, `WindowBuilder::with_min_dimensions` and `WindowBuilder::with_max_dimensions` now correctly account for DPI.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -278,8 +278,10 @@ impl UnownedWindow {
 
             // set size hints
             {
-                let mut min_dimensions = window_attrs.min_dimensions;
-                let mut max_dimensions = window_attrs.max_dimensions;
+                let mut min_dimensions = window_attrs.min_dimensions
+                    .map(|size| size.to_physical(dpi_factor));
+                let mut max_dimensions = window_attrs.max_dimensions
+                    .map(|size| size.to_physical(dpi_factor));
                 if !window_attrs.resizable {
                     if util::wm_name_is_one_of(&["Xfwm4"]) {
                         warn!("To avoid a WM bug, disabling resizing has no effect on Xfwm4");


### PR DESCRIPTION
Fixes #722