### PR TITLE
macOS: Correct `prepareForDragOperation:` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - On Wayland, fix resizing and DPI calculation when a `wl_output` is removed without sending a `leave` event to the `wl_surface`, such as disconnecting a monitor from a laptop.
 - On Wayland, DPI calculation is handled by smithay-client-toolkit.
 - On X11, `WindowBuilder::with_min_dimensions` and `WindowBuilder::with_max_dimensions` now correctly account for DPI.
+- On macOS, fixed unsoundness in drag-and-drop that could result in drops being rejected.
 
 # Version 0.18.0 (2018-11-07)
 

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -324,7 +324,9 @@ impl WindowDelegate {
         }
 
         /// Invoked when the image is released
-        extern fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) {}
+        extern fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) -> BOOL {
+            YES
+        }
 
         /// Invoked after the released image has been removed from the screen
         extern fn perform_drag_operation(this: &Object, _: Sel, sender: id) -> BOOL {
@@ -459,7 +461,7 @@ impl WindowDelegate {
             decl.add_method(sel!(draggingEntered:),
                 dragging_entered as extern fn(&Object, Sel, id) -> BOOL);
             decl.add_method(sel!(prepareForDragOperation:),
-                prepare_for_drag_operation as extern fn(&Object, Sel, id));
+                prepare_for_drag_operation as extern fn(&Object, Sel, id) -> BOOL);
             decl.add_method(sel!(performDragOperation:),
                 perform_drag_operation as extern fn(&Object, Sel, id) -> BOOL);
             decl.add_method(sel!(concludeDragOperation:),


### PR DESCRIPTION
https://developer.apple.com/documentation/appkit/nsdraggingdestination/1416066-preparefordragoperation?language=objc

This method has been incorrect since v0.13, but through the joys of UB it worked anyway.