### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
+- On FreeBSD, NetBSD, and OpenBSD, fix build of X11 backend.
 
 # Version 0.19.0 (2019-03-06)
 

--- a/src/platform/linux/x11/mod.rs
+++ b/src/platform/linux/x11/mod.rs
@@ -23,9 +23,9 @@ use libc::{select, fd_set, FD_SET, FD_ZERO, FD_ISSET, EINTR, EINVAL, ENOMEM, EBA
 #[cfg(target_os = "linux")]
 use libc::__errno_location;
 #[cfg(target_os = "freebsd")]
-use libc::__error;
+use libc::__error as __errno_location;
 #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-use libc::__errno;
+use libc::__errno as __errno_location;
 use std::sync::{Arc, mpsc, Weak};
 use std::sync::atomic::{self, AtomicBool};
 
@@ -238,12 +238,7 @@ impl EventsLoop {
                 std::ptr::null_mut()); // timeout
 
             if err < 0 {
-                #[cfg(target_os = "linux")]
                 let errno_ptr = __errno_location();
-                #[cfg(target_os = "freebsd")]
-                let errno_ptr = __error();
-                #[cfg(any(target_os = "netbsd", target_os = "openbsd"))]
-                let errno_ptr = __errno();
                 let errno = *errno_ptr;
 
                 if errno == EINTR {


### PR DESCRIPTION
```
error[E0432]: unresolved import `libc::__errno_location`
  --> src/platform/linux/x11/mod.rs:22:85
   |
22 | use libc::{select, fd_set, FD_SET, FD_ZERO, FD_ISSET, EINTR, EINVAL, ENOMEM, EBADF, __errno_location};
   |                                                                                     ^^^^^^^^^^^^^^^^ no `__errno_location` in the root
```
__errno_location is called __error on FreeBSD and __errno on Open- and NetBSD.

Note that I only tested on FreeBSD.  The OpenBSD and NetBSD bits are a pure guess on my part based on libc documentation and their errno.h [2,3,4,5].

[1] FreeBSD: https://rust-lang.github.io/libc/x86_64-unknown-freebsd/libc/fn.__error.html
[2] NetBSD: https://rust-lang.github.io/libc/x86_64-unknown-netbsd/libc/fn.__errno.html
[3] NetBSD: https://github.com/NetBSD/src/blob/trunk/include/errno.h
[4] OpenBSD: https://rust-lang.github.io/libc/x86_64-unknown-openbsd/libc/fn.__errno.html
[5] OpenBSD: https://github.com/OpenBSD/src/blob/master/include/errno.h