### PR TITLE
Update winit to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# Version 0.19.0 (xxxx-xx-xx)
+# Version 0.19.0 (2019-03-06)
 
 - On X11, we will use the faster `XRRGetScreenResourcesCurrent` function instead of `XRRGetScreenResources` when available.
 - On macOS, fix keycodes being incorrect when using a non-US keyboard layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Version 0.19.0 (xxxx-xx-xx)
+
 - On Wayland, fix `with_title()` not setting the windows title
 - On Wayland, add `set_wayland_theme()` to control client decoration color theme
 - Added serde serialization to `os::unix::XWindowType`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ```toml
 [dependencies]
-winit = "0.18.1"
+winit = "0.19.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
Not much to see here. This is breaking since it updates the `image` dependency.

I'd maybe like to see #763 and #772 get merged for this release, but that requires another reviewer look at them and confirm that it's what we want to do (cc @francesca64, since #772 is X11)