### PR TITLE
Add support for generating dummy DeviceIDs and WindowIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - On Wayland, fix resizing and DPI calculation when a `wl_output` is removed without sending a `leave` event to the `wl_surface`, such as disconnecting a monitor from a laptop.
 - On Wayland, DPI calculation is handled by smithay-client-toolkit.
 - On X11, `WindowBuilder::with_min_dimensions` and `WindowBuilder::with_max_dimensions` now correctly account for DPI.
-- Added support for generating dummy DeviceIds and WindowIds to better support unit testing.
+- Added support for generating dummy `DeviceId`s and `WindowId`s to better support unit testing.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - On Wayland, fix resizing and DPI calculation when a `wl_output` is removed without sending a `leave` event to the `wl_surface`, such as disconnecting a monitor from a laptop.
 - On Wayland, DPI calculation is handled by smithay-client-toolkit.
 - On X11, `WindowBuilder::with_min_dimensions` and `WindowBuilder::with_max_dimensions` now correctly account for DPI.
+- Added support for generating dummy DeviceIds and WindowIds to better support unit testing.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,9 @@ impl std::fmt::Debug for Window {
 pub struct WindowId(platform::WindowId);
 
 impl WindowId {
-    /// Returns a dummy `WindowId`, useful for unit testing. Absolutely no guarantees are made
-    /// about this `WindowId`, it may be equal to a real `WindowId`.
+    /// Returns a dummy `WindowId`, useful for unit testing. The only guarantee made about the return
+    /// value of this function is that it will always be equal to itself and to future values returned
+    /// by this function.  No other guarantees are made. This may be equal to a real `WindowId`.
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
     pub unsafe fn dummy() -> Self {
@@ -188,8 +189,9 @@ impl WindowId {
 pub struct DeviceId(platform::DeviceId);
 
 impl DeviceId {
-    /// Returns a dummy `DeviceId`, useful for unit testing. Absolutely no guarantees are made
-    /// about this `DeviceId`, it may be equal to a real `DeviceId`.
+    /// Returns a dummy `DeviceId`, useful for unit testing. The only guarantee made about the return
+    /// value of this function is that it will always be equal to itself and to future values returned
+    /// by this function.  No other guarantees are made. This may be equal to a real `DeviceId`.
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
     pub unsafe fn dummy() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,16 @@ impl std::fmt::Debug for Window {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(platform::WindowId);
 
+impl WindowId {
+    /// Returns a dummy WindowId, useful for unit testing. Absolutely no guarantees are made
+    /// about this window id, it may be equal to a real WindowId.
+    ///
+    /// **Passing this into a winit function will result in undefined behavior.**
+    pub fn dummy() -> Self {
+        WindowId(platform::WindowId::dummy())
+    }
+}
+
 /// Identifier of an input device.
 ///
 /// Whenever you receive an event arising from a particular input device, this event contains a `DeviceId` which
@@ -176,6 +186,16 @@ pub struct WindowId(platform::WindowId);
 /// physical. Virtual devices typically aggregate inputs from multiple physical devices.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(platform::DeviceId);
+
+impl DeviceId {
+    /// Returns a dummy DeviceId, useful for unit testing. Absolutely no guarantees are made
+    /// about this device id, it may be equal to a real DeviceId.
+    ///
+    /// **Passing this into a winit function will result in undefined behavior.**
+    pub fn dummy() -> Self {
+        DeviceId(platform::DeviceId::dummy())
+    }
+}
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
 /// the events loop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,11 +170,11 @@ impl std::fmt::Debug for Window {
 pub struct WindowId(platform::WindowId);
 
 impl WindowId {
-    /// Returns a dummy WindowId, useful for unit testing. Absolutely no guarantees are made
-    /// about this window id, it may be equal to a real WindowId.
+    /// Returns a dummy `WindowId`, useful for unit testing. Absolutely no guarantees are made
+    /// about this `WindowId`, it may be equal to a real `WindowId`.
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId(platform::WindowId::dummy())
     }
 }
@@ -188,11 +188,11 @@ impl WindowId {
 pub struct DeviceId(platform::DeviceId);
 
 impl DeviceId {
-    /// Returns a dummy DeviceId, useful for unit testing. Absolutely no guarantees are made
-    /// about this device id, it may be equal to a real DeviceId.
+    /// Returns a dummy `DeviceId`, useful for unit testing. Absolutely no guarantees are made
+    /// about this `DeviceId`, it may be equal to a real `DeviceId`.
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId(platform::DeviceId::dummy())
     }
 }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -171,7 +171,7 @@ impl EventsLoopProxy {
 pub struct WindowId;
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId
     }
 }
@@ -180,7 +180,7 @@ impl WindowId {
 pub struct DeviceId;
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId
     }
 }

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -170,8 +170,20 @@ impl EventsLoopProxy {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId;
 
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
+
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId
+    }
+}
 
 pub struct Window {
     native_window: *const c_void,

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -28,7 +28,7 @@ unsafe impl Sync for PlatformSpecificWindowBuilderAttributes {}
 pub struct DeviceId;
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId
     }
 }
@@ -156,7 +156,7 @@ impl EventsLoop {
 pub struct WindowId(usize);
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId(0)
     }
 }

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -27,6 +27,12 @@ unsafe impl Sync for PlatformSpecificWindowBuilderAttributes {}
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
@@ -148,6 +154,12 @@ impl EventsLoop {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(usize);
+
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId(0)
+    }
+}
 
 pub struct Window2 {
     cursor_grabbed: Mutex<bool>,

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -291,7 +291,7 @@ impl EventsLoopProxy {
 pub struct WindowId;
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId
     }
 }
