### PR TITLE
On wayland, fix `with_title()` not setting the windows title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Wayland, fix `with_title()` not setting the windows title
 - Added serde serialization to `os::unix::XWindowType`.
 - **Breaking:** `image` crate upgraded to 0.21. This is exposed as part of the `icon_loading` API.
 

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -81,6 +81,8 @@ impl Window {
             frame.set_app_id(app_id);
         }
 
+        frame.set_title(attributes.title);
+
         for &(_, ref seat) in evlp.seats.lock().unwrap().iter() {
             frame.new_seat(seat);
         }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Wayland windows currently did not set their title when built with the `with_title()` function.
