### PR TITLE
Add ability to get wayland display from events loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.
 - On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
 - On macOS, fix command key event left and right reverse.
 - On FreeBSD, NetBSD, and OpenBSD, fix build of X11 backend.

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -113,6 +113,13 @@ pub trait EventsLoopExt {
 
     #[doc(hidden)]
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>>;
+
+    /// Returns a pointer to the `wl_display` object of wayland that is used by this `EventsLoop`.
+    ///
+    /// Returns `None` if the `EventsLoop` doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the glutin `EventsLoop` is destroyed.
+    fn get_wayland_display(&self) -> Option<*mut raw::c_void>;
 }
 
 impl EventsLoopExt for EventsLoop {
@@ -151,6 +158,14 @@ impl EventsLoopExt for EventsLoop {
     #[doc(hidden)]
     fn get_xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         self.events_loop.x_connection().cloned()
+    }
+
+    #[inline]
+    fn get_wayland_display(&self) -> Option<*mut raw::c_void> {
+        match self.events_loop {
+            LinuxEventsLoop::Wayland(ref e) => Some(e.get_display().c_ptr() as *mut _),
+            _ => None
+        }
     }
 }
 

--- a/src/platform/linux/wayland/event_loop.rs
+++ b/src/platform/linux/wayland/event_loop.rs
@@ -229,6 +229,10 @@ impl EventsLoop {
     pub fn get_available_monitors(&self) -> VecDeque<MonitorId> {
         get_available_monitors(&self.env.outputs)
     }
+
+    pub fn get_display(&self) -> &Display {
+        &*self.display
+    }
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
