### PR TITLE
Fix incorrect keycodes when using a non-US keyboard layout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fix keycodes being incorrect when using a non-US keyboard layout.
 - On macOS, fix `Yen` (JIS) so applications receive the event.
 - On X11 with a tiling WM, fixed high CPU usage when moving windows across monitors.
 - On X11, fixed panic caused by dropping the window before running the event loop.

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -544,68 +544,67 @@ impl Proxy {
     }
 }
 
-pub fn windows_key_code_for_char_code(c: char) -> Option<c_ushort> {
+pub fn char_to_keycode(c: char) -> Option<events::VirtualKeyCode> {
     // We only translate keys that are affected by keyboard layout.
     //
     // Note that since keys are translated in a somewhat "dumb" way (reading character)
     // there is a concern that some combination, i.e. Cmd+char, causes the wrong
     // letter to be received, and so we receive the wrong key.
     //
-    // Codes taken from `to_virtual_key_code`.
-    // It may be better to map these codes to something more immediately meaningful.
+    // Implementation reference: https://github.com/WebKit/webkit/blob/82bae82cf0f329dbe21059ef0986c4e92fea4ba6/Source/WebCore/platform/cocoa/KeyEventCocoa.mm#L626
     Some(match c {
-        'a' | 'A' => 0x00,
-        's' | 'S' => 0x01,
-        'd' | 'D' => 0x02,
-        'f' | 'F' => 0x03,
-        'h' | 'H' => 0x04,
-        'g' | 'G' => 0x05,
-        'z' | 'Z' => 0x06,
-        'x' | 'X' => 0x07,
-        'c' | 'C' => 0x08,
-        'v' | 'V' => 0x09,
-        'b' | 'B' => 0x0b,
-        'q' | 'Q' => 0x0c,
-        'w' | 'W' => 0x0d,
-        'e' | 'E' => 0x0e,
-        'r' | 'R' => 0x0f,
-        'y' | 'Y' => 0x10,
-        't' | 'T' => 0x11,
-        '1' | '!' => 0x12,
-        '2' | '@' => 0x13,
-        '3' | '#' => 0x14,
-        '4' | '$' => 0x15,
-        '6' | '^' => 0x16,
-        '5' | '%' => 0x17,
-        '=' | '+' => 0x18,
-        '9' | '(' => 0x19,
-        '7' | '&' => 0x1a,
-        '-' | '_' => 0x1b,
-        '8' | '*' => 0x1c,
-        '0' | ')' => 0x1d,
-        ']' | '}' => 0x1e,
-        'o' | 'O' => 0x1f,
-        'u' | 'U' => 0x20,
-        '[' | '{' => 0x21,
-        'i' | 'I' => 0x22,
-        'p' | 'P' => 0x23,
-        'l' | 'L' => 0x25,
-        'j' | 'J' => 0x26,
-        '\''| '"' => 0x27,
-        'k' | 'K' => 0x28,
-        ';' | ':' => 0x29,
-        '\\'| '|' => 0x2a,
-        ',' | '<' => 0x2b,
-        '/' | '?' => 0x2c,
-        'n' | 'N' => 0x2d,
-        'm' | 'M' => 0x2e,
-        '.' | '>' => 0x2f,
-        '`' | '~' => 0x32,
+        'a' | 'A' => events::VirtualKeyCode::A,
+        'b' | 'B' => events::VirtualKeyCode::B,
+        'c' | 'C' => events::VirtualKeyCode::C,
+        'd' | 'D' => events::VirtualKeyCode::D,
+        'e' | 'E' => events::VirtualKeyCode::E,
+        'f' | 'F' => events::VirtualKeyCode::F,
+        'g' | 'G' => events::VirtualKeyCode::G,
+        'h' | 'H' => events::VirtualKeyCode::H,
+        'i' | 'I' => events::VirtualKeyCode::I,
+        'j' | 'J' => events::VirtualKeyCode::J,
+        'k' | 'K' => events::VirtualKeyCode::K,
+        'l' | 'L' => events::VirtualKeyCode::L,
+        'm' | 'M' => events::VirtualKeyCode::M,
+        'n' | 'N' => events::VirtualKeyCode::N,
+        'o' | 'O' => events::VirtualKeyCode::O,
+        'p' | 'P' => events::VirtualKeyCode::P,
+        'q' | 'Q' => events::VirtualKeyCode::Q,
+        'r' | 'R' => events::VirtualKeyCode::R,
+        's' | 'S' => events::VirtualKeyCode::S,
+        't' | 'T' => events::VirtualKeyCode::T,
+        'u' | 'U' => events::VirtualKeyCode::U,
+        'v' | 'V' => events::VirtualKeyCode::V,
+        'w' | 'W' => events::VirtualKeyCode::W,
+        'x' | 'X' => events::VirtualKeyCode::X,
+        'y' | 'Y' => events::VirtualKeyCode::Y,
+        'z' | 'Z' => events::VirtualKeyCode::Z,
+        '1' | '!' => events::VirtualKeyCode::Key1,
+        '2' | '@' => events::VirtualKeyCode::Key2,
+        '3' | '#' => events::VirtualKeyCode::Key3,
+        '4' | '$' => events::VirtualKeyCode::Key4,
+        '5' | '%' => events::VirtualKeyCode::Key5,
+        '6' | '^' => events::VirtualKeyCode::Key6,
+        '7' | '&' => events::VirtualKeyCode::Key7,
+        '8' | '*' => events::VirtualKeyCode::Key8,
+        '9' | '(' => events::VirtualKeyCode::Key9,
+        '0' | ')' => events::VirtualKeyCode::Key0,
+        '=' | '+' => events::VirtualKeyCode::Equals,
+        '-' | '_' => events::VirtualKeyCode::Minus,
+        ']' | '}' => events::VirtualKeyCode::RBracket,
+        '[' | '{' => events::VirtualKeyCode::LBracket,
+        '\''| '"' => events::VirtualKeyCode::Apostrophe,
+        ';' | ':' => events::VirtualKeyCode::Semicolon,
+        '\\'| '|' => events::VirtualKeyCode::Backslash,
+        ',' | '<' => events::VirtualKeyCode::Comma,
+        '/' | '?' => events::VirtualKeyCode::Slash,
+        '.' | '>' => events::VirtualKeyCode::Period,
+        '`' | '~' => events::VirtualKeyCode::Grave,
         _ => return None,
     })
 }
 
-pub fn to_virtual_key_code(code: c_ushort) -> Option<events::VirtualKeyCode> {
+pub fn scancode_to_keycode(code: c_ushort) -> Option<events::VirtualKeyCode> {
     Some(match code {
         0x00 => events::VirtualKeyCode::A,
         0x01 => events::VirtualKeyCode::S,
@@ -741,20 +740,19 @@ pub fn to_virtual_key_code(code: c_ushort) -> Option<events::VirtualKeyCode> {
     })
 }
 
-pub fn check_additional_virtual_key_codes(
-    s: &Option<String>
+pub fn check_function_keys(
+    s: &String
 ) -> Option<events::VirtualKeyCode> {
-    if let &Some(ref s) = s {
-        if let Some(ch) = s.encode_utf16().next() {
-            return Some(match ch {
-                0xf718 => events::VirtualKeyCode::F21,
-                0xf719 => events::VirtualKeyCode::F22,
-                0xf71a => events::VirtualKeyCode::F23,
-                0xf71b => events::VirtualKeyCode::F24,
-                _ => return None,
-            })
-        }
+    if let Some(ch) = s.encode_utf16().next() {
+        return Some(match ch {
+            0xf718 => events::VirtualKeyCode::F21,
+            0xf719 => events::VirtualKeyCode::F22,
+            0xf71a => events::VirtualKeyCode::F23,
+            0xf71b => events::VirtualKeyCode::F24,
+            _ => return None,
+        })
     }
+
     None
 }
 
@@ -770,6 +768,16 @@ pub fn event_mods(event: cocoa::base::id) -> ModifiersState {
     }
 }
 
+pub fn get_scancode(event: cocoa::base::id) -> c_ushort {
+    // In AppKit, `keyCode` refers to the position (scancode) of a key rather than its character,
+    // and there is no easy way to navtively retrieve the layout-dependent character.
+    // In winit, we use keycode to refer to the key's character, and so this function aligns
+    // AppKit's terminology with ours.
+    unsafe {
+        msg_send![event, keyCode]
+    }
+}
+
 unsafe fn modifier_event(
     ns_event: cocoa::base::id,
     keymask: NSEventModifierFlags,
@@ -782,14 +790,14 @@ unsafe fn modifier_event(
         } else {
             ElementState::Pressed
         };
-        let keycode = NSEvent::keyCode(ns_event);
-        let scancode = keycode as u32;
-        let virtual_keycode = to_virtual_key_code(keycode);
+
+        let scancode = get_scancode(ns_event);
+        let virtual_keycode = scancode_to_keycode(scancode);
         Some(WindowEvent::KeyboardInput {
             device_id: DEVICE_ID,
             input: KeyboardInput {
                 state,
-                scancode,
+                scancode: scancode as u32,
                 virtual_keycode,
                 modifiers: event_mods(ns_event),
             },

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -551,7 +551,7 @@ pub fn windows_key_code_for_char_code(c: char) -> Option<c_ushort> {
     // there is a concern that some combination, i.e. Cmd+char, causes the wrong
     // letter to be received, and so we receive the wrong key.
     //
-    // Codes taken from to_virtual_key_code.
+    // Codes taken from `to_virtual_key_code`.
     // It may be better to map these codes to something more immediately meaningful.
     Some(match c {
         'a' | 'A' => 0x00,

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -544,6 +544,67 @@ impl Proxy {
     }
 }
 
+pub fn windows_key_code_for_char_code(c: char) -> Option<c_ushort> {
+    // We only translate keys that are affected by keyboard layout.
+    //
+    // Note that since keys are translated in a somewhat "dumb" way (reading character)
+    // there is a concern that some combination, i.e. Cmd+char, causes the wrong
+    // letter to be received, and so we receive the wrong key.
+    //
+    // Codes taken from to_virtual_key_code.
+    // It may be better to map these codes to something more immediately meaningful.
+    Some(match c {
+        'a' | 'A' => 0x00,
+        's' | 'S' => 0x01,
+        'd' | 'D' => 0x02,
+        'f' | 'F' => 0x03,
+        'h' | 'H' => 0x04,
+        'g' | 'G' => 0x05,
+        'z' | 'Z' => 0x06,
+        'x' | 'X' => 0x07,
+        'c' | 'C' => 0x08,
+        'v' | 'V' => 0x09,
+        'b' | 'B' => 0x0b,
+        'q' | 'Q' => 0x0c,
+        'w' | 'W' => 0x0d,
+        'e' | 'E' => 0x0e,
+        'r' | 'R' => 0x0f,
+        'y' | 'Y' => 0x10,
+        't' | 'T' => 0x11,
+        '1' | '!' => 0x12,
+        '2' | '@' => 0x13,
+        '3' | '#' => 0x14,
+        '4' | '$' => 0x15,
+        '6' | '^' => 0x16,
+        '5' | '%' => 0x17,
+        '=' | '+' => 0x18,
+        '9' | '(' => 0x19,
+        '7' | '&' => 0x1a,
+        '-' | '_' => 0x1b,
+        '8' | '*' => 0x1c,
+        '0' | ')' => 0x1d,
+        ']' | '}' => 0x1e,
+        'o' | 'O' => 0x1f,
+        'u' | 'U' => 0x20,
+        '[' | '{' => 0x21,
+        'i' | 'I' => 0x22,
+        'p' | 'P' => 0x23,
+        'l' | 'L' => 0x25,
+        'j' | 'J' => 0x26,
+        '\''| '"' => 0x27,
+        'k' | 'K' => 0x28,
+        ';' | ':' => 0x29,
+        '\\'| '|' => 0x2a,
+        ',' | '<' => 0x2b,
+        '/' | '?' => 0x2c,
+        'n' | 'N' => 0x2d,
+        'm' | 'M' => 0x2e,
+        '.' | '>' => 0x2f,
+        '`' | '~' => 0x32,
+        _ => return None,
+    })
+}
+
 pub fn to_virtual_key_code(code: c_ushort) -> Option<events::VirtualKeyCode> {
     Some(match code {
         0x00 => events::VirtualKeyCode::A,

--- a/src/platform/macos/view.rs
+++ b/src/platform/macos/view.rs
@@ -14,7 +14,7 @@ use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Protocol, Sel, BOOL, YES};
 
 use {ElementState, Event, KeyboardInput, MouseButton, WindowEvent, WindowId};
-use platform::platform::events_loop::{DEVICE_ID, event_mods, Shared, to_virtual_key_code, check_additional_virtual_key_codes};
+use platform::platform::events_loop::{DEVICE_ID, event_mods, Shared, to_virtual_key_code, windows_key_code_for_char_code, check_additional_virtual_key_codes};
 use platform::platform::util;
 use platform::platform::ffi::*;
 use platform::platform::window::{get_window_id, IdRef};
@@ -403,6 +403,44 @@ fn get_characters(event: id) -> Option<String> {
     }
 }
 
+fn get_characters_ignoring_modifiers(event: id) -> Option<String> {
+    unsafe {
+        let characters: id = msg_send![event, charactersIgnoringModifiers];
+        let slice = slice::from_raw_parts(
+            characters.UTF8String() as *const c_uchar,
+            characters.len(),
+        );
+        let string = str::from_utf8_unchecked(slice);
+        Some(string.to_owned())
+    }
+}
+
+// Translate macos scancode into the corresponding windows key code.
+fn to_translated_macos_scancode(event: id) -> c_ushort {
+    // Cmd switches Roman letters for Dvorak-QWERTY layout, so try modified characters first.
+    let characters = get_characters(event);
+    if let Some(chars) = characters {
+        let code = chars.chars().next().map_or(0, |c| windows_key_code_for_char_code(c).unwrap_or(0));
+        if code != 0 {
+            return code;
+        }
+    }
+
+    // Translate characters that weren't caught in the above operation.
+    let raw_characters = get_characters_ignoring_modifiers(event);
+    if let Some(chars) = raw_characters {
+        let code = chars.chars().next().map_or(0, |c| windows_key_code_for_char_code(c).unwrap_or(0));
+        if code != 0 {
+            return code;
+        }
+    }
+
+    unsafe {
+        // We've checked all layout-related keys, so the fall-through to scancode.
+        msg_send![event, keyCode]
+    }
+}
+
 extern fn key_down(this: &Object, _sel: Sel, event: id) {
     //println!("keyDown");
     unsafe {
@@ -412,15 +450,16 @@ extern fn key_down(this: &Object, _sel: Sel, event: id) {
 
         state.raw_characters = get_characters(event);
 
-        let keycode: c_ushort = msg_send![event, keyCode];
         // We are checking here for F21-F24 keys, since their keycode
         // can vary, but we know that they are encoded
         // in characters property.
+        let keycode = to_translated_macos_scancode(event);
         let virtual_keycode = to_virtual_key_code(keycode)
             .or_else(|| {
                 check_additional_virtual_key_codes(&state.raw_characters)
             });
-        let scancode = keycode as u32;
+
+        let scancode: u32 = msg_send![event, keyCode];
         let is_repeat = msg_send![event, isARepeat];
 
         let window_event = Event::WindowEvent {
@@ -436,6 +475,7 @@ extern fn key_down(this: &Object, _sel: Sel, event: id) {
             },
         };
 
+        // NOTE: this code is run twice.
         let characters: id = msg_send![event, characters];
         let slice = slice::from_raw_parts(
             characters.UTF8String() as *const c_uchar,
@@ -487,12 +527,14 @@ extern fn key_up(this: &Object, _sel: Sel, event: id) {
         // F21-F24.
         let characters = get_characters(event);
 
-        let keycode: c_ushort = msg_send![event, keyCode];
+        let keycode = to_translated_macos_scancode(event);
         let virtual_keycode = to_virtual_key_code(keycode)
             .or_else(|| {
                 check_additional_virtual_key_codes(&characters)
             });
-        let scancode = keycode as u32;
+
+        let scancode: u32 = msg_send![event, keyCode];
+
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.window)),
             event: WindowEvent::KeyboardInput {


### PR DESCRIPTION
This commit fixes the issue described in #752, and uses the advised
method to fix it.

I'm relatively new to contributing and Rust (this is my first real contribution), and I'm sure my lack of experience is shining through here.  Regardless, I hope that this PR fixes/assists in fixing the issue adequately!

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
