### PR TITLE
Wayland: add `set_wayland_theme()` to control client decoration color…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Wayland, add `set_wayland_theme()` to control client decoration color theme
 - Added serde serialization to `os::unix::XWindowType`.
 - **Breaking:** `image` crate upgraded to 0.21. This is exposed as part of the `icon_loading` API.
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -4,6 +4,8 @@ use std::os::raw;
 use std::ptr;
 use std::sync::Arc;
 
+use sctk::window::{ButtonState, Theme};
+
 use {
     EventsLoop,
     LogicalSize,
@@ -24,6 +26,74 @@ pub use platform::x11;
 
 pub use platform::XNotSupported;
 pub use platform::x11::util::WindowType as XWindowType;
+
+/// Theme for wayland client side decorations
+///
+/// Colors must be in native endian ARGB8888 format
+pub struct WaylandTheme {
+    /// Primary color when the window is focused
+    pub primary_active: [u8; 4],
+    /// Primary color when the window is unfocused
+    pub primary_inactive: [u8; 4],
+    /// Secondary color when the window is focused
+    pub secondary_active: [u8; 4],
+    /// Secondary color when the window is unfocused
+    pub secondary_inactive: [u8; 4],
+    /// Close button color when hovered over
+    pub close_button_hovered: [u8; 4],
+    /// Close button color
+    pub close_button: [u8; 4],
+    /// Close button color when hovered over
+    pub maximize_button_hovered: [u8; 4],
+    /// Maximize button color
+    pub maximize_button: [u8; 4],
+    /// Minimize button color when hovered over
+    pub minimize_button_hovered: [u8; 4],
+    /// Minimize button color
+    pub minimize_button: [u8; 4],
+}
+
+struct WaylandThemeObject(WaylandTheme);
+
+impl Theme for WaylandThemeObject {
+    fn get_primary_color(&self, active: bool) -> [u8; 4] {
+        if active {
+            self.0.primary_active
+        } else {
+            self.0.primary_inactive
+        }
+    }
+
+    // Used for division line
+    fn get_secondary_color(&self, active: bool) -> [u8; 4] {
+        if active {
+            self.0.secondary_active
+        } else {
+            self.0.secondary_inactive
+        }
+    }
+
+    fn get_close_button_color(&self, state: ButtonState) -> [u8; 4] {
+        match state {
+            ButtonState::Hovered => self.0.close_button_hovered,
+            _ => self.0.close_button,
+        }
+    }
+
+    fn get_maximize_button_color(&self, state: ButtonState) -> [u8; 4] {
+        match state {
+            ButtonState::Hovered => self.0.maximize_button_hovered,
+            _ => self.0.maximize_button,
+        }
+    }
+
+    fn get_minimize_button_color(&self, state: ButtonState) -> [u8; 4] {
+        match state {
+            ButtonState::Hovered => self.0.minimize_button_hovered,
+            _ => self.0.minimize_button,
+        }
+    }
+}
 
 /// Additional methods on `EventsLoop` that are specific to Linux.
 pub trait EventsLoopExt {
@@ -127,6 +197,9 @@ pub trait WindowExt {
     /// The pointer will become invalid when the glutin `Window` is destroyed.
     fn get_wayland_display(&self) -> Option<*mut raw::c_void>;
 
+    /// Sets the color theme of the client side window decorations on wayland
+    fn set_wayland_theme(&mut self, theme: WaylandTheme);
+
     /// Check if the window is ready for drawing
     ///
     /// It is a remnant of a previous implementation detail for the
@@ -199,6 +272,14 @@ impl WindowExt for Window {
         match self.window {
             LinuxWindow::Wayland(ref w) => Some(w.get_display().c_ptr() as *mut _),
             _ => None
+        }
+    }
+
+    #[inline]
+    fn set_wayland_theme(&mut self, theme: WaylandTheme) {
+        match self.window {
+            LinuxWindow::Wayland(ref mut w) => w.set_theme(WaylandThemeObject(theme)),
+            _ => {}
         }
     }
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -29,7 +29,7 @@ pub use platform::x11::util::WindowType as XWindowType;
 
 /// Theme for wayland client side decorations
 ///
-/// Colors must be in native endian ARGB8888 format
+/// Colors must be in ARGB8888 format
 pub struct WaylandTheme {
     /// Primary color when the window is focused
     pub primary_active: [u8; 4],

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -198,7 +198,7 @@ pub trait WindowExt {
     fn get_wayland_display(&self) -> Option<*mut raw::c_void>;
 
     /// Sets the color theme of the client side window decorations on wayland
-    fn set_wayland_theme(&mut self, theme: WaylandTheme);
+    fn set_wayland_theme(&self, theme: WaylandTheme);
 
     /// Check if the window is ready for drawing
     ///
@@ -276,9 +276,9 @@ impl WindowExt for Window {
     }
 
     #[inline]
-    fn set_wayland_theme(&mut self, theme: WaylandTheme) {
+    fn set_wayland_theme(&self, theme: WaylandTheme) {
         match self.window {
-            LinuxWindow::Wayland(ref mut w) => w.set_theme(WaylandThemeObject(theme)),
+            LinuxWindow::Wayland(ref w) => w.set_theme(WaylandThemeObject(theme)),
             _ => {}
         }
     }

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -236,7 +236,7 @@ impl Window {
     }
 
 
-    pub fn set_theme<T: Theme>(&mut self, theme: T) {
+    pub fn set_theme<T: Theme>(&self, theme: T) {
         self.frame.lock().unwrap().set_theme(theme)
     }
 

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -7,7 +7,7 @@ use platform::{MonitorId as PlatformMonitorId, PlatformSpecificWindowBuilderAttr
 use window::MonitorId as RootMonitorId;
 
 use sctk::surface::{get_dpi_factor, get_outputs};
-use sctk::window::{ConceptFrame, Event as WEvent, Window as SWindow};
+use sctk::window::{ConceptFrame, Event as WEvent, Window as SWindow, Theme};
 use sctk::reexports::client::{Display, Proxy};
 use sctk::reexports::client::protocol::{wl_seat, wl_surface};
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
@@ -233,6 +233,11 @@ impl Window {
         } else {
             self.frame.lock().unwrap().unset_fullscreen();
         }
+    }
+
+
+    pub fn set_theme<T: Theme>(&mut self, theme: T) {
+        self.frame.lock().unwrap().set_theme(theme)
     }
 
     #[inline]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

I've created a new function `set_wayland_theme()` in `winit::os::unix::WindowExt` that takes a struct of `winit::os::unix::WaylandTheme` to allow for theming of the client side wayland decorations.

Using `WaylandTheme` allows for us to not expose SCTKs internal data types or traits

Fixes https://github.com/tomaka/winit/issues/765