### PR TITLE
Refactor win32 window state code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@
 - Removed minimum supported Rust version guarantee.
 - On Windows, fix malformed function pointer typecast that could invoke undefined behavior.
 - Refactored Windows state/flag-setting code.
-  - Hiding the cursor no longer hides the cursor for all Winit windows - just the one `hide_cursor` was called on.
-  - Beforehand, cursor grabs would get perpetually canceled when the grabbing window lost focus. Now, cursor grabs get automatically re-initialized when the window regains focus and the mouse moves over the client area.
+- On Windows, hiding the cursor no longer hides the cursor for all Winit windows - just the one `hide_cursor` was called on.
+- On Windows, cursor grabs used to get perpetually canceled when the grabbing window lost focus. Now, cursor grabs automatically get re-initialized when the window regains focus and the mouse moves over the client area.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - On macOS, implemented `WindowEvent::Refresh`.
 - On macOS, all `MouseCursor` variants are now implemented and the cursor will no longer reset after unfocusing.
 - Removed minimum supported Rust version guarantee.
+- On Windows, fix malformed function pointer typecast that could invoke undefined behavior.
+- Refactored Windows state/flag-setting code.
+  - Hiding the cursor no longer hides the cursor for all Winit windows - just the one `hide_cursor` was called on.
+  - Beforehand, cursor grabs would get perpetually canceled when the grabbing window lost focus. Now, cursor grabs get automatically re-initialized when the window regains focus and the mouse moves over the client area.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ core-graphics = "0.17.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 backtrace = "0.3"
+bitflags = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,9 @@ extern crate serde;
 extern crate winapi;
 #[cfg(target_os = "windows")]
 extern crate backtrace;
+#[macro_use]
+#[cfg(target_os = "windows")]
+extern crate bitflags;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[macro_use]
 extern crate objc;

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -637,7 +637,7 @@ unsafe fn callback_inner(
                         let mut w = w.lock().unwrap();
 
                         let was_outside_window = !w.mouse.cursor_flags().contains(CursorFlags::IN_WINDOW);
-                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, true));
+                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, true)).ok();
                         return was_outside_window;
                     }
                 }
@@ -680,7 +680,7 @@ unsafe fn callback_inner(
                 if let Some(context_stash) = context_stash.as_mut() {
                     if let Some(w) = context_stash.windows.get_mut(&window) {
                         let mut w = w.lock().unwrap();
-                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, false));
+                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, false)).ok();
                     }
                 }
             });

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -329,7 +329,8 @@ lazy_static! {
             winuser::RegisterWindowMessageA("Winit::InitialDpiMsg\0".as_ptr() as LPCSTR)
         }
     };
-    // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag.
+    // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag. See the
+    // documentation in the `window_state` module for more information.
     pub static ref SET_RETAIN_STATE_ON_SIZE_MSG_ID: u32 = unsafe {
         winuser::RegisterWindowMessageA("Winit::SetRetainMaximized\0".as_ptr() as LPCSTR)
     };
