### PR TITLE
Use `XRRGetScreenResourcesCurrent` when avail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On X11, we will use the faster `XRRGetScreenResourcesCurrent` function instead of `XRRGetScreenResources` when available.
 - On macOS, fix keycodes being incorrect when using a non-US keyboard layout.
 - On Wayland, fix `with_title()` not setting the windows title
 - On Wayland, add `set_wayland_theme()` to control client decoration color theme

--- a/src/platform/linux/x11/monitor.rs
+++ b/src/platform/linux/x11/monitor.rs
@@ -131,9 +131,14 @@ impl XConnection {
     fn query_monitor_list(&self) -> Vec<MonitorId> {
         unsafe {
             let root = (self.xlib.XDefaultRootWindow)(self.display);
-            // WARNING: this function is supposedly very slow, on the order of hundreds of ms.
-            // Upon failure, `resources` will be null.
-            let resources = (self.xrandr.XRRGetScreenResources)(self.display, root);
+            let resources = if version_is_at_least(1, 3) {
+                (self.xrandr.XRRGetScreenResourcesCurrent)(self.display, root)
+            } else {
+                // WARNING: this function is supposedly very slow, on the order of hundreds of ms.
+                // Upon failure, `resources` will be null.
+                (self.xrandr.XRRGetScreenResources)(self.display, root)
+            };
+
             if resources.is_null() {
                 panic!("[winit] `XRRGetScreenResources` returned NULL. That should only happen if the root window doesn't exist.");
             }


### PR DESCRIPTION
Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