@@ -300,7 +300,7 @@ impl WindowId {
 pub struct DeviceId;
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId
     }
 }

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -290,8 +290,20 @@ impl EventsLoopProxy {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId;
 
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
+
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId
+    }
+}
 
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -67,7 +67,7 @@ pub enum WindowId {
 }
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId::X(x11::WindowId::dummy())
     }
 }
@@ -79,7 +79,7 @@ pub enum DeviceId {
 }
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId::X(x11::DeviceId::dummy())
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -66,10 +66,22 @@ pub enum WindowId {
     Wayland(wayland::WindowId),
 }
 
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId::X(x11::WindowId::dummy())
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceId {
     X(x11::DeviceId),
     Wayland(wayland::DeviceId),
+}
+
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId::X(x11::DeviceId::dummy())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -17,7 +17,7 @@ mod window;
 pub struct DeviceId;
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId
     }
 }
@@ -26,7 +26,7 @@ impl DeviceId {
 pub struct WindowId(usize);
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId(0)
     }
 }

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -16,8 +16,20 @@ mod window;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(usize);
+
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId(0)
+    }
+}
 
 #[inline]
 fn make_wid(s: &Proxy<wl_surface::WlSurface>) -> WindowId {

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -1260,8 +1260,20 @@ impl<'a> Deref for DeviceInfo<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(ffi::Window);
 
+impl WindowId {
+    pub fn dummy() -> Self {
+        WindowId(0)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(c_int);
+
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId(0)
+    }
+}
 
 pub struct Window(Arc<UnownedWindow>);
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -1261,7 +1261,7 @@ impl<'a> Deref for DeviceInfo<'a> {
 pub struct WindowId(ffi::Window);
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         WindowId(0)
     }
 }
@@ -1270,7 +1270,7 @@ impl WindowId {
 pub struct DeviceId(c_int);
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId(0)
     }
 }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -8,6 +8,12 @@ use std::sync::Arc;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId
+    }
+}
+
 use {CreationError};
 
 pub struct Window {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 pub struct DeviceId;
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId
     }
 }

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -49,6 +49,12 @@ use window::MonitorId as RootMonitorId;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id(pub usize);
 
+impl Id {
+    pub fn dummy() -> Self {
+        Id(0)
+    }
+}
+
 // TODO: It's possible for delegate methods to be called asynchronously, causing data races / `RefCell` panics.
 pub struct DelegateState {
     view: IdRef,

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -50,7 +50,7 @@ use window::MonitorId as RootMonitorId;
 pub struct Id(pub usize);
 
 impl Id {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         Id(0)
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -27,7 +27,7 @@ unsafe impl Sync for Cursor {}
 pub struct DeviceId(u32);
 
 impl DeviceId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         DeviceId(0)
     }
 }
@@ -55,7 +55,7 @@ unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}
 
 impl WindowId {
-    pub fn dummy() -> Self {
+    pub unsafe fn dummy() -> Self {
         use std::ptr::null_mut;
 
         WindowId(null_mut())

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -27,6 +27,12 @@ unsafe impl Sync for Cursor {}
 pub struct DeviceId(u32);
 
 impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId(0)
+    }
+}
+
+impl DeviceId {
     pub fn get_persistent_identifier(&self) -> Option<String> {
         if self.0 != 0 {
             raw_input::get_raw_input_device_name(self.0 as _)
@@ -47,6 +53,14 @@ fn wrap_device_id(id: u32) -> ::DeviceId {
 pub struct WindowId(HWND);
 unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}
+
+impl WindowId {
+    pub fn dummy() -> Self {
+        use std::ptr::null_mut;
+
+        WindowId(null_mut())
+    }
+}
 
 mod dpi;
 mod drop_handler;


### PR DESCRIPTION
Fixes #330 

- [x] Tested on all platforms changed
  - [x] Windows
  - [x] Android
  - [x] Emscripten
  - [x] iOS
  - [x] Linux
  - [x] OSX
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