@@ -595,6 +596,7 @@ unsafe fn callback_inner(
                 if let Some(w) = cstash.windows.get_mut(&window) {
                     let mut w = w.lock().unwrap();
 
+                    // See WindowFlags::MARKER_RETAIN_STATE_ON_SIZE docs for info on why this `if` check exists.
                     if !w.window_flags().contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE) {
                         let maximized = wparam == winuser::SIZE_MAXIMIZED;
                         w.set_window_flags_in_place(|f| f.set(WindowFlags::MAXIMIZED, maximized));

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -51,7 +51,7 @@ use {
     WindowId as SuperWindowId,
 };
 use events::{DeviceEvent, Touch, TouchPhase};
-use platform::platform::{event, Cursor, WindowId, DEVICE_ID, wrap_device_id, util};
+use platform::platform::{event, WindowId, DEVICE_ID, wrap_device_id, util};
 use platform::platform::dpi::{
     become_dpi_aware,
     dpi_to_scale_factor,
@@ -60,64 +60,9 @@ use platform::platform::dpi::{
 };
 use platform::platform::drop_handler::FileDropHandler;
 use platform::platform::event::{handle_extended_keys, process_key_params, vkey_to_winit_vkey};
-use platform::platform::icon::WinIcon;
 use platform::platform::raw_input::{get_raw_input_data, get_raw_mouse_button_state};
 use platform::platform::window::adjust_size;
-
-/// Contains saved window info for switching between fullscreen
-#[derive(Clone)]
-pub struct SavedWindowInfo {
-    /// Window style
-    pub style: LONG,
-    /// Window ex-style
-    pub ex_style: LONG,
-    /// Window position and size
-    pub client_rect: RECT,
-    // Since a window can be fullscreened to a different monitor, a DPI change can be triggered. This could result in
-    // the window being automitcally resized to smaller/larger than it was supposed to be restored to, so we thus must
-    // check if the post-fullscreen DPI matches the pre-fullscreen DPI.
-    pub is_fullscreen: bool,
-    pub dpi_factor: Option<f64>,
-}
-
-/// Contains information about states and the window that the callback is going to use.
-#[derive(Clone)]
-pub struct WindowState {
-    /// Cursor to set at the next `WM_SETCURSOR` event received.
-    pub cursor: Cursor,
-    pub cursor_grabbed: bool,
-    pub cursor_hidden: bool,
-    /// Used by `WM_GETMINMAXINFO`.
-    pub max_size: Option<PhysicalSize>,
-    pub min_size: Option<PhysicalSize>,
-    /// Will contain `true` if the mouse is hovering the window.
-    pub mouse_in_window: bool,
-    /// Saved window info for fullscreen restored
-    pub saved_window_info: Option<SavedWindowInfo>,
-    // This is different from the value in `SavedWindowInfo`! That one represents the DPI saved upon entering
-    // fullscreen. This will always be the most recent DPI for the window.
-    pub dpi_factor: f64,
-    pub fullscreen: Option<::MonitorId>,
-    pub window_icon: Option<WinIcon>,
-    pub taskbar_icon: Option<WinIcon>,
-    pub decorations: bool,
-    pub always_on_top: bool,
-    pub maximized: bool,
-    pub resizable: bool,
-}
-
-impl WindowState {
-    pub fn update_min_max(&mut self, old_dpi_factor: f64, new_dpi_factor: f64) {
-        let scale_factor = new_dpi_factor / old_dpi_factor;
-        let dpi_adjuster = |mut physical_size: PhysicalSize| -> PhysicalSize {
-            physical_size.width *= scale_factor;
-            physical_size.height *= scale_factor;
-            physical_size
-        };
-        self.max_size = self.max_size.map(&dpi_adjuster);
-        self.min_size = self.min_size.map(&dpi_adjuster);
-    }
-}
+use platform::platform::window_state::{CursorFlags, WindowFlags, WindowState};
 
 /// Dummy object that allows inserting a window's state.
 // We store a pointer in order to !impl Send and Sync.
@@ -278,6 +223,7 @@ impl EventsLoop {
 
     pub fn create_proxy(&self) -> EventsLoopProxy {
         EventsLoopProxy {
+            thread_id: self.thread_id,
             thread_msg_target: self.thread_msg_target,
             sender: self.sender.clone(),
         }
@@ -308,6 +254,7 @@ impl Drop for EventsLoop {
 
 #[derive(Clone)]
 pub struct EventsLoopProxy {
+    thread_id: DWORD,
     thread_msg_target: HWND,
     sender: mpsc::Sender<EventsLoopEvent>,
 }
@@ -333,25 +280,31 @@ impl EventsLoopProxy {
     /// `WindowState` then you should call this within the lock of `WindowState`. Otherwise the
     /// events may be sent to the other thread in different order to the one in which you set
     /// `WindowState`, leaving them out of sync.
-    pub fn execute_in_thread<F>(&self, function: F)
+    pub fn execute_in_thread<F>(&self, mut function: F)
     where
         F: FnMut(Inserter) + Send + 'static,
     {
-        // We are using double-boxing here because it make casting back much easier
-        let double_box = Box::new(Box::new(function) as Box<FnMut(_)>);
-        let raw = Box::into_raw(double_box);
+        if unsafe{ processthreadsapi::GetCurrentThreadId() } == self.thread_id {
+            function(Inserter(ptr::null_mut()));
+        } else {
+            // We are using double-boxing here because it make casting back much easier
+            let double_box: ThreadExecFn = Box::new(Box::new(function) as Box<FnMut(_)>);
+            let raw = Box::into_raw(double_box);
 
-        let res = unsafe {
-            winuser::PostMessageW(
-                self.thread_msg_target,
-                *EXEC_MSG_ID,
-                raw as *mut () as usize as WPARAM,
-                0,
-            )
-        };
-        assert!(res != 0, "PostMessage failed; is the messages queue full?");
+            let res = unsafe {
+                winuser::PostMessageW(
+                    self.thread_msg_target,
+                    *EXEC_MSG_ID,
+                    raw as *mut () as usize as WPARAM,
+                    0,
+                )
+            };
+            assert!(res != 0, "PostMessage failed; is the messages queue full?");
+        }
     }
 }
+
+type ThreadExecFn = Box<Box<FnMut(Inserter)>>;
 
 lazy_static! {
     // Message sent when we want to execute a closure in the thread.
@@ -375,6 +328,10 @@ lazy_static! {
         unsafe {
             winuser::RegisterWindowMessageA("Winit::InitialDpiMsg\0".as_ptr() as LPCSTR)
         }
+    };
+    // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag.
+    pub static ref SET_RETAIN_STATE_ON_SIZE_MSG_ID: u32 = unsafe {
+        winuser::RegisterWindowMessageA("Winit::SetRetainMaximized\0".as_ptr() as LPCSTR)
     };
     static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> = unsafe {
         use std::ffi::OsStr;
@@ -622,18 +579,27 @@ unsafe fn callback_inner(
             let w = LOWORD(lparam as DWORD) as u32;
             let h = HIWORD(lparam as DWORD) as u32;
 
+            let dpi_factor = get_hwnd_scale_factor(window);
+            let logical_size = LogicalSize::from_physical((w, h), dpi_factor);
+            let event = Event::WindowEvent {
+                window_id: SuperWindowId(WindowId(window)),
+                event: Resized(logical_size),
+            };
+
             // Wait for the parent thread to process the resize event before returning from the
             // callback.
             CONTEXT_STASH.with(|context_stash| {
                 let mut context_stash = context_stash.borrow_mut();
                 let cstash = context_stash.as_mut().unwrap();
 
-                let dpi_factor = get_hwnd_scale_factor(window);
-                let logical_size = LogicalSize::from_physical((w, h), dpi_factor);
-                let event = Event::WindowEvent {
-                    window_id: SuperWindowId(WindowId(window)),
-                    event: Resized(logical_size),
-                };
+                if let Some(w) = cstash.windows.get_mut(&window) {
+                    let mut w = w.lock().unwrap();
+
+                    if !w.window_flags().contains(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE) {
+                        let maximized = wparam == winuser::SIZE_MAXIMIZED;
+                        w.set_window_flags_in_place(|f| f.set(WindowFlags::MAXIMIZED, maximized));
+                    }
+                }
 
                 cstash.sender.send(EventsLoopEvent::WinitEvent(event)).ok();
             });
@@ -661,22 +627,26 @@ unsafe fn callback_inner(
 
         winuser::WM_MOUSEMOVE => {
             use events::WindowEvent::{CursorEntered, CursorMoved};
-            let mouse_outside_window = CONTEXT_STASH.with(|context_stash| {
+            let x = windowsx::GET_X_LPARAM(lparam);
+            let y = windowsx::GET_Y_LPARAM(lparam);
+
+            let mouse_was_outside_window = CONTEXT_STASH.with(|context_stash| {
                 let mut context_stash = context_stash.borrow_mut();
                 if let Some(context_stash) = context_stash.as_mut() {
                     if let Some(w) = context_stash.windows.get_mut(&window) {
                         let mut w = w.lock().unwrap();
-                        if !w.mouse_in_window {
-                            w.mouse_in_window = true;
-                            return true;
-                        }
+
+                        let was_outside_window = !w.mouse.cursor_flags().contains(CursorFlags::IN_WINDOW);
+                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, true));
+                        return was_outside_window;
                     }
                 }
 
                 false
             });
 
-            if mouse_outside_window {
+
+            if mouse_was_outside_window {
                 send_event(Event::WindowEvent {
                     window_id: SuperWindowId(WindowId(window)),
                     event: CursorEntered { device_id: DEVICE_ID },
@@ -691,10 +661,8 @@ unsafe fn callback_inner(
                 });
             }
 
-            let x = windowsx::GET_X_LPARAM(lparam) as f64;
-            let y = windowsx::GET_Y_LPARAM(lparam) as f64;
             let dpi_factor = get_hwnd_scale_factor(window);
-            let position = LogicalPosition::from_physical((x, y), dpi_factor);
+            let position = LogicalPosition::from_physical((x as f64, y as f64), dpi_factor);
 
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
@@ -706,27 +674,21 @@ unsafe fn callback_inner(
 
         winuser::WM_MOUSELEAVE => {
             use events::WindowEvent::CursorLeft;
-            let mouse_in_window = CONTEXT_STASH.with(|context_stash| {
+
+            CONTEXT_STASH.with(|context_stash| {
                 let mut context_stash = context_stash.borrow_mut();
                 if let Some(context_stash) = context_stash.as_mut() {
                     if let Some(w) = context_stash.windows.get_mut(&window) {
                         let mut w = w.lock().unwrap();
-                        if w.mouse_in_window {
-                            w.mouse_in_window = false;
-                            return true;
-                        }
+                        w.mouse.set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, false));
                     }
                 }
-
-                false
             });
 
-            if mouse_in_window {
-                send_event(Event::WindowEvent {
-                    window_id: SuperWindowId(WindowId(window)),
-                    event: CursorLeft { device_id: DEVICE_ID }
-                });
-            }
+            send_event(Event::WindowEvent {
+                window_id: SuperWindowId(WindowId(window)),
+                event: CursorLeft { device_id: DEVICE_ID }
+            });
 
             0
         },
@@ -1101,31 +1063,31 @@ unsafe fn callback_inner(
         },
 
         winuser::WM_SETCURSOR => {
-            let call_def_window_proc = CONTEXT_STASH.with(|context_stash| {
+            let set_cursor_to = CONTEXT_STASH.with(|context_stash| {
                 context_stash
                     .borrow()
                     .as_ref()
                     .and_then(|cstash| cstash.windows.get(&window))
-                    .map(|window_state_mutex| {
+                    .and_then(|window_state_mutex| {
                         let window_state = window_state_mutex.lock().unwrap();
-                        if window_state.mouse_in_window {
-                            let cursor = winuser::LoadCursorW(
-                                ptr::null_mut(),
-                                window_state.cursor.0,
-                            );
-                            winuser::SetCursor(cursor);
-                            false
+                        if window_state.mouse.cursor_flags().contains(CursorFlags::IN_WINDOW) {
+                            Some(window_state.mouse.cursor)
                         } else {
-                            true
+                            None
                         }
                     })
-                    .unwrap_or(true)
             });
 
-            if call_def_window_proc {
-                winuser::DefWindowProcW(window, msg, wparam, lparam)
-            } else {
-                0
+            match set_cursor_to {
+                Some(cursor) => {
+                    let cursor = winuser::LoadCursorW(
+                        ptr::null_mut(),
+                        cursor.to_windows_cursor(),
+                    );
+                    winuser::SetCursor(cursor);
+                    0
+                },
+                None => winuser::DefWindowProcW(window, msg, wparam, lparam)
             }
         },
 
@@ -1148,10 +1110,12 @@ unsafe fn callback_inner(
                             let style = winuser::GetWindowLongA(window, winuser::GWL_STYLE) as DWORD;
                             let ex_style = winuser::GetWindowLongA(window, winuser::GWL_EXSTYLE) as DWORD;
                             if let Some(min_size) = window_state.min_size {
+                                let min_size = min_size.to_physical(window_state.dpi_factor);
                                 let (width, height) = adjust_size(min_size, style, ex_style);
                                 (*mmi).ptMinTrackSize = POINT { x: width as i32, y: height as i32 };
                             }
                             if let Some(max_size) = window_state.max_size {
+                                let max_size = max_size.to_physical(window_state.dpi_factor);
                                 let (width, height) = adjust_size(max_size, style, ex_style);
                                 (*mmi).ptMaxTrackSize = POINT { x: width as i32, y: height as i32 };
                             }
@@ -1175,38 +1139,21 @@ unsafe fn callback_inner(
             let new_dpi_x = u32::from(LOWORD(wparam as DWORD));
             let new_dpi_factor = dpi_to_scale_factor(new_dpi_x);
 
-            let suppress_resize = CONTEXT_STASH.with(|context_stash| {
-                context_stash
-                    .borrow()
-                    .as_ref()
-                    .and_then(|cstash| cstash.windows.get(&window))
-                    .map(|window_state_mutex| {
-                        let mut window_state = window_state_mutex.lock().unwrap();
-                        let suppress_resize = window_state.saved_window_info
-                            .as_mut()
-                            .map(|saved_window_info| {
-                                let dpi_changed = if !saved_window_info.is_fullscreen {
-                                    saved_window_info.dpi_factor.take() != Some(new_dpi_factor)
-                                } else {
-                                    false
-                                };
-                                !dpi_changed || saved_window_info.is_fullscreen
-                            })
-                            .unwrap_or(false);
-                        // Now we adjust the min/max dimensions for the new DPI.
-                        if !suppress_resize {
-                            let old_dpi_factor = window_state.dpi_factor;
-                            window_state.update_min_max(old_dpi_factor, new_dpi_factor);
-                        }
-                        window_state.dpi_factor = new_dpi_factor;
-                        suppress_resize
-                    })
-                    .unwrap_or(false)
+            let allow_resize = CONTEXT_STASH.with(|context_stash| {
+                if let Some(wstash) = context_stash.borrow().as_ref().and_then(|cstash| cstash.windows.get(&window)) {
+                    let mut window_state = wstash.lock().unwrap();
+                    let old_dpi_factor = window_state.dpi_factor;
+                    window_state.dpi_factor = new_dpi_factor;
+
+                    new_dpi_factor != old_dpi_factor && window_state.fullscreen.is_none()
+                } else {
+                    true
+                }
             });
 
             // This prevents us from re-applying DPI adjustment to the restored size after exiting
             // fullscreen (the restored size is already DPI adjusted).
-            if !suppress_resize {
+            if allow_resize {
                 // Resize window to the size suggested by Windows.
                 let rect = &*(lparam as *const RECT);
                 winuser::SetWindowPos(
@@ -1272,6 +1219,16 @@ unsafe fn callback_inner(
                     | winuser::SWP_NOACTIVATE,
                 );
                 0
+            } else if msg == *SET_RETAIN_STATE_ON_SIZE_MSG_ID {
+                CONTEXT_STASH.with(|context_stash| {
+                    if let Some(cstash) = context_stash.borrow().as_ref() {
+                        if let Some(wstash) = cstash.windows.get(&window) {
+                            let mut window_state = wstash.lock().unwrap();
+                            window_state.set_window_flags_in_place(|f| f.set(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE, wparam != 0));
+                        }
+                    }
+                });
+                0
             } else {
                 winuser::DefWindowProcW(window, msg, wparam, lparam)
             }
@@ -1289,8 +1246,8 @@ pub unsafe extern "system" fn thread_event_target_callback(
     run_catch_panic(-1, || {
         match msg {
             _ if msg == *EXEC_MSG_ID => {
-                let mut function: Box<Box<FnMut()>> = Box::from_raw(wparam as usize as *mut _);
-                function();
+                let mut function: ThreadExecFn = Box::from_raw(wparam as usize as *mut _);
+                function(Inserter(ptr::null_mut()));
                 0
             },
             _ => winuser::DefWindowProcW(window, msg, wparam, lparam)

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -71,3 +71,4 @@ mod monitor;
 mod raw_input;
 mod util;
 mod window;
+mod window_state;

--- a/src/platform/windows/monitor.rs
+++ b/src/platform/windows/monitor.rs
@@ -99,7 +99,7 @@ impl Window {
     }
 }
 
-fn get_monitor_info(hmonitor: HMONITOR) -> Result<winuser::MONITORINFOEXW, util::WinError> {
+pub(crate) fn get_monitor_info(hmonitor: HMONITOR) -> Result<winuser::MONITORINFOEXW, util::WinError> {
     let mut monitor_info: winuser::MONITORINFOEXW = unsafe { mem::uninitialized() };
     monitor_info.cbSize = mem::size_of::<winuser::MONITORINFOEXW>() as DWORD;
     let status = unsafe {

--- a/src/platform/windows/util.rs
+++ b/src/platform/windows/util.rs
@@ -71,7 +71,7 @@ pub fn get_client_rect(hwnd: HWND) -> Result<RECT, io::Error> {
         let mut top_left = mem::zeroed();
 
         win_to_err(|| winuser::ClientToScreen(hwnd, &mut top_left))?;
-        win_to_err(|| winuser::GetClientRect(hwnd, &mut rect));
+        win_to_err(|| winuser::GetClientRect(hwnd, &mut rect))?;
         rect.left += top_left.x;
         rect.top += top_left.y;
         rect.right += top_left.x;
@@ -111,20 +111,6 @@ pub fn set_cursor_clip(rect: Option<RECT>) -> Result<(), io::Error> {
         let rect_ptr = rect.as_ref().map(|r| r as *const RECT).unwrap_or(ptr::null());
         win_to_err(|| winuser::ClipCursor(rect_ptr))
     }
-}
-
-// This won't be needed anymore if we just add a derive to winapi.
-pub fn rect_eq(a: &RECT, b: &RECT) -> bool {
-    let left_eq = a.left == b.left;
-    let right_eq = a.right == b.right;
-    let top_eq = a.top == b.top;
-    let bottom_eq = a.bottom == b.bottom;
-    left_eq && right_eq && top_eq && bottom_eq
-}
-
-pub fn rect_contains(r: RECT, point: POINT) -> bool {
-    r.left <= point.x && point.x <= r.right &&
-    r.top <= point.y && point.y <= r.bottom
 }
 
 pub fn is_focused(window: HWND) -> bool {

--- a/src/platform/windows/util.rs
+++ b/src/platform/windows/util.rs
@@ -157,7 +157,7 @@ pub unsafe fn get_last_error() -> Option<String> {
 }
 
 impl MouseCursor {
-    pub(crate) fn to_windows_cursor(self) -> *const winapi::ctypes::wchar_t {
+    pub(crate) fn to_windows_cursor(self) -> *const wchar_t {
         match self {
             MouseCursor::Arrow | MouseCursor::Default => winuser::IDC_ARROW,
             MouseCursor::Hand => winuser::IDC_HAND,

--- a/src/platform/windows/util.rs
+++ b/src/platform/windows/util.rs
@@ -1,6 +1,8 @@
-use std::{self, mem, ptr, slice};
+use std::{self, mem, ptr, slice, io};
 use std::ops::BitAnd;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+use MouseCursor;
 use winapi::ctypes::wchar_t;
 use winapi::shared::minwindef::{BOOL, DWORD};
 use winapi::shared::windef::{HWND, POINT, RECT};
@@ -47,6 +49,14 @@ pub unsafe fn status_map<T, F: FnMut(&mut T) -> BOOL>(mut fun: F) -> Option<T> {
     }
 }
 
+fn win_to_err<F: FnOnce() -> BOOL>(f: F) -> Result<(), io::Error> {
+    if f() != 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
 pub fn get_cursor_pos() -> Option<POINT> {
     unsafe { status_map(|cursor_pos| winuser::GetCursorPos(cursor_pos)) }
 }
@@ -55,17 +65,52 @@ pub fn get_window_rect(hwnd: HWND) -> Option<RECT> {
     unsafe { status_map(|rect| winuser::GetWindowRect(hwnd, rect)) }
 }
 
-pub fn get_client_rect(hwnd: HWND) -> Option<RECT> {
-    unsafe { status_map(|rect| {
+pub fn get_client_rect(hwnd: HWND) -> Result<RECT, io::Error> {
+    unsafe {
+        let mut rect = mem::uninitialized();
         let mut top_left = mem::zeroed();
-        if 0 == winuser::ClientToScreen(hwnd, &mut top_left) {return 0;};
-        if 0 == winuser::GetClientRect(hwnd, rect) {return 0};
+
+        win_to_err(|| winuser::ClientToScreen(hwnd, &mut top_left))?;
+        win_to_err(|| winuser::GetClientRect(hwnd, &mut rect));
         rect.left += top_left.x;
         rect.top += top_left.y;
         rect.right += top_left.x;
         rect.bottom += top_left.y;
-        1
+
+        Ok(rect)
+    }
+}
+
+pub fn adjust_window_rect(hwnd: HWND, rect: RECT) -> Option<RECT> {
+    unsafe {
+        let style = winuser::GetWindowLongW(hwnd, winuser::GWL_STYLE);
+        let style_ex = winuser::GetWindowLongW(hwnd, winuser::GWL_EXSTYLE);
+        adjust_window_rect_with_styles(hwnd, style as _, style_ex as _, rect)
+    }
+}
+
+pub fn adjust_window_rect_with_styles(hwnd: HWND, style: DWORD, style_ex: DWORD, rect: RECT) -> Option<RECT> {
+    unsafe { status_map(|r| {
+        *r = rect;
+
+        let b_menu = !winuser::GetMenu(hwnd).is_null() as BOOL;
+        winuser::AdjustWindowRectEx(r, style as _ , b_menu, style_ex as _)
     }) }
+}
+
+pub fn set_cursor_hidden(hidden: bool) {
+    static HIDDEN: AtomicBool = AtomicBool::new(false);
+    let changed = HIDDEN.swap(hidden, Ordering::SeqCst) ^ hidden;
+    if changed {
+        unsafe{ winuser::ShowCursor(!hidden as BOOL) };
+    }
+}
+
+pub fn set_cursor_clip(rect: Option<RECT>) -> Result<(), io::Error> {
+    unsafe {
+        let rect_ptr = rect.as_ref().map(|r| r as *const RECT).unwrap_or(ptr::null());
+        win_to_err(|| winuser::ClipCursor(rect_ptr))
+    }
 }
 
 // This won't be needed anymore if we just add a derive to winapi.
@@ -75,6 +120,15 @@ pub fn rect_eq(a: &RECT, b: &RECT) -> bool {
     let top_eq = a.top == b.top;
     let bottom_eq = a.bottom == b.bottom;
     left_eq && right_eq && top_eq && bottom_eq
+}
+
+pub fn rect_contains(r: RECT, point: POINT) -> bool {
+    r.left <= point.x && point.x <= r.right &&
+    r.top <= point.y && point.y <= r.bottom
+}
+
+pub fn is_focused(window: HWND) -> bool {
+    window == unsafe{ winuser::GetActiveWindow() }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -114,4 +168,30 @@ pub unsafe fn get_last_error() -> Option<String> {
         }
     }
     None
+}
+
+impl MouseCursor {
+    pub(crate) fn to_windows_cursor(self) -> *const winapi::ctypes::wchar_t {
+        match self {
+            MouseCursor::Arrow | MouseCursor::Default => winuser::IDC_ARROW,
+            MouseCursor::Hand => winuser::IDC_HAND,
+            MouseCursor::Crosshair => winuser::IDC_CROSS,
+            MouseCursor::Text | MouseCursor::VerticalText => winuser::IDC_IBEAM,
+            MouseCursor::NotAllowed | MouseCursor::NoDrop => winuser::IDC_NO,
+            MouseCursor::Grab | MouseCursor::Grabbing |
+            MouseCursor::Move | MouseCursor::AllScroll => winuser::IDC_SIZEALL,
+            MouseCursor::EResize | MouseCursor::WResize |
+            MouseCursor::EwResize | MouseCursor::ColResize => winuser::IDC_SIZEWE,
+            MouseCursor::NResize | MouseCursor::SResize |
+            MouseCursor::NsResize | MouseCursor::RowResize => winuser::IDC_SIZENS,
+            MouseCursor::NeResize | MouseCursor::SwResize |
+            MouseCursor::NeswResize => winuser::IDC_SIZENESW,
+            MouseCursor::NwResize | MouseCursor::SeResize |
+            MouseCursor::NwseResize => winuser::IDC_SIZENWSE,
+            MouseCursor::Wait => winuser::IDC_WAIT,
+            MouseCursor::Progress => winuser::IDC_APPSTARTING,
+            MouseCursor::Help => winuser::IDC_HELP,
+            _ => winuser::IDC_ARROW, // use arrow for the missing cases.
+        }
+    }
 }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -35,8 +35,6 @@ use platform::platform::raw_input::register_all_mice_and_keyboards_for_raw_input
 use platform::platform::util;
 use platform::platform::window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState};
 
-const WS_RESIZABLE: DWORD = winuser::WS_SIZEBOX | winuser::WS_MAXIMIZEBOX;
-
 /// The Win32 implementation of the main `Window` object.
 pub struct Window {
     /// Main handle for the window.
@@ -309,7 +307,7 @@ impl Window {
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);
         });
-        rx.recv().unwrap();
+        rx.recv().unwrap().ok();
     }
 
     #[inline]
@@ -399,8 +397,6 @@ impl Window {
                         window_state_lock.fullscreen = None;
 
                         if let Some(SavedWindow{client_rect, dpi_factor}) = window_state_lock.saved_window {
-                            let rect = util::adjust_window_rect(window.0, client_rect).expect("adjust client rect failed!");
-
                             window_state_lock.dpi_factor = dpi_factor;
                             window_state_lock.saved_window = None;
 
@@ -597,7 +593,6 @@ unsafe fn init(
     info!("Guessed window DPI factor: {}", guessed_dpi_factor);
 
     let dimensions = attributes.dimensions.unwrap_or_else(|| (1024, 768).into());
-    let (width, height): (u32, u32) = dimensions.to_physical(guessed_dpi_factor).into();
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::DECORATIONS, attributes.decorations);

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -599,10 +599,9 @@ unsafe fn init(
     window_flags.set(WindowFlags::ALWAYS_ON_TOP, attributes.always_on_top);
     window_flags.set(WindowFlags::NO_BACK_BUFFER, pl_attribs.no_redirection_bitmap);
     window_flags.set(WindowFlags::TRANSPARENT, attributes.transparent);
-    // WindowFlags::VISIBLE is set down below after the window has been configured.
+    // WindowFlags::VISIBLE and MAXIMIZED are set down below after the window has been configured.
     window_flags.set(WindowFlags::RESIZABLE, attributes.resizable);
     window_flags.set(WindowFlags::CHILD, pl_attribs.parent.is_some());
-    window_flags.set(WindowFlags::MAXIMIZED, attributes.maximized);
     window_flags.set(WindowFlags::ON_TASKBAR, true);
 
     // creating the real window this time, by using the functions in `extra_functions`
@@ -688,6 +687,7 @@ unsafe fn init(
     }
 
     window_flags.set(WindowFlags::VISIBLE, attributes.visible);
+    window_flags.set(WindowFlags::MAXIMIZED, attributes.maximized);
 
     let window_state = {
         let mut window_state = WindowState::new(

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -1,0 +1,336 @@
+use {MouseCursor, WindowAttributes};
+use std::{io, ptr};
+use std::sync::MutexGuard;
+use dpi::LogicalSize;
+use platform::platform::{util, events_loop};
+use platform::platform::icon::WinIcon;
+use winapi::shared::windef::{RECT, HWND};
+use winapi::shared::minwindef::DWORD;
+use winapi::um::winuser;
+
+/// Contains information about states and the window that the callback is going to use.
+#[derive(Clone)]
+pub struct WindowState {
+    pub mouse: MouseProperties,
+
+    /// Used by `WM_GETMINMAXINFO`.
+    pub min_size: Option<LogicalSize>,
+    pub max_size: Option<LogicalSize>,
+
+    pub window_icon: Option<WinIcon>,
+    pub taskbar_icon: Option<WinIcon>,
+
+    pub saved_window: Option<SavedWindow>,
+    pub dpi_factor: f64,
+
+    pub fullscreen: Option<::MonitorId>,
+    window_flags: WindowFlags,
+}
+
+#[derive(Clone)]
+pub struct SavedWindow {
+    pub client_rect: RECT,
+    pub dpi_factor: f64,
+}
+
+#[derive(Clone)]
+pub struct MouseProperties {
+    pub cursor: MouseCursor,
+    cursor_flags: CursorFlags,
+}
+
+bitflags! {
+    pub struct CursorFlags: u8 {
+        const GRABBED   = 1 << 0;
+        const HIDDEN    = 1 << 1;
+        const IN_WINDOW = 1 << 2;
+    }
+}
+bitflags! {
+    pub struct WindowFlags: u32 {
+        const RESIZABLE      = 1 << 0;
+        const DECORATIONS    = 1 << 1;
+        const VISIBLE        = 1 << 2;
+        const ON_TASKBAR     = 1 << 3;
+        const ALWAYS_ON_TOP  = 1 << 4;
+        const NO_BACK_BUFFER = 1 << 5;
+        const TRANSPARENT    = 1 << 6;
+        const CHILD          = 1 << 7;
+        const MAXIMIZED      = 1 << 8;
+
+        /// Marker flag for fullscreen. Should always match `WindowState::fullscreen`, but is
+        /// included here to make masking easier.
+        const MARKER_FULLSCREEN = 1 << 9;
+
+        /// The `WM_SIZE` event contains some parameters that can effect the state of `WindowFlags`.
+        /// In most cases, it's okay to let those parameters change the state. However, when we're
+        /// running the `WindowFlags::apply_diff` function, we *don't* want those parameters to
+        /// effect our stored state, because the purpose of `apply_diff` is to update the actual
+        /// window's state to match our stored state. This controls whether to accept those changes.
+        const MARKER_RETAIN_STATE_ON_SIZE = 1 << 10;
+
+        const FULLSCREEN_AND_MASK = !(
+            WindowFlags::DECORATIONS.bits |
+            WindowFlags::RESIZABLE.bits |
+            WindowFlags::MAXIMIZED.bits
+        );
+        const NO_DECORATIONS_AND_MASK = !WindowFlags::RESIZABLE.bits;
+        const INVISIBLE_AND_MASK = !WindowFlags::MAXIMIZED.bits;
+    }
+}
+
+impl WindowState {
+    pub fn new(
+        attributes: &WindowAttributes,
+        window_icon: Option<WinIcon>,
+        taskbar_icon: Option<WinIcon>,
+        dpi_factor: f64
+    ) -> WindowState {
+        WindowState {
+            mouse: MouseProperties {
+                cursor: MouseCursor::default(),
+                cursor_flags: CursorFlags::empty(),
+            },
+
+            min_size: attributes.min_dimensions,
+            max_size: attributes.max_dimensions,
+
+            window_icon,
+            taskbar_icon,
+
+            saved_window: None,
+            dpi_factor,
+
+            fullscreen: None,
+            window_flags: WindowFlags::empty()
+        }
+    }
+
+    pub fn window_flags(&self) -> WindowFlags {
+        self.window_flags
+    }
+
+    pub fn set_window_flags<F>(mut this: MutexGuard<Self>, window: HWND, set_client_rect: Option<RECT>, f: F)
+        where F: FnOnce(&mut WindowFlags)
+    {
+        let old_flags = this.window_flags;
+        f(&mut this.window_flags);
+
+        let is_fullscreen = this.fullscreen.is_some();
+        this.window_flags.set(WindowFlags::MARKER_FULLSCREEN, is_fullscreen);
+        let new_flags = this.window_flags;
+
+        drop(this);
+        old_flags.apply_diff(window, new_flags, set_client_rect);
+    }
+
+    pub fn refresh_window_state(this: MutexGuard<Self>, window: HWND, set_client_rect: Option<RECT>) {
+        Self::set_window_flags(this, window, set_client_rect, |_| ());
+    }
+
+    pub fn set_window_flags_in_place<F>(&mut self, f: F)
+        where F: FnOnce(&mut WindowFlags)
+    {
+        f(&mut self.window_flags);
+    }
+}
+
+impl MouseProperties {
+    pub fn cursor_flags(&self) -> CursorFlags {
+        self.cursor_flags
+    }
+
+    pub fn set_cursor_flags<F>(&mut self, window: HWND, f: F) -> Result<(), io::Error>
+        where F: FnOnce(&mut CursorFlags)
+    {
+        let old_flags = self.cursor_flags;
+        f(&mut self.cursor_flags);
+        match self.cursor_flags.refresh_os_cursor(window) {
+            Ok(()) => (),
+            Err(e) => {
+                self.cursor_flags = old_flags;
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn refresh_os_cursor(&self, window: HWND) -> Result<(), io::Error> {
+        self.cursor_flags.refresh_os_cursor(window)?;
+        Ok(())
+    }
+}
+
+impl WindowFlags {
+    fn mask(mut self) -> WindowFlags {
+        if self.contains(WindowFlags::MARKER_FULLSCREEN) {
+            self &= WindowFlags::FULLSCREEN_AND_MASK;
+        }
+        if !self.contains(WindowFlags::VISIBLE) {
+            self &= WindowFlags::INVISIBLE_AND_MASK;
+        }
+        if !self.contains(WindowFlags::DECORATIONS) {
+            self &= WindowFlags::NO_DECORATIONS_AND_MASK;
+        }
+        self
+    }
+
+    pub fn to_window_styles(self) -> (DWORD, DWORD) {
+        use winapi::um::winuser::*;
+
+        let (mut style, mut style_ex) = (0, 0);
+
+        if self.contains(WindowFlags::RESIZABLE) {
+            style |= winuser::WS_SIZEBOX | winuser::WS_MAXIMIZEBOX;
+        }
+        if self.contains(WindowFlags::DECORATIONS) {
+            style |= WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER;
+            style_ex = WS_EX_WINDOWEDGE;
+        }
+        if self.contains(WindowFlags::VISIBLE) {
+            style |= WS_VISIBLE;
+        }
+        if self.contains(WindowFlags::ON_TASKBAR) {
+            style_ex |= WS_EX_APPWINDOW;
+        } else {
+            style |= WS_POPUP;
+        }
+        if self.contains(WindowFlags::ALWAYS_ON_TOP) {
+            style_ex |= WS_EX_TOPMOST;
+        }
+        if self.contains(WindowFlags::NO_BACK_BUFFER) {
+            style_ex |= WS_EX_NOREDIRECTIONBITMAP;
+        }
+        if self.contains(WindowFlags::TRANSPARENT) {
+            // Is this necessary? The docs say that WS_EX_LAYERED requires a windows class without
+            // CS_OWNDC, and Winit windows have that flag set.
+            style_ex |= WS_EX_LAYERED;
+        }
+        if self.contains(WindowFlags::CHILD) {
+            style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
+        }
+        if self.contains(WindowFlags::MAXIMIZED) {
+            style |= WS_MAXIMIZE;
+        }
+
+        style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
+        style_ex |= WS_EX_ACCEPTFILES;
+
+        (style, style_ex)
+    }
+
+    /// Adjust the window client rectangle to the return value, if present.
+    fn apply_diff(mut self, window: HWND, mut new: WindowFlags, set_client_rect: Option<RECT>) {
+        self = self.mask();
+        new = new.mask();
+
+        let diff = self ^ new;
+        if diff == WindowFlags::empty() {
+            return;
+        }
+
+        if diff.contains(WindowFlags::VISIBLE) {
+            unsafe {
+                winuser::ShowWindow(
+                    window,
+                    match new.contains(WindowFlags::VISIBLE) {
+                        true => winuser::SW_SHOW,
+                        false => winuser::SW_HIDE
+                    }
+                );
+            }
+        }
+        if diff.contains(WindowFlags::ALWAYS_ON_TOP) {
+            unsafe {
+                winuser::SetWindowPos(
+                    window,
+                    match new.contains(WindowFlags::ALWAYS_ON_TOP) {
+                        true  => winuser::HWND_TOPMOST,
+                        false => winuser::HWND_NOTOPMOST,
+                    },
+                    0, 0, 0, 0,
+                    winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOMOVE | winuser::SWP_NOSIZE,
+                );
+                winuser::UpdateWindow(window);
+            }
+        }
+
+        if diff != WindowFlags::empty() {
+            let (style, style_ex) = new.to_window_styles();
+
+            unsafe {
+                winuser::SendMessageW(window, *events_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID, 1, 0);
+
+                winuser::SetWindowLongW(window, winuser::GWL_STYLE, style as _);
+                winuser::SetWindowLongW(window, winuser::GWL_EXSTYLE, style_ex as _);
+
+                match set_client_rect.and_then(|r| util::adjust_window_rect_with_styles(window, style, style_ex, r)) {
+                    Some(client_rect) => {
+                        let (x, y, w, h) = (
+                            client_rect.left,
+                            client_rect.top,
+                            client_rect.right - client_rect.left,
+                            client_rect.bottom - client_rect.top,
+                        );
+                        winuser::SetWindowPos(
+                            window,
+                            ptr::null_mut(),
+                            x, y, w, h,
+                            winuser::SWP_NOZORDER
+                            | winuser::SWP_FRAMECHANGED,
+                        );
+                    },
+                    None => {
+                        // Refresh the window frame.
+                        winuser::SetWindowPos(
+                            window,
+                            ptr::null_mut(),
+                            0, 0, 0, 0,
+                            winuser::SWP_NOZORDER
+                            | winuser::SWP_NOMOVE
+                            | winuser::SWP_NOSIZE
+                            | winuser::SWP_FRAMECHANGED,
+                        );
+                    }
+                }
+                winuser::SendMessageW(window, *events_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID, 0, 0);
+            }
+        }
+
+        if diff.contains(WindowFlags::MAXIMIZED) {
+            unsafe {
+                winuser::ShowWindow(
+                    window,
+                    match new.contains(WindowFlags::MAXIMIZED) {
+                        true => winuser::SW_MAXIMIZE,
+                        false => winuser::SW_RESTORE
+                    }
+                );
+            }
+        }
+    }
+}
+
+impl CursorFlags {
+    fn refresh_os_cursor(self, window: HWND) -> Result<(), io::Error> {
+        let client_rect = util::get_client_rect(window)?;
+
+        if util::is_focused(window) {
+            if self.contains(CursorFlags::GRABBED) {
+                util::set_cursor_clip(Some(client_rect))?;
+            } else {
+                util::set_cursor_clip(None);
+            }
+        }
+
+        let cursor_in_client = self.contains(CursorFlags::IN_WINDOW);
+        if cursor_in_client {
+            util::set_cursor_hidden(self.contains(CursorFlags::HIDDEN));
+        } else {
+            util::set_cursor_hidden(false);
+        }
+
+        Ok(())
+    }
+}

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -177,7 +177,7 @@ impl WindowFlags {
         let (mut style, mut style_ex) = (0, 0);
 
         if self.contains(WindowFlags::RESIZABLE) {
-            style |= winuser::WS_SIZEBOX | winuser::WS_MAXIMIZEBOX;
+            style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
         }
         if self.contains(WindowFlags::DECORATIONS) {
             style |= WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER;

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -203,9 +203,9 @@ impl WindowFlags {
         if self.contains(WindowFlags::CHILD) {
             style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
         }
-        if self.contains(WindowFlags::MAXIMIZED) {
-            style |= WS_MAXIMIZE;
-        }
+        // if self.contains(WindowFlags::MAXIMIZED) {
+        //     // This is handed with the call to ShowWindow in `apply_diff`.
+        // }
 
         style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
         style_ex |= WS_EX_ACCEPTFILES;
@@ -246,6 +246,12 @@ impl WindowFlags {
                     winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOMOVE | winuser::SWP_NOSIZE,
                 );
                 winuser::UpdateWindow(window);
+            }
+        }
+
+        if diff.contains(WindowFlags::MAXIMIZED) && !new.contains(WindowFlags::MAXIMIZED) {
+            unsafe {
+                winuser::ShowWindow(window, winuser::SW_RESTORE);
             }
         }
 
@@ -291,15 +297,9 @@ impl WindowFlags {
             }
         }
 
-        if diff.contains(WindowFlags::MAXIMIZED) {
+        if diff.contains(WindowFlags::MAXIMIZED) && new.contains(WindowFlags::MAXIMIZED) {
             unsafe {
-                winuser::ShowWindow(
-                    window,
-                    match new.contains(WindowFlags::MAXIMIZED) {
-                        true => winuser::SW_MAXIMIZE,
-                        false => winuser::SW_RESTORE
-                    }
-                );
+                winuser::ShowWindow(window, winuser::SW_MAXIMIZE);
             }
         }
     }

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -203,9 +203,9 @@ impl WindowFlags {
         if self.contains(WindowFlags::CHILD) {
             style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
         }
-        // if self.contains(WindowFlags::MAXIMIZED) {
-        //     // This is handed with the call to ShowWindow in `apply_diff`.
-        // }
+        if self.contains(WindowFlags::MAXIMIZED) {
+            style |= WS_MAXIMIZE;
+        }
 
         style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
         style_ex |= WS_EX_ACCEPTFILES;
@@ -249,9 +249,15 @@ impl WindowFlags {
             }
         }
 
-        if diff.contains(WindowFlags::MAXIMIZED) && !new.contains(WindowFlags::MAXIMIZED) {
+        if diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED) {
             unsafe {
-                winuser::ShowWindow(window, winuser::SW_RESTORE);
+                winuser::ShowWindow(
+                    window,
+                    match new.contains(WindowFlags::MAXIMIZED) {
+                        true => winuser::SW_MAXIMIZE,
+                        false => winuser::SW_RESTORE
+                    }
+                );
             }
         }
 
@@ -294,12 +300,6 @@ impl WindowFlags {
                     }
                 }
                 winuser::SendMessageW(window, *events_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID, 0, 0);
-            }
-        }
-
-        if diff.contains(WindowFlags::MAXIMIZED) && new.contains(WindowFlags::MAXIMIZED) {
-            unsafe {
-                winuser::ShowWindow(window, winuser::SW_MAXIMIZE);
             }
         }
     }

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -155,11 +155,6 @@ impl MouseProperties {
 
         Ok(())
     }
-
-    pub fn refresh_os_cursor(&self, window: HWND) -> Result<(), io::Error> {
-        self.cursor_flags.refresh_os_cursor(window)?;
-        Ok(())
-    }
 }
 
 impl WindowFlags {
@@ -320,7 +315,7 @@ impl CursorFlags {
             if self.contains(CursorFlags::GRABBED) {
                 util::set_cursor_clip(Some(client_rect))?;
             } else {
-                util::set_cursor_clip(None);
+                util::set_cursor_clip(None)?;
             }
         }
 

--- a/src/platform/windows/window_state.rs
+++ b/src/platform/windows/window_state.rs
@@ -188,8 +188,6 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::ON_TASKBAR) {
             style_ex |= WS_EX_APPWINDOW;
-        } else {
-            style |= WS_POPUP;
         }
         if self.contains(WindowFlags::ALWAYS_ON_TOP) {
             style_ex |= WS_EX_TOPMOST;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

This PR refactors the Windows state-setting code to make it significantly easier to read and modify going forward. It also fixes #723 and a few other miscellaneous untracked issues I found when doing the refactor.

### TODO:
- [x] Mask out `WS_CHILD` when `WS_POPUP` is enabled
- [x] Fix `set_maximized`
- [ ] Fix the unfixed window shrinking bug in #718