### PR TITLE
Set ime spot with logical position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added serde serialization to `os::unix::XWindowType`.
 - **Breaking:** `image` crate upgraded to 0.21. This is exposed as part of the `icon_loading` API.
+- On X11, fix incorrect ime spot on HiDPI.
 
 # Version 0.18.1 (2018-12-30)
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -1204,7 +1204,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_ime_spot(&self, logical_spot: LogicalPosition) {
-        let (x, y) = logical_spot.to_physical(self.get_hidpi_factor()).into();
+        let (x, y) = logical_spot.into();
         self.set_ime_spot_physical(x, y);
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality

It seems that we should send xim with the logical position rather than physical position.

Before this commit:
![ime_spot_before](https://user-images.githubusercontent.com/16643669/51383173-a706ff80-1b53-11e9-8d09-49853faea40a.png)

After this commit:
![ime_spot_after](https://user-images.githubusercontent.com/16643669/51383184-acfce080-1b53-11e9-8733-756c57bb89dc.png)
