### PR TITLE
[Rebased] [x11-backend] Retrieve DPI from Xft.dpi XResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
 - On macOS, fix command key event left and right reverse.
 - On FreeBSD, NetBSD, and OpenBSD, fix build of X11 backend.
+- X11 - Dpi scaling factor behavior changed. First, winit tries to read it from "Xft.dpi" XResource, and uses DPI calculation from xrandr dimensions as fallback behavior.
 
 # Version 0.19.0 (2019-03-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
 - On macOS, fix command key event left and right reverse.
 - On FreeBSD, NetBSD, and OpenBSD, fix build of X11 backend.
-- X11 - Dpi scaling factor behavior changed. First, winit tries to read it from "Xft.dpi" XResource, and uses DPI calculation from xrandr dimensions as fallback behavior.
+- On X11, change DPI scaling factor behavior. First, winit tries to read it from "Xft.dpi" XResource, and uses DPI calculation from xrandr dimensions as fallback behavior.
 
 # Version 0.19.0 (2019-03-06)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -485,7 +485,7 @@ impl MonitorId {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **X11:** This respects Xft.dpi XResource, and can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {


### PR DESCRIPTION
This is @semtexzv's fix for DPI behaviour on x11 at #606 rebased onto master. I just tested both master and this rebased branch locally and this branch still fixes my DPI problem on x11.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- ~Created an example program if it would help users understand this functionality~

edit: cc @francesca64 I just noticed you were ready to merge this a while back, just thought I'd ping you!