### PR TITLE
On Windows, fix CursorMoved(0, 0) getting sent on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
+
 # Version 0.19.0 (2019-03-06)
 
 - On X11, we will use the faster `XRRGetScreenResourcesCurrent` function instead of `XRRGetScreenResources` when available.

--- a/src/platform/windows/events_loop.rs
+++ b/src/platform/windows/events_loop.rs
@@ -1052,20 +1052,10 @@ unsafe fn callback_inner(
         }
 
         winuser::WM_SETFOCUS => {
-            use events::WindowEvent::{Focused, CursorMoved};
+            use events::WindowEvent::Focused;
             send_event(Event::WindowEvent {
                 window_id: SuperWindowId(WindowId(window)),
                 event: Focused(true)
-            });
-
-            let x = windowsx::GET_X_LPARAM(lparam) as f64;
-            let y = windowsx::GET_Y_LPARAM(lparam) as f64;
-            let dpi_factor = get_hwnd_scale_factor(window);
-            let position = LogicalPosition::from_physical((x, y), dpi_factor);
-
-            send_event(Event::WindowEvent {
-                window_id: SuperWindowId(WindowId(window)),
-                event: CursorMoved { device_id: DEVICE_ID, position, modifiers: event::get_key_mods() },
             });
 
             0


### PR DESCRIPTION
The code that was sending it shouldn't even have been there to begin with. This PR removes said code.